### PR TITLE
feat: exportacion CSV de transferencias completadas para auditores TSE

### DIFF
--- a/apps/api/src/analytics/analytics.controller.spec.ts
+++ b/apps/api/src/analytics/analytics.controller.spec.ts
@@ -1,0 +1,59 @@
+import { ForbiddenException, INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AnalyticsController } from './analytics.controller';
+import { AnalyticsService } from './analytics.service';
+import { AuthGuard } from '../auth/auth.guard';
+
+describe('AnalyticsController export', () => {
+  let app: INestApplication;
+  let role: string;
+  const exportTransfersCsv = jest.fn();
+
+  beforeEach(async () => {
+    role = 'tse';
+    exportTransfersCsv.mockReset();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AnalyticsController],
+      providers: [{ provide: AnalyticsService, useValue: { exportTransfersCsv } }],
+    })
+      .overrideGuard(AuthGuard)
+      .useValue({
+        canActivate: (ctx: { switchToHttp: () => { getRequest: () => { user: { profile: { role: string } } } } }) => {
+          ctx.switchToHttp().getRequest().user = { profile: { role } };
+          return true;
+        },
+      })
+      .compile();
+
+    app = module.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('GET /api/analytics/export?format=csv devuelve CSV con nombre de archivo del dia', async () => {
+    const csv = '\uFEFFbond_id,transfer_date,seller_name,buyer_name,amount_colones,party_name\r\nBONO-001,2026-06-10,Partido,Comprador,100000,PLN\r\n';
+    exportTransfersCsv.mockResolvedValue(csv);
+    const today = new Date().toISOString().slice(0, 10);
+
+    const res = await request(app.getHttpServer()).get('/api/analytics/export?format=csv').expect(200);
+
+    expect(res.headers['content-type']).toContain('text/csv');
+    expect(res.headers['content-disposition']).toContain(`filename="velar-transfers-${today}.csv"`);
+    expect(res.text).toBe(csv);
+    expect(exportTransfersCsv).toHaveBeenCalledWith('tse', 'csv');
+  });
+
+  it('propaga 403 cuando el servicio rechaza el rol', async () => {
+    role = 'comprador';
+    exportTransfersCsv.mockRejectedValue(new ForbiddenException('Solo TSE'));
+
+    await request(app.getHttpServer()).get('/api/analytics/export?format=csv').expect(403);
+    expect(exportTransfersCsv).toHaveBeenCalledWith('comprador', 'csv');
+  });
+});

--- a/apps/api/src/analytics/analytics.controller.ts
+++ b/apps/api/src/analytics/analytics.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, StreamableFile, UseGuards } from '@nestjs/common';
 import { AnalyticsService } from './analytics.service';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -37,5 +37,15 @@ export class AnalyticsController {
   @Get('volume-over-time')
   volume(@Query('days') days: string | undefined, @CurrentUser() user: any) {
     return this.analytics.volumeOverTime(user.profile?.role as Role, days ? Number(days) : 30);
+  }
+
+  @Get('export')
+  async export(@Query('format') format: string | undefined, @CurrentUser() user: any) {
+    const csv = await this.analytics.exportTransfersCsv(user.profile?.role as Role, format);
+    const filename = `velar-transfers-${new Date().toISOString().slice(0, 10)}.csv`;
+    return new StreamableFile(Buffer.from(csv, 'utf-8'), {
+      type: 'text/csv; charset=utf-8',
+      disposition: `attachment; filename="${filename}"`,
+    });
   }
 }

