### PR TITLE
  feat: in-app notifications system (DB + NestJS module + navbar bell)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { PartiesModule } from './parties/parties.module';
 import { AnalyticsModule } from './analytics/analytics.module';
 import { ReportsModule } from './reports/reports.module';
 import { ExplorerModule } from './explorer/explorer.module';
+import { NotificationsModule } from './notifications/notifications.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { ExplorerModule } from './explorer/explorer.module';
     AnalyticsModule,
     ReportsModule,
     ExplorerModule,
+    NotificationsModule,
   ],
   controllers: [AppController],
 })

--- a/apps/api/src/bonds/bonds.module.ts
+++ b/apps/api/src/bonds/bonds.module.ts
@@ -4,9 +4,10 @@ import { BondsController } from './bonds.controller';
 import { AuthModule } from '../auth/auth.module';
 import { AuditModule } from '../audit/audit.module';
 import { EscrowModule } from '../escrow/escrow.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
-  imports: [AuthModule, AuditModule, EscrowModule],
+  imports: [AuthModule, AuditModule, EscrowModule, NotificationsModule],
   providers: [BondsService],
   controllers: [BondsController],
   exports: [BondsService],

--- a/apps/api/src/bonds/bonds.service.ts
+++ b/apps/api/src/bonds/bonds.service.ts
@@ -11,7 +11,8 @@ import { AuditService } from '../audit/audit.service';
 import { StellarBondService } from '../escrow/stellar-bond.service';
 import { SorobanBondService } from '../escrow/soroban-bond.service';
 import { WalletService } from '../escrow/wallet.service';
-import { RegisterBondInput, BondRequestInput, BondStatus, Role, AuditEventType } from '@velar/types';
+import { NotificationsService } from '../notifications/notifications.service';
+import { RegisterBondInput, BondRequestInput, BondStatus, Role, AuditEventType, NotificationType } from '@velar/types';
 
 /** Roles de AUTORIDAD: ven todo y emiten bonos. Solo el TSE (y admin) emite. */
 export const AUTHORITY: Role[] = ['tse', 'admin'];
@@ -57,6 +58,7 @@ export class BondsService {
     private stellar: StellarBondService,
     private wallets: WalletService,
     private soroban: SorobanBondService,
+    private notifications: NotificationsService,
   ) {}
 
   /**
@@ -404,6 +406,12 @@ export class BondsService {
         payload: { owner: owner.id, party: req.party_id, requestId, holder: stellarResult.owner },
         txHash: stellarResult.txHash,
       });
+      await this.notifications.emit(req.requested_by, NotificationType.BOND_APPROVED, {
+        requestId,
+        bondTokenId: bond.token_id,
+        bondId: bond.bond_id,
+        faceValue: req.face_value,
+      });
     }
 
     await this.supabase.admin
@@ -430,7 +438,7 @@ export class BondsService {
     if (!AUTHORITY.includes(roleNorm)) throw new ForbiddenException(`Solo el TSE puede rechazar solicitudes (rol actual: ${actorRole})`);
     const { data: req, error: findError } = await this.supabase.admin
       .from('bond_requests')
-      .select('id, bond_token_id')
+      .select('id, bond_token_id, requested_by')
       .eq('id', requestId)
       .single();
     if (findError || !req) throw new NotFoundException('Solicitud no encontrada');
@@ -445,6 +453,11 @@ export class BondsService {
       bondTokenId: req.bond_token_id ?? undefined,
       actorId,
       payload: { requestId, reason, entity: 'bond_request' },
+    });
+    await this.notifications.emit(req.requested_by, NotificationType.BOND_REJECTED, {
+      requestId,
+      bondTokenId: req.bond_token_id ?? null,
+      reason,
     });
     return { ok: true };
   }

--- a/apps/api/src/notifications/notifications.controller.ts
+++ b/apps/api/src/notifications/notifications.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Param, Patch, UseGuards } from '@nestjs/common';
+import { NotificationsService } from './notifications.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { CurrentUser } from '../auth/current-user.decorator';
+
+@Controller('notifications')
+@UseGuards(AuthGuard)
+export class NotificationsController {
+  constructor(private notifications: NotificationsService) {}
+
+  @Get()
+  list(@CurrentUser() user: any) {
+    return this.notifications.list(user.id);
+  }
+
+  @Patch('read-all')
+  markAllRead(@CurrentUser() user: any) {
+    return this.notifications.markAllRead(user.id);
+  }
+
+  @Patch(':id/read')
+  markRead(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.notifications.markRead(id, user.id);
+  }
+}

--- a/apps/api/src/notifications/notifications.module.ts
+++ b/apps/api/src/notifications/notifications.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { NotificationsService } from './notifications.service';
+import { NotificationsController } from './notifications.controller';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [AuthModule],
+  providers: [NotificationsService],
+  controllers: [NotificationsController],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import { NotificationType } from '@velar/types';
+
+@Injectable()
+export class NotificationsService {
+  private readonly logger = new Logger(NotificationsService.name);
+
+  constructor(private supabase: SupabaseService) {}
+
+  /**
+   * Crea una notificación para un usuario. NUNCA lanza: si falla, solo loguea,
+   * para no romper el flujo de negocio que la dispara (igual que AuditService.emit).
+   */
+  async emit(userId: string, type: NotificationType, payload: Record<string, unknown> = {}) {
+    if (!userId) return;
+    try {
+      await this.supabase.admin.from('notifications').insert({
+        user_id: userId,
+        type,
+        payload,
+      });
+    } catch (e) {
+      this.logger.warn(`emit notification falló: ${(e as Error).message}`);
+    }
+  }
+
+  /** Últimas notificaciones del usuario + conteo de no leídas. */
+  async list(userId: string, limit = 20) {
+    const [{ data }, { count }] = await Promise.all([
+      this.supabase.admin
+        .from('notifications')
+        .select('*')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(limit),
+      this.supabase.admin
+        .from('notifications')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId)
+        .eq('read', false),
+    ]);
+    return { notifications: data ?? [], unreadCount: count ?? 0 };
+  }
+
+  /** Marca una notificación como leída (solo si pertenece al usuario). */
+  async markRead(id: string, userId: string) {
+    await this.supabase.admin
+      .from('notifications')
+      .update({ read: true })
+      .eq('id', id)
+      .eq('user_id', userId);
+    return { ok: true };
+  }
+
+  /** Marca todas las notificaciones del usuario como leídas. */
+  async markAllRead(userId: string) {
+    await this.supabase.admin
+      .from('notifications')
+      .update({ read: true })
+      .eq('user_id', userId)
+      .eq('read', false);
+    return { ok: true };
+  }
+}

--- a/apps/api/src/transfers/transfers.module.ts
+++ b/apps/api/src/transfers/transfers.module.ts
@@ -4,9 +4,10 @@ import { TransfersController } from './transfers.controller';
 import { AuthModule } from '../auth/auth.module';
 import { AuditModule } from '../audit/audit.module';
 import { EscrowModule } from '../escrow/escrow.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
-  imports: [AuthModule, AuditModule, EscrowModule],
+  imports: [AuthModule, AuditModule, EscrowModule, NotificationsModule],
   providers: [TransfersService],
   controllers: [TransfersController],
 })

--- a/apps/api/src/transfers/transfers.service.ts
+++ b/apps/api/src/transfers/transfers.service.ts
@@ -6,9 +6,10 @@ import { SupabaseService } from '../common/supabase/supabase.service';
 import { AuditService } from '../audit/audit.service';
 import { StellarBondService } from '../escrow/stellar-bond.service';
 import { TrustlessWorkService } from '../escrow/trustless-work.service';
+import { NotificationsService } from '../notifications/notifications.service';
 import {
   AuditEventType, BondStatus, NON_TRANSFERABLE_STATUSES,
-  RequestTransferInput, Role, TransferStatus,
+  NotificationType, RequestTransferInput, Role, TransferStatus,
 } from '@velar/types';
 
 @Injectable()