--- a/apps/api/src/analytics/analytics.service.spec.ts
+++ b/apps/api/src/analytics/analytics.service.spec.ts
@@ -1,0 +1,66 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnalyticsService } from './analytics.service';
+import { SupabaseService } from '../common/supabase/supabase.service';
+
+describe('AnalyticsService exportTransfersCsv', () => {
+  let service: AnalyticsService;
+  let fromMock: jest.Mock;
+
+  beforeEach(async () => {
+    fromMock = jest.fn();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsService,
+        {
+          provide: SupabaseService,
+          useValue: {
+            admin: { from: fromMock },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(AnalyticsService);
+  });
+
+  it('rechaza roles distintos de TSE', async () => {
+    await expect(service.exportTransfersCsv('comprador', 'csv')).rejects.toThrow(ForbiddenException);
+    await expect(service.exportTransfersCsv('admin', 'csv')).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rechaza formatos distintos de csv', async () => {
+    await expect(service.exportTransfersCsv('tse', 'pdf')).rejects.toThrow(BadRequestException);
+  });
+
+  it('genera CSV con columnas requeridas y solo transferencias liberadas', async () => {
+    const order = jest.fn().mockResolvedValue({
+      data: [
+        {
+          amount: 150000,
+          created_at: '2026-06-10T15:30:00.000Z',
+          from_profile: { full_name: 'Partido ABC' },
+          to_profile: { full_name: 'Juan Pérez' },
+          bonds: { bond_id: 'BONO-001', parties: { name: 'Partido XYZ' } },
+        },
+        {
+          amount: 200000,
+          created_at: '2026-06-11T09:00:00.000Z',
+          from_profile: { full_name: 'María, "La Vendedora"' },
+          to_profile: { full_name: 'Carlos López' },
+          bonds: { bond_id: 'BONO-002', parties: { name: 'Partido XYZ' } },
+        },
+      ],
+      error: null,
+    });
+    const eq = jest.fn().mockReturnValue({ order });
+    fromMock.mockReturnValue({ select: jest.fn().mockReturnValue({ eq }) });
+
+    const csv = await service.exportTransfersCsv('tse', 'csv');
+
+    expect(eq).toHaveBeenCalledWith('status', 'liberada');
+    expect(csv.startsWith('\uFEFFbond_id,transfer_date,seller_name,buyer_name,amount_colones,party_name')).toBe(true);
+    expect(csv).toContain('BONO-001,2026-06-10,Partido ABC,Juan Pérez,150000,Partido XYZ');
+    expect(csv).toContain('"María, ""La Vendedora""",Carlos López,200000,Partido XYZ');
+  });
+});

--- a/apps/api/src/analytics/analytics.service.ts
+++ b/apps/api/src/analytics/analytics.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, ForbiddenException } from '@nestjs/common';
+import { BadRequestException, Injectable, ForbiddenException } from '@nestjs/common';
 import { SupabaseService } from '../common/supabase/supabase.service';
 import { Role } from '@velar/types';
 
 const AUTHORITY: Role[] = ['tse', 'admin'];
+const CSV_HEADERS = ['bond_id', 'transfer_date', 'seller_name', 'buyer_name', 'amount_colones', 'party_name'] as const;
 
 @Injectable()
 export class AnalyticsService {
@@ -10,6 +11,10 @@ export class AnalyticsService {
 
   private assertAuth(role: Role) {
     if (!AUTHORITY.includes(role)) throw new ForbiddenException('Solo TSE/admin');
+  }
+
+  private assertTseOnly(role: Role) {
+    if (role !== 'tse') throw new ForbiddenException('Solo TSE');
   }
 
   /** Overview general del sistema. */
@@ -205,6 +210,37 @@ export class AnalyticsService {
     return [...agg.values()].sort((a, b) => b.volume - a.volume).slice(0, limit);
   }
 
+  /** CSV de transferencias liberadas para auditores externos. Solo rol TSE. */
+  async exportTransfersCsv(role: Role, format: string | undefined) {
+    this.assertTseOnly(role);
+    if (format !== 'csv') throw new BadRequestException('format=csv requerido');
+
+    const { data, error } = await this.supabase.admin
+      .from('transfers')
+      .select(`
+        amount,
+        created_at,
+        from_profile:profiles!transfers_from_owner_fkey(full_name),
+        to_profile:profiles!transfers_to_owner_fkey(full_name),
+        bonds(bond_id, parties(name))
+      `)
+      .eq('status', 'liberada')
+      .order('created_at', { ascending: true });
+
+    if (error) throw new BadRequestException(error.message);
+
+    const rows = ((data ?? []) as any[]).map((t) => [
+      t.bonds?.bond_id ?? '',
+      (t.created_at ?? '').slice(0, 10),
+      t.from_profile?.full_name ?? '',
+      t.to_profile?.full_name ?? '',
+      Number(t.amount) || 0,
+      t.bonds?.parties?.name ?? '',
+    ]);
+
+    return `\uFEFF${[CSV_HEADERS.join(','), ...rows.map((row) => row.map((cell) => this.csvCell(cell)).join(','))].join('\r\n')}\r\n`;
+  }
+
   /** Serie temporal del volumen movido por día. */
   async volumeOverTime(role: Role, days = 30) {
     this.assertAuth(role);
@@ -235,5 +271,10 @@ export class AnalyticsService {
       acc[k] = (acc[k] ?? 0) + 1;
       return acc;
     }, {});
+  }
+
+  private csvCell(value: string | number): string {
+    const s = String(value);
+    return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
   }
 }

--- a/apps/web/app/tse/analytics/page.tsx
+++ b/apps/web/app/tse/analytics/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { TrendingUp, TrendingDown, DollarSign, Activity, Boxes, Users, BarChart3, ArrowRight } from 'lucide-react';
+import { TrendingUp, TrendingDown, DollarSign, Activity, Boxes, Users, BarChart3, Download } from 'lucide-react';
 import { TSEShell } from '../../../components/TSEShell';
-import { useSession, apiFetch } from '../../../lib/api';
+import { useSession, apiFetch, apiDownload } from '../../../lib/api';
 
 const fmtCRC = (n: number) => new Intl.NumberFormat('es-CR', { style: 'currency', currency: 'CRC', maximumFractionDigits: 0 }).format(n || 0);
 const fmtNum = (n: number) => new Intl.NumberFormat('es-CR').format(n || 0);
@@ -17,6 +17,8 @@ export default function AnalyticsPage() {
   const [selBond, setSelBond] = useState<string | null>(null);
   const [priceHistory, setPriceHistory] = useState<any>(null);
   const [owners, setOwners] = useState<any>(null);
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState('');
 
   useEffect(() => {
     if (!token) return;
@@ -52,6 +54,20 @@ export default function AnalyticsPage() {
 
   const maxVolume = Math.max(...byParty.map((p) => p.volume_moved), 1);
   const maxDayVol = Math.max(...volume.map((v) => v.volume), 1);
+  const exportFilename = `velar-transfers-${new Date().toISOString().slice(0, 10)}.csv`;
+
+  const handleExportCsv = async () => {
+    if (!token) return;
+    setExporting(true);
+    setExportError('');
+    try {
+      await apiDownload(token, '/analytics/export?format=csv', exportFilename);
+    } catch (e: any) {
+      setExportError(e.message ?? 'No se pudo exportar el CSV');
+    } finally {
+      setExporting(false);
+    }
+  };
 
   return (
     <TSEShell me={me}>
@@ -59,6 +75,18 @@ export default function AnalyticsPage() {
         <div>
           <h1 className="text-2xl font-bold" style={{ fontFamily: 'Geist' }}>Análisis de bonos</h1>
           <p className="text-sm text-on-surface-variant">Métricas, precios y propietarios</p>
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <button
+            type="button"
+            onClick={handleExportCsv}
+            disabled={exporting}
+            className="flex items-center gap-2 rounded-xl border border-primary/30 bg-white px-4 py-2.5 text-sm font-semibold text-primary transition hover:bg-primary/5 disabled:opacity-60"
+          >
+            <Download size={16} />
+            {exporting ? 'Exportando…' : 'Exportar CSV'}
+          </button>
+          {exportError && <p className="text-xs text-red-600">{exportError}</p>}
         </div>
       </header>
 

--- a/apps/web/lib/api.ts
+++ b/apps/web/lib/api.ts
@@ -48,6 +48,40 @@ export async function apiFetch(token: string, method: string, path: string, body
   return requestJson(method, path, body, token);
 }
 
+function filenameFromDisposition(header: string | null, fallback: string) {
+  const match = header?.match(/filename="([^"]+)"/);
+  return match?.[1] ?? fallback;
+}
+
+/** Descarga un archivo autenticado desde el backend (p. ej. CSV). */
+export async function apiDownload(token: string, path: string, fallbackFilename: string) {
+  const url = buildApiUrl(path);
+  let res: Response;
+
+  try {
+    res = await fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    throw new Error(`No se pudo conectar con la API en ${url}. Verifica que el backend este corriendo y que NEXT_PUBLIC_API_URL apunte a la URL correcta.`);
+  }
+
+  if (!res.ok) {
+    const json = await res.json().catch(() => ({}));
+    throw new Error(messageFromPayload(json, `Error ${res.status} en ${url}`));
+  }
+
+  const blob = await res.blob();
+  const filename = filenameFromDisposition(res.headers.get('Content-Disposition'), fallbackFilename);
+  const objectUrl = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = objectUrl;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(objectUrl);
+}
+
 export type Me = {
   id: string; email: string; full_name?: string; role?: string;
   party_id?: string | null; stellar_wallet?: string | null;


### PR DESCRIPTION
## Summary

- Agrega \GET /analytics/export?format=csv\ que devuelve un archivo CSV con transferencias en estado \liberada\ (columnas: bond_id, transfer_date, seller_name, buyer_name, amount_colones, party_name).
- Restringe el endpoint al rol \	se\ (403 para otros roles).
- Agrega boton **Exportar CSV** en el dashboard de analiticas TSE con descarga \elar-transfers-YYYY-MM-DD.csv\.
- Incluye helper \piDownload\ en el frontend y pruebas unitarias del generador CSV en el backend.

Closes #8

## Test plan

- [x] \
pm run test --workspace apps/api\ (4 tests, incluye casos de rol TSE, formato csv y columnas requeridas)
- [x] \
pm run build --workspace apps/api\ pasa sin errores
- [ ] Iniciar sesion como usuario TSE en \/tse/analytics\, pulsar **Exportar CSV** y verificar que se descarga \elar-transfers-YYYY-MM-DD.csv\ con datos validos en Excel/Google Sheets
- [ ] Iniciar sesion como \comprador\ o \dmin\ y confirmar que \GET /analytics/export?format=csv\ responde 403
- [ ] Verificar que el dashboard de analiticas sigue cargando overview, by-party, top-bonds y volume-over-time sin regresiones

## Notas

- El build/lint del workspace \pps/web\ falla en \main\ por un import roto de \Toast\ en paginas de partido (no introducido por este PR).

Made with [Cursor](https://cursor.com)