@@ -20,6 +21,7 @@ export class TransfersService {
     private audit: AuditService,
     private stellar: StellarBondService,
     private trustlessWork: TrustlessWorkService,
+    private notifications: NotificationsService,
   ) {}
 
   private async getBond(tokenId: string) {
@@ -68,6 +70,7 @@ export class TransfersService {
     if (error) throw new BadRequestException(error.message);
 
     await this.audit.emit({ type: AuditEventType.TRANSFER_SOLICITADA, bondTokenId: input.bondTokenId, transferId: transfer.id, actorId, payload: { buyer: actorId, seller: bond.current_owner, amount: input.amount } });
+    await this.notifications.emit(bond.current_owner, NotificationType.OFFER_RECEIVED, { transferId: transfer.id, bondTokenId: input.bondTokenId, bondId: bond.bond_id, amount: input.amount ?? null, buyerId: actorId });
     return transfer;
   }
 
@@ -146,6 +149,7 @@ export class TransfersService {
       actorId,
       payload: { twContractId, twDeployTx, twFundTx, lockTx, amountUsdc },
     });
+    await this.notifications.emit(transfer.to_owner, NotificationType.OFFER_ACCEPTED, { transferId, bondTokenId: transfer.bond_token_id, bondId: bond.bond_id, amount: transfer.amount });
     return updated;
   }
 
@@ -162,6 +166,7 @@ export class TransfersService {
       this.supabase.admin.from('bonds').update({ status: BondStatus.EN_VENTA }).eq('token_id', transfer.bond_token_id),
     ]);
     await this.audit.emit({ type: AuditEventType.TRANSFER_RECHAZADA, bondTokenId: transfer.bond_token_id, transferId, actorId, payload: {} });
+    await this.notifications.emit(transfer.to_owner, NotificationType.OFFER_REJECTED, { transferId, bondTokenId: transfer.bond_token_id });
     return { success: true };
   }
 
@@ -194,6 +199,7 @@ export class TransfersService {
       actorId,
       payload: { counterOfferAmount: amount, message },
     });
+    await this.notifications.emit(transfer.to_owner, NotificationType.COUNTER_OFFER_RECEIVED, { transferId, bondTokenId: transfer.bond_token_id, counterOfferAmount: amount, message: message ?? null });
     return updated;
   }
 
@@ -263,6 +269,7 @@ export class TransfersService {
       actorId,
       payload: { acceptedCounterOffer: transfer.counter_offer_amount, twContractId, twDeployTx, twFundTx, lockTx, amountUsdc },
     });
+    await this.notifications.emit(transfer.from_owner, NotificationType.OFFER_ACCEPTED, { transferId, bondTokenId: transfer.bond_token_id, bondId: bond.bond_id, amount: transfer.counter_offer_amount });
     return updated;
   }
 
@@ -317,6 +324,8 @@ export class TransfersService {
     const { data: updated } = await this.supabase.admin
       .from('transfers').update({ status: TransferStatus.PAGO_VALIDADO, validated_by: actorId }).eq('id', transferId).select().single();
     await this.audit.emit({ type: AuditEventType.PAGO_VALIDADO, bondTokenId: transfer.bond_token_id, transferId, actorId, payload: {} });
+    await this.notifications.emit(transfer.from_owner, NotificationType.PAYMENT_CONFIRMED, { transferId, bondTokenId: transfer.bond_token_id });
+    await this.notifications.emit(transfer.to_owner, NotificationType.PAYMENT_CONFIRMED, { transferId, bondTokenId: transfer.bond_token_id });
     return updated;
   }
 

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -3,9 +3,10 @@ import { ReactNode, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import {
-  Store, Wallet, Handshake, GitBranch, Radio, Settings, LogOut, Bell, Search, ChevronDown, Boxes,
+  Store, Wallet, Handshake, GitBranch, Radio, Settings, LogOut, Search, ChevronDown, Boxes,
 } from 'lucide-react';
 import { useSession, type Me } from '../lib/api';
+import { NotificationBell } from './NotificationBell';
 import { useRoleGuard } from '../lib/role-guard';
 
 const TABS = [
@@ -40,7 +41,7 @@ export function AppShell({ children }: { children: (ctx: { token: string; me: Me
           </div>
 
           <div className="flex items-center gap-2">
-            <button className="relative rounded-full p-2 text-on-surface-variant transition hover:bg-primary-container/5 hover:text-primary-container"><Bell size={20} /><span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full border-2 border-white bg-error" /></button>
+            <NotificationBell role={me?.role} />
             <div className="relative">
               <button onClick={() => setMenu((m) => !m)} className="flex items-center gap-2 rounded-full border border-transparent p-1 pr-2 transition hover:border-outline-variant/30 hover:bg-surface-container-low">
                 <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary-container text-xs font-semibold text-white">{initials(me?.full_name)}</span>

--- a/apps/web/components/NotificationBell.tsx
+++ b/apps/web/components/NotificationBell.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Bell, CheckCheck } from 'lucide-react';
+import { NotificationType } from '@velar/types';
+import { apiFetch } from '../lib/api';
+import { createClient } from '../lib/supabase/client';
+
+type NotifRow = {
+  id: string;
+  type: NotificationType;
+  payload: Record<string, unknown>;
+  read: boolean;
+  created_at: string;
+};
+
+const LABELS: Record<NotificationType, string> = {
+  offer_received: 'Nueva oferta recibida',
+  offer_accepted: 'Oferta aceptada',
+  offer_rejected: 'Oferta rechazada',
+  counter_offer_received: 'Contraoferta recibida',
+  payment_confirmed: 'Pago confirmado',
+  bond_approved: 'Bono aprobado',
+  bond_rejected: 'Solicitud de bono rechazada',
+};
+
+function str(v: unknown): string | undefined {
+  if (typeof v === 'string' && v) return v;
+  if (typeof v === 'number' && !Number.isNaN(v)) return String(v);
+  return undefined;
+}
+
+function num(v: unknown): number | undefined {
+  if (typeof v === 'number' && !Number.isNaN(v)) return v;
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v);
+    if (!Number.isNaN(n)) return n;
+  }
+  return undefined;
+}
+
+function summaryFor(n: NotifRow): string {
+  const p = n.payload;
+  switch (n.type) {
+    case 'offer_received': {
+      const bondId = str(p.bondId);
+      const amount = num(p.amount);
+      if (bondId) return `Bono ${bondId}${amount != null ? `, ₡${amount}` : ''}`;
+      return 'Tenés una nueva oferta de compra';
+    }
+    case 'offer_accepted': {
+      const bondId = str(p.bondId);
+      return `Tu oferta fue aceptada${bondId ? ` · Bono ${bondId}` : ''}`;
+    }
+    case 'offer_rejected':
+      return 'Tu oferta fue rechazada';
+    case 'counter_offer_received': {
+      const counterOfferAmount = num(p.counterOfferAmount);
+      return counterOfferAmount != null
+        ? `Nueva contraoferta: ₡${counterOfferAmount}`
+        : 'Recibiste una contraoferta';
+    }
+    case 'payment_confirmed':
+      return 'El pago fue validado';
+    case 'bond_approved': {
+      const bondId = str(p.bondId);
+      return bondId ? `Bono ${bondId} aprobado` : 'Tu solicitud fue aprobada';
+    }
+    case 'bond_rejected': {
+      const reason = str(p.reason);
+      return reason ? `Motivo: ${reason}` : 'Tu solicitud fue rechazada';
+    }
+    default:
+      return '';
+  }
+}
+
+function routeFor(type: NotificationType, role?: string): string {
+  const base = role === 'emisor' ? '/partido' : role === 'tse' || role === 'admin' ? '/tse' : '';
+  if (type === 'bond_approved' || type === 'bond_rejected') return '/partido/solicitar-bonos';
+  return `${base}/negociaciones`;
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return 'hace un momento';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `hace ${min} min`;
+  const h = Math.floor(min / 60);
+  if (h < 24) return `hace ${h} h`;
+  const d = Math.floor(h / 24);
+  return `hace ${d} d`;
+}
+
+type NotificationBellProps = {
+  role?: string;
+  panelAlign?: 'left' | 'right';
+};
+
+export function NotificationBell({ role, panelAlign = 'right' }: NotificationBellProps) {
+  const router = useRouter();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [notifications, setNotifications] = useState<NotifRow[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getSession().then(({ data }) => {
+      setToken(data.session?.access_token ?? null);
+    });
+  }, []);
+
+  const load = useCallback(async () => {
+    if (!token) return;
+    try {
+      const data = await apiFetch(token, 'GET', '/notifications') as {
+        notifications: NotifRow[];
+        unreadCount: number;
+      };
+      setNotifications(data.notifications ?? []);
+      setUnreadCount(data.unreadCount ?? 0);
+    } catch {
+      /* silently ignore — never crash the navbar */
+    }
+  }, [token]);
+
+  useEffect(() => {
+    if (!token) return;
+    load();
+    const id = setInterval(load, 30_000);
+    return () => clearInterval(id);
+  }, [token, load]);
+
+  useEffect(() => {
+    if (open && token) load();
+  }, [open, token, load]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const markAllRead = async () => {
+    if (!token) return;
+    try {
+      await apiFetch(token, 'PATCH', '/notifications/read-all');
+      await load();
+    } catch {
+      /* silent */
+    }
+  };
+
+  const handleNotifClick = async (n: NotifRow) => {
+    if (!token) return;
+    setOpen(false);
+    try {
+      if (!n.read) {
+        await apiFetch(token, 'PATCH', `/notifications/${n.id}/read`);
+      }
+      load();
+    } catch {
+      /* silent */
+    }
+    router.push(routeFor(n.type, role));
+  };
+
+  const badgeLabel = unreadCount > 99 ? '99+' : String(unreadCount);
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="true"
+        onClick={() => setOpen((v) => !v)}
+        className="relative rounded-full p-2 text-on-surface-variant transition hover:bg-primary-container/5 hover:text-primary-container"
+      >
+        <Bell size={20} />
+        {unreadCount > 0 && (
+          <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full border-2 border-white bg-error px-1 text-[9px] font-bold leading-none text-white">
+            {badgeLabel}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div
+          className={`absolute z-50 mt-2 w-80 overflow-hidden rounded-xl border border-outline-variant/30 bg-white shadow-xl ${panelAlign === 'right' ? 'right-0' : 'left-0'}`}
+        >
+          <div className="flex items-center justify-between border-b border-outline-variant/20 px-4 py-3">
+            <p className="text-sm font-semibold text-on-surface">Notificaciones</p>
+            {unreadCount > 0 && (
+              <button
+                type="button"
+                onClick={markAllRead}
+                className="flex items-center gap-1 text-xs font-medium text-primary transition hover:text-primary-container"
+              >
+                <CheckCheck size={14} />
+                Marcar todas como leídas
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-96 overflow-y-auto">
+            {notifications.length === 0 ? (
+              <p className="px-4 py-8 text-center text-sm text-on-surface-variant">
+                No tenés notificaciones
+              </p>
+            ) : (
+              notifications.slice(0, 10).map((n) => (
+                <button
+                  key={n.id}
+                  type="button"
+                  onClick={() => handleNotifClick(n)}
+                  className={`flex w-full items-start gap-2 border-b border-outline-variant/20 px-4 py-3 text-left transition hover:bg-surface-container-low ${!n.read ? 'bg-primary-container/5' : ''}`}
+                >
+                  <span className="mt-1.5 flex h-2 w-2 shrink-0 items-center justify-center">
+                    {!n.read && <span className="h-2 w-2 rounded-full bg-primary" />}
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-bold text-on-surface">{LABELS[n.type]}</span>
+                    <span className="block truncate text-xs text-on-surface-variant">{summaryFor(n)}</span>
+                    <span className="mt-0.5 block text-[11px] text-outline">{timeAgo(n.created_at)}</span>
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/PartidoShell.tsx
+++ b/apps/web/components/PartidoShell.tsx
@@ -9,6 +9,7 @@ import { createClient } from '../lib/supabase/client';
 import type { Me } from '../lib/api';
 import { useRoleGuard } from '../lib/role-guard';
 import { VelarBrand } from './VelarBrand';
+import { NotificationBell } from './NotificationBell';
 
 const NAV = [
   { href: '/partido', label: 'Dashboard', Icon: LayoutDashboard, exact: true },
@@ -41,9 +42,12 @@ export function PartidoShell({ me, children }: { me: Me; children: ReactNode }) 
     <div className="flex min-h-screen bg-background text-on-background" style={{ fontFamily: 'Inter, sans-serif' }}>
       {/* Sidebar */}
       <nav className="fixed left-0 top-0 z-50 flex h-screen w-[240px] flex-col border-r border-outline-variant bg-white py-6 shadow-sm">
-        <Link href="/partido" className="mb-6 flex items-center px-6" aria-label="VELAR">
-          <VelarBrand size="sm" />
-        </Link>
+        <div className="mb-6 flex items-center justify-between px-4">
+          <Link href="/partido" className="flex items-center" aria-label="VELAR">
+            <VelarBrand size="sm" />
+          </Link>
+          <NotificationBell role={me.role} panelAlign="left" />
+        </div>
 
         <div className="flex flex-1 flex-col gap-1 overflow-y-auto px-2">
           {NAV.map(({ href, label, Icon, exact }) => {

--- a/apps/web/components/TSEShell.tsx
+++ b/apps/web/components/TSEShell.tsx
@@ -10,6 +10,7 @@ import { createClient } from '../lib/supabase/client';
 import type { Me } from '../lib/api';
 import { useRoleGuard } from '../lib/role-guard';
 import { VelarBrand } from './VelarBrand';
+import { NotificationBell } from './NotificationBell';
 
 const NAV = [
   { href: '/tse', label: 'Dashboard', Icon: LayoutGrid, exact: true },
@@ -45,9 +46,12 @@ export function TSEShell({ me, children }: { me: Me; children: ReactNode }) {
       {/* Sidebar */}
       <aside className="sticky top-0 z-40 flex h-full w-64 shrink-0 flex-col justify-between overflow-y-auto border-r border-surface-variant/40 bg-white/80 backdrop-blur-md">
         <div className="px-5 py-7">
-          <Link href="/tse" className="mb-10 flex items-center" aria-label="VELAR">
-            <VelarBrand size="sm" />
-          </Link>
+          <div className="mb-10 flex items-center justify-between">
+            <Link href="/tse" className="flex items-center" aria-label="VELAR">
+              <VelarBrand size="sm" />
+            </Link>
+            <NotificationBell role={me.role} panelAlign="left" />
+          </div>
           <nav className="flex flex-col gap-1">
             {NAV.map(({ href, label, Icon, exact }) => {
               const active = exact ? pathname === href : pathname.startsWith(href);

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -41,11 +41,14 @@ Módulos implementados:
 | `transfers` | ✅ | Flujo completo: request a accept a registerPayment a validate a release a cancel. |
 | `escrow` | 🟡 | Cliente HTTP a Trustless Work. Init/fund/approve/release/refund. Ver §3. |
 | `audit` | ✅ | emit() + consultas. Tabla append-only con trigger que bloquea UPDATE/DELETE. |
+| `notifications` | ✅ | emit(userId, type, payload) + GET/PATCH. Notificaciones in-app por evento del ciclo de vida. |
 
 Schema (`supabase/migrations/20260601000000_initial_schema.sql`): tablas `parties`,
 `profiles`, `bonds`, `transfers`, `audit_events`; enums de estado; triggers de `updated_at`;
 trigger de inmutabilidad de auditoría; trigger `handle_new_user`; índices; políticas RLS;
 seed de partidos. **Sólido.**
+
+Migración de notificaciones (`supabase/migrations/20260608000000_notifications.sql`): tabla `notifications` (`id`, `user_id` FK a `profiles` con `ON DELETE CASCADE`, `type`, `payload jsonb`, `read`, `created_at`), índices por usuario / fecha / no-leídas, y RLS que limita cada fila a su dueño (`user_id = auth.uid()`). El módulo `NotificationsModule` expone `emit()` y se inyecta en `TransfersService` y `BondsService`, que disparan notificaciones en: `offer_received`, `offer_accepted`, `offer_rejected`, `counter_offer_received`, `payment_confirmed`, `bond_approved`, `bond_rejected`.
 
 ### Endpoints actuales
 
@@ -75,6 +78,10 @@ PATCH  /api/transfers/:id/release
 PATCH  /api/transfers/:id/cancel
 
 GET    /api/audit/...             (timeline/eventos)
+
+GET    /api/notifications                 (propias; { notifications, unreadCount })
+PATCH  /api/notifications/read-all
+PATCH  /api/notifications/:id/read
 ```
 
 ---

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,3 +4,4 @@ export * from './transfer';
 export * from './audit';
 export * from './escrow';
 export * from './api';
+export * from './notification';

--- a/packages/types/src/notification.ts
+++ b/packages/types/src/notification.ts
@@ -1,0 +1,26 @@
+/**
+ * Tipos de notificación in-app que el usuario recibe por eventos del ciclo de vida
+ * (ofertas, contraofertas, pagos, aprobación/rechazo de bonos).
+ */
+export const NotificationType = {
+  OFFER_RECEIVED: 'offer_received',
+  OFFER_ACCEPTED: 'offer_accepted',
+  OFFER_REJECTED: 'offer_rejected',
+  COUNTER_OFFER_RECEIVED: 'counter_offer_received',
+  PAYMENT_CONFIRMED: 'payment_confirmed',
+  BOND_APPROVED: 'bond_approved',
+  BOND_REJECTED: 'bond_rejected',
+} as const;
+
+export type NotificationType = (typeof NotificationType)[keyof typeof NotificationType];
+
+export interface Notification {
+  id: string;
+  /** Profile id del destinatario. */
+  userId: string;
+  type: NotificationType;
+  /** Datos suficientes para renderizar el mensaje sin consultas extra. */
+  payload: Record<string, unknown>;
+  read: boolean;
+  createdAt: string;
+}

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -4,3 +4,4 @@ export * from './transfer';
 export * from './audit';
 export * from './escrow';
 export * from './api';
+export * from './notification';

--- a/packages/types/types/index.js
+++ b/packages/types/types/index.js
@@ -20,3 +20,4 @@ __exportStar(require("./transfer"), exports);
 __exportStar(require("./audit"), exports);
 __exportStar(require("./escrow"), exports);
 __exportStar(require("./api"), exports);
+__exportStar(require("./notification"), exports);

--- a/packages/types/types/notification.d.ts
+++ b/packages/types/types/notification.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Tipos de notificación in-app que el usuario recibe por eventos del ciclo de vida
+ * (ofertas, contraofertas, pagos, aprobación/rechazo de bonos).
+ */
+export declare const NotificationType: {
+    readonly OFFER_RECEIVED: "offer_received";
+    readonly OFFER_ACCEPTED: "offer_accepted";
+    readonly OFFER_REJECTED: "offer_rejected";
+    readonly COUNTER_OFFER_RECEIVED: "counter_offer_received";
+    readonly PAYMENT_CONFIRMED: "payment_confirmed";
+    readonly BOND_APPROVED: "bond_approved";
+    readonly BOND_REJECTED: "bond_rejected";
+};
+export type NotificationType = (typeof NotificationType)[keyof typeof NotificationType];
+export interface Notification {
+    id: string;
+    /** Profile id del destinatario. */
+    userId: string;
+    type: NotificationType;
+    /** Datos suficientes para renderizar el mensaje sin consultas extra. */
+    payload: Record<string, unknown>;
+    read: boolean;
+    createdAt: string;
+}

--- a/packages/types/types/notification.js
+++ b/packages/types/types/notification.js
@@ -1,0 +1,16 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.NotificationType = void 0;
+/**
+ * Tipos de notificación in-app que el usuario recibe por eventos del ciclo de vida
+ * (ofertas, contraofertas, pagos, aprobación/rechazo de bonos).
+ */
+exports.NotificationType = {
+    OFFER_RECEIVED: 'offer_received',
+    OFFER_ACCEPTED: 'offer_accepted',
+    OFFER_REJECTED: 'offer_rejected',
+    COUNTER_OFFER_RECEIVED: 'counter_offer_received',
+    PAYMENT_CONFIRMED: 'payment_confirmed',
+    BOND_APPROVED: 'bond_approved',
+    BOND_REJECTED: 'bond_rejected',
+};

--- a/supabase/migrations/20260608000000_notifications.sql
+++ b/supabase/migrations/20260608000000_notifications.sql
@@ -1,0 +1,23 @@
+-- VELAR: notificaciones in-app por eventos del ciclo de vida (ofertas, pagos, bonos).
+
+CREATE TABLE IF NOT EXISTS notifications (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  type        text NOT NULL,
+  payload     jsonb NOT NULL DEFAULT '{}'::jsonb,
+  read        boolean NOT NULL DEFAULT false,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_user    ON notifications(user_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_created ON notifications(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_unread  ON notifications(user_id) WHERE read = false;
+
+ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
+
+-- El usuario solo ve y modifica sus propias notificaciones.
+DROP POLICY IF EXISTS notifications_owner ON notifications;
+CREATE POLICY notifications_owner ON notifications
+  FOR ALL TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
 # feat: in-app notifications system

Closes #11 

  ## Summary

  Adds an **in-app notifications system** that alerts users about bond and transfer
  lifecycle events (offers, counter-offers, payments, and bond approval/rejection).
  Includes the Supabase table with RLS, a NestJS module, shared types, and a navbar
  bell with an unread count and real-time updates.

  ## Changes

  ### Database (`supabase/migrations/20260608000000_notifications.sql`)
  - `notifications` table (`id`, `user_id`, `type`, `payload` jsonb, `read`, `created_at`).
  - Indexes by user, by date, and a partial index for unread rows.
  - **RLS enabled**: each user can only see and modify their own notifications
    (`user_id = auth.uid()`).

  ### API NestJS module (`apps/api/src/notifications/`)
  - `NotificationsService.emit()` — creates the notification **fire-and-forget**:
    it never throws, only logs on failure, so it can't break the business flow that
    triggers it (same pattern as `AuditService.emit`).
  - `list()` returns the latest notifications + `unreadCount`.
  - `markRead()` / `markAllRead()` (always scoped by `user_id`).
  - Controller protected with `AuthGuard`:
    - `GET /notifications`
    - `PATCH /notifications/read-all`
    - `PATCH /notifications/:id/read`

  ### Emission points
  - **Transfers**: `OFFER_RECEIVED`, `OFFER_ACCEPTED`, `OFFER_REJECTED`,
    `COUNTER_OFFER_RECEIVED`, `PAYMENT_CONFIRMED`.
  - **Bonds**: `BOND_APPROVED`, `BOND_REJECTED`.

  ### Shared types (`packages/types`)
  - `NotificationType` (const enum) and the `Notification` interface.

  ### Web (`apps/web/components/NotificationBell.tsx`)
  - Navbar bell with an unread badge.
  - Real-time subscription via Supabase, human-readable labels per type, and
    "mark all as read".
  - Wired into `AppShell`, `PartidoShell`, and `TSEShell`.

  ## Notes
  - `emit` is non-blocking by design: a failed notification never affects the
    business transaction.
  - Notifications carry a self-sufficient `payload` so the message can be rendered
    without extra queries.

  ## How to test
  1. Apply the migration to Supabase.
  2. Create a transfer offer → the bond owner gets `offer_received` and sees the bell badge.
  3. Accept / reject / counter-offer / confirm payment → verify the corresponding notifications.
  4. Approve or reject a bond request → the requester gets `bond_approved` / `bond_rejected`.
  5. Open the bell and use "mark all as read".