### PR TITLE
feat: paginacion en listados de bonds, transfers y audit/events

### DIFF
--- a/apps/api/src/audit/audit.controller.ts
+++ b/apps/api/src/audit/audit.controller.ts
@@ -26,9 +26,13 @@ export class AuditController {
   }
 
   @Get('events')
-  getRecentEvents(@Query('limit') limit: string, @CurrentUser() user: any) {
+  getRecentEvents(
+    @Query('page') page: string | undefined,
+    @Query('limit') limit: string | undefined,
+    @CurrentUser() user: any,
+  ) {
     const role: Role = user.profile?.role;
     if (!['tse', 'admin'].includes(role)) throw new ForbiddenException('TSE/Admin only');
-    return this.audit.getRecentEvents(limit ? Number(limit) : 50);
+    return this.audit.getRecentEvents(page, limit);
   }
 }

--- a/apps/api/src/audit/audit.service.ts
+++ b/apps/api/src/audit/audit.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import { SupabaseService } from '../common/supabase/supabase.service';
+import { paginatedResponse, parsePagination } from '../common/pagination';
 import { AuditEventType, BondSearchQuery } from '@velar/types';
 
 @Injectable()
@@ -64,12 +65,14 @@ export class AuditService {
     return data ?? [];
   }
 
-  async getRecentEvents(limit = 50) {
-    const { data } = await this.supabase.admin
+  async getRecentEvents(page?: string, limit?: string) {
+    const { page: p, limit: l, from, to } = parsePagination(page, limit);
+    const { data, count, error } = await this.supabase.admin
       .from('audit_events')
-      .select('*, bonds(bond_id, status), profiles!audit_events_actor_id_fkey(full_name, email)')
+      .select('*, bonds(bond_id, status), profiles!audit_events_actor_id_fkey(full_name, email)', { count: 'exact' })
       .order('created_at', { ascending: false })
-      .limit(limit);
-    return data ?? [];
+      .range(from, to);
+    if (error) throw new BadRequestException(error.message);
+    return paginatedResponse(data ?? [], count ?? 0, p, l);
   }
 }

--- a/apps/api/src/bonds/bonds.controller.ts
+++ b/apps/api/src/bonds/bonds.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
 import { BondsService } from './bonds.service';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -15,8 +15,12 @@ export class BondsController {
   }
 
   @Get()
-  findAll(@CurrentUser() user: any) {
-    return this.bonds.findAll(user.id, user.profile?.role as Role, user.profile?.party_id);
+  findAll(
+    @Query('page') page: string | undefined,
+    @Query('limit') limit: string | undefined,
+    @CurrentUser() user: any,
+  ) {
+    return this.bonds.findAll(user.id, user.profile?.role as Role, user.profile?.party_id, page, limit);
   }
 
   @Get('requests')

--- a/apps/api/src/bonds/bonds.service.ts
+++ b/apps/api/src/bonds/bonds.service.ts
@@ -7,6 +7,7 @@ import {
 import * as crypto from 'crypto';
 import { Logger } from '@nestjs/common';
 import { SupabaseService } from '../common/supabase/supabase.service';
+import { paginatedResponse, parsePagination } from '../common/pagination';
 import { AuditService } from '../audit/audit.service';
 import { StellarBondService } from '../escrow/stellar-bond.service';
 import { SorobanBondService } from '../escrow/soroban-bond.service';
@@ -283,10 +284,11 @@ export class BondsService {
     return updated ?? data;
   }
 
-  async findAll(actorId: string, actorRole: Role, partyId?: string) {
+  async findAll(actorId: string, actorRole: Role, partyId?: string, page?: string, limit?: string) {
+    const { page: p, limit: l, from, to } = parsePagination(page, limit);
     let q = this.supabase.admin
       .from('bonds')
-      .select('*, parties(*), profiles!bonds_current_owner_fkey(id, full_name, email)')
+      .select('*, parties(*), profiles!bonds_current_owner_fkey(id, full_name, email)', { count: 'exact' })
       .order('created_at', { ascending: false });
 
     if (AUTHORITY.includes(actorRole)) {
@@ -298,8 +300,9 @@ export class BondsService {
       // Comprador ve solo los bonos que posee
       q = q.eq('current_owner', actorId);
     }
-    const { data } = await q;
-    return data ?? [];
+    const { data, count, error } = await q.range(from, to);
+    if (error) throw new BadRequestException(error.message);
+    return paginatedResponse(data ?? [], count ?? 0, p, l);
   }
 
   /** Solicitudes de bono enviadas por el partido. */

--- a/apps/api/src/common/pagination.spec.ts
+++ b/apps/api/src/common/pagination.spec.ts
@@ -1,0 +1,27 @@
+import { parsePagination, paginatedResponse } from './pagination';
+
+describe('parsePagination', () => {
+  it('usa page=1 y limit=20 por defecto', () => {
+    expect(parsePagination(undefined, undefined)).toEqual({ page: 1, limit: 20, from: 0, to: 19 });
+  });
+
+  it('calcula el rango para page=2 y limit=5', () => {
+    expect(parsePagination('2', '5')).toEqual({ page: 2, limit: 5, from: 5, to: 9 });
+  });
+
+  it('limita valores invalidos', () => {
+    expect(parsePagination('0', '-1')).toEqual({ page: 1, limit: 1, from: 0, to: 0 });
+    expect(parsePagination('1', '500').limit).toBe(100);
+  });
+});
+
+describe('paginatedResponse', () => {
+  it('devuelve la forma PaginatedResponse', () => {
+    expect(paginatedResponse(['a', 'b'], 12, 2, 5)).toEqual({
+      data: ['a', 'b'],
+      total: 12,
+      page: 2,
+      limit: 5,
+    });
+  });
+});

--- a/apps/api/src/common/pagination.ts
+++ b/apps/api/src/common/pagination.ts
@@ -1,0 +1,22 @@
+import { PaginatedResponse } from '@velar/types';
+
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_LIMIT = 20;
+export const MAX_LIMIT = 100;
+
+export function parsePagination(page?: string, limit?: string) {
+  const parsedPage = Math.max(1, Number(page) || DEFAULT_PAGE);
+  const parsedLimit = Math.min(MAX_LIMIT, Math.max(1, Number(limit) || DEFAULT_LIMIT));
+  const from = (parsedPage - 1) * parsedLimit;
+  const to = from + parsedLimit - 1;
+  return { page: parsedPage, limit: parsedLimit, from, to };
+}
+
+export function paginatedResponse<T>(
+  data: T[],
+  total: number,
+  page: number,
+  limit: number,
+): PaginatedResponse<T> {
+  return { data, total, page, limit };
+}

--- a/apps/api/src/transfers/transfers.controller.ts
+++ b/apps/api/src/transfers/transfers.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
 import { TransfersService } from './transfers.service';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -10,8 +10,12 @@ export class TransfersController {
   constructor(private transfers: TransfersService) {}
 
   @Get()
-  findAll(@CurrentUser() user: any) {
-    return this.transfers.findMyTransfers(user.id, user.profile?.role as Role);
+  findAll(
+    @Query('page') page: string | undefined,
+    @Query('limit') limit: string | undefined,
+    @CurrentUser() user: any,
+  ) {
+    return this.transfers.findMyTransfers(user.id, user.profile?.role as Role, page, limit);
   }
 
   @Get(':id')

--- a/apps/api/src/transfers/transfers.service.ts
+++ b/apps/api/src/transfers/transfers.service.ts
@@ -3,6 +3,7 @@ import {
 } from '@nestjs/common';
 import * as crypto from 'crypto';
 import { SupabaseService } from '../common/supabase/supabase.service';
+import { paginatedResponse, parsePagination } from '../common/pagination';
 import { AuditService } from '../audit/audit.service';
 import { StellarBondService } from '../escrow/stellar-bond.service';
 import { TrustlessWorkService } from '../escrow/trustless-work.service';
@@ -494,10 +495,11 @@ export class TransfersService {
     return { success: true };
   }
 
-  async findMyTransfers(actorId: string, actorRole: Role) {
+  async findMyTransfers(actorId: string, actorRole: Role, page?: string, limit?: string) {
+    const { page: p, limit: l, from, to } = parsePagination(page, limit);
     let q = this.supabase.admin
       .from('transfers')
-      .select('*, bonds!inner(bond_id, status, face_value, issuer_party_id), from_profile:profiles!transfers_from_owner_fkey(id, full_name, email), to_profile:profiles!transfers_to_owner_fkey(id, full_name, email)')
+      .select('*, bonds!inner(bond_id, status, face_value, issuer_party_id), from_profile:profiles!transfers_from_owner_fkey(id, full_name, email), to_profile:profiles!transfers_to_owner_fkey(id, full_name, email)', { count: 'exact' })
       .order('created_at', { ascending: false });
 
     if (!['tse', 'admin'].includes(actorRole)) {
@@ -517,8 +519,9 @@ export class TransfersService {
         q = q.or(`from_owner.eq.${actorId},to_owner.eq.${actorId}`);
       }
     }
-    const { data } = await q;
-    return data ?? [];
+    const { data, count, error } = await q.range(from, to);
+    if (error) throw new BadRequestException(error.message);
+    return paginatedResponse(data ?? [], count ?? 0, p, l);
   }
 
   async findOne(transferId: string) {

--- a/apps/web/app/en-vivo/page.tsx
+++ b/apps/web/app/en-vivo/page.tsx
@@ -4,6 +4,7 @@ import { Radio, Activity, ExternalLink } from 'lucide-react';
 import { AppShell } from '../../components/AppShell';
 import { StatusBadge, EmptyState, fmtDate } from '../../components/ui';
 import { apiFetch } from '../../lib/api';
+import { unwrapPaginated } from '../../lib/pagination';
 import { stellarExpert } from '../../lib/stellar';
 
 type Transfer = { id: string; status: string; created_at?: string; bonds?: { bond_id?: string }; from_profile?: { full_name?: string }; to_profile?: { full_name?: string } };
@@ -15,7 +16,7 @@ export default function EnVivoPage() {
 function Content({ token }: { token: string }) {
   const [items, setItems] = useState<Transfer[]>([]);
 
-  const load = () => apiFetch(token, 'GET', '/transfers').then((t) => setItems((t as Transfer[]).slice(0, 30))).catch(() => {});
+  const load = () => apiFetch(token, 'GET', '/transfers?page=1&limit=30').then((res) => setItems(unwrapPaginated(res))).catch(() => {});
   useEffect(() => { load(); const id = setInterval(load, 15000); return () => clearInterval(id); /* eslint-disable-next-line */ }, []);
 
   return (

--- a/apps/web/app/marketplace/MarketplacePageClient.tsx
+++ b/apps/web/app/marketplace/MarketplacePageClient.tsx
@@ -6,6 +6,7 @@ import { Handshake, ShieldCheck, SlidersHorizontal, Store } from 'lucide-react';
 import { AppShell } from '../../components/AppShell';
 import { EmptyState, fmtMoney, StatusBadge, StellarExpertButton } from '../../components/ui';
 import { apiFetch } from '../../lib/api';
+import { unwrapPaginated } from '../../lib/pagination';
 import { bondExplorerUrl } from '../../lib/stellar';
 
 type Bond = {
@@ -42,7 +43,7 @@ function Content({ token }: { token: string }) {
 
   const load = useCallback(() => {
     apiFetch(token, 'GET', '/bonds/available').then(setBonds).catch((e) => notify.err(e.message));
-    apiFetch(token, 'GET', '/transfers').then(setTransfers).catch(() => undefined);
+    apiFetch(token, 'GET', '/transfers?page=1&limit=100').then((res) => setTransfers(unwrapPaginated(res))).catch(() => undefined);
   }, [token]);
 
   useEffect(() => { load(); }, [load]);

--- a/apps/web/app/mis-bonos/page.tsx
+++ b/apps/web/app/mis-bonos/page.tsx
@@ -4,10 +4,12 @@ import { useEffect, useState } from 'react';
 import { Wallet, TrendingUp, Boxes, ShoppingCart } from 'lucide-react';
 import { AppShell } from '../../components/AppShell';
 import { StellarExpertButton, StatusBadge, EmptyState, fmtMoney } from '../../components/ui';
+import { PaginationControls } from '../../components/PaginationControls';
 import { apiFetch } from '../../lib/api';
+import { paginatedQuery, paginationMeta, unwrapPaginated } from '../../lib/pagination';
 import { bondExplorerUrl } from '../../lib/stellar';
 
-type Bond = { token_id: string; bond_id: string; status: string; face_value: number | null; parties?: { name?: string }; created_at?: string };
+type Bond = { token_id: string; bond_id: string; status: string; face_value: number | null; soroban_contract_id?: string | null; parties?: { name?: string }; created_at?: string };
 
 export default function MisBonosPage() {
   return <AppShell>{({ token }) => <Content token={token} />}</AppShell>;
@@ -15,24 +17,32 @@ export default function MisBonosPage() {
 
 function Content({ token }: { token: string }) {
   const [bonds, setBonds] = useState<Bond[]>([]);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
   const [busy, setBusy] = useState<string | null>(null);
   
 
-  const load = () => apiFetch(token, 'GET', '/bonds').then(setBonds).catch(() => {});
-  useEffect(() => { load(); /* eslint-disable-next-line */ }, []);
+  const load = (p = page) => apiFetch(token, 'GET', `/bonds?${paginatedQuery(p, limit)}`)
+    .then((res) => {
+      setBonds(unwrapPaginated(res));
+      setTotal(paginationMeta(res).total);
+    })
+    .catch(() => {});
+  useEffect(() => { load(page); /* eslint-disable-next-line */ }, [page]);
 
   async function publicar(tokenId: string) {
     setBusy(tokenId); 
-    try { await apiFetch(token, 'PATCH', `/bonds/${tokenId}/publish`); notify.ok('Bono publicado en el marketplace.'); load(); }
+    try { await apiFetch(token, 'PATCH', `/bonds/${tokenId}/publish`); notify.ok('Bono publicado en el marketplace.'); load(page); }
     catch (e: any) { notify.err(e.message); } finally { setBusy(null); }
   }
 
-  const total = bonds.reduce((s, b) => s + (Number(b.face_value) || 0), 0);
+  const portfolioTotal = bonds.reduce((s, b) => s + (Number(b.face_value) || 0), 0);
   const activos = bonds.filter((b) => b.status === 'activo').length;
 
   const stats = [
-    ['Bonos en cartera', bonds.length, <Boxes size={20} key="a" />],
-    ['Valor total', fmtMoney(total), <Wallet size={20} key="b" />],
+    ['Bonos en cartera', total, <Boxes size={20} key="a" />],
+    ['Valor total', fmtMoney(portfolioTotal), <Wallet size={20} key="b" />],
     ['Disponibles', activos, <TrendingUp size={20} key="c" />],
   ] as const;
 
@@ -83,6 +93,7 @@ function Content({ token }: { token: string }) {
               })}
             </tbody>
           </table>
+          <PaginationControls page={page} limit={limit} total={total} onPageChange={setPage} />
         </div>
       )}
     </>

--- a/apps/web/app/negociaciones/page.tsx
+++ b/apps/web/app/negociaciones/page.tsx
@@ -3,8 +3,10 @@ import { notify } from '../../components/Toast';
 import { useEffect, useState } from 'react';
 import { Handshake, ArrowRight, Shield, ExternalLink } from 'lucide-react';
 import { AppShell } from '../../components/AppShell';
+import { PaginationControls } from '../../components/PaginationControls';
 import { StatusBadge, EmptyState, fmtMoney, fmtDate } from '../../components/ui';
 import { apiFetch, type Me } from '../../lib/api';
+import { paginatedQuery, paginationMeta, unwrapPaginated } from '../../lib/pagination';
 
 type Transfer = {
   id: string; status: string; amount: number | null; from_owner: string; to_owner: string;
@@ -21,11 +23,19 @@ export default function NegociacionesPage() {
 
 function Content({ token, me }: { token: string; me: Me }) {
   const [transfers, setTransfers] = useState<Transfer[]>([]);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
   
   const [busy, setBusy] = useState<string | null>(null);
 
-  const load = () => apiFetch(token, 'GET', '/transfers').then(setTransfers).catch((e) => notify.err(e.message));
-  useEffect(() => { load(); /* eslint-disable-next-line */ }, []);
+  const load = (p = page) => apiFetch(token, 'GET', `/transfers?${paginatedQuery(p, limit)}`)
+    .then((res) => {
+      setTransfers(unwrapPaginated(res));
+      setTotal(paginationMeta(res).total);
+    })
+    .catch((e) => notify.err(e.message));
+  useEffect(() => { load(page); /* eslint-disable-next-line */ }, [page]);
 
   async function act(id: string, action: string) {
     let body: any = undefined;
@@ -39,7 +49,7 @@ function Content({ token, me }: { token: string; me: Me }) {
     try {
       await apiFetch(token, 'PATCH', `/transfers/${id}/${action}`, body);
       notify.ok(action === 'request-return' ? 'Solicitud enviada al TSE' : 'Acción realizada');
-      load();
+      load(page);
     } catch (e: any) { notify.err(e.message); }
     finally { setBusy(null); }
   }
@@ -107,6 +117,7 @@ function Content({ token, me }: { token: string; me: Me }) {
           <div className="flex flex-col gap-3 opacity-90">{historial.map((t) => <Row key={t.id} t={t} />)}</div>
         </>
       )}
+      <PaginationControls page={page} limit={limit} total={total} onPageChange={setPage} />
     </>
   );
 }

--- a/apps/web/app/partido/PartidoPageClient.tsx
+++ b/apps/web/app/partido/PartidoPageClient.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { PartidoShell } from '../../components/PartidoShell';
 import { useSession } from '../../lib/api';
 import { apiFetch } from '../../lib/api';
+import { unwrapPaginated } from '../../lib/pagination';
 
 const fmt = (n: number | null | undefined, cur = 'CRC') => {
   if (n == null) return '—';
@@ -36,11 +37,11 @@ export default function PartidoPageClient() {
 
   const load = (tok: string) =>
     Promise.all([
-      apiFetch(tok, 'GET', '/bonds').catch(() => null),
-      apiFetch(tok, 'GET', '/transfers').catch(() => null),
+      apiFetch(tok, 'GET', '/bonds?page=1&limit=20').catch(() => null),
+      apiFetch(tok, 'GET', '/transfers?page=1&limit=20').catch(() => null),
     ]).then(([bs, trs]) => {
-      setBonds(Array.isArray(bs) ? bs : []);
-      setTransfers(Array.isArray(trs) ? trs : []);
+      setBonds(unwrapPaginated(bs ?? []));
+      setTransfers(unwrapPaginated(trs ?? []));
     });
 
   useEffect(() => { if (token) load(token); /* eslint-disable-next-line */ }, [token]);

--- a/apps/web/app/partido/historial/page.tsx
+++ b/apps/web/app/partido/historial/page.tsx
@@ -2,7 +2,9 @@
 import { useEffect, useState } from 'react';
 import { History, ArrowRight } from 'lucide-react';
 import { PartidoShell } from '../../../components/PartidoShell';
+import { PaginationControls } from '../../../components/PaginationControls';
 import { useSession, apiFetch } from '../../../lib/api';
+import { paginatedQuery, paginationMeta, unwrapPaginated } from '../../../lib/pagination';
 
 type Transfer = {
   id: string; status: string; created_at?: string; amount: number | null;
@@ -16,11 +18,20 @@ const fmtDate = (d?: string) => d ? new Date(d).toLocaleDateString('es-CR', { da
 export default function PartidoHistorialPage() {
   const { token, me, loading, error } = useSession();
   const [transfers, setTransfers] = useState<Transfer[]>([]);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
 
   useEffect(() => {
-    if (token) apiFetch(token, 'GET', '/transfers').then(setTransfers).catch(() => {});
+    if (!token) return;
+    apiFetch(token, 'GET', `/transfers?${paginatedQuery(page, limit)}`)
+      .then((res) => {
+        setTransfers(unwrapPaginated(res));
+        setTotal(paginationMeta(res).total);
+      })
+      .catch(() => {});
     /* eslint-disable-next-line */
-  }, [token]);
+  }, [token, page, limit]);
 
   if (loading || !token || !me) {
     return (
@@ -71,6 +82,7 @@ export default function PartidoHistorialPage() {
                 ))}
               </tbody>
             </table>
+            <PaginationControls page={page} limit={limit} total={total} onPageChange={setPage} />
           </div>
         )}
       </div>

--- a/apps/web/app/partido/mis-bonos/page.tsx
+++ b/apps/web/app/partido/mis-bonos/page.tsx
@@ -1,10 +1,12 @@
 'use client';
-import { notify } from '../../components/Toast';
+import { notify } from '../../../components/Toast';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Wallet, Boxes, ExternalLink, ShoppingCart, TrendingUp } from 'lucide-react';
 import { PartidoShell } from '../../../components/PartidoShell';
+import { PaginationControls } from '../../../components/PaginationControls';
 import { useSession, apiFetch } from '../../../lib/api';
+import { paginatedQuery, paginationMeta, unwrapPaginated } from '../../../lib/pagination';
 import { bondExplorerUrl } from '../../../lib/stellar';
 
 type Bond = {
@@ -18,6 +20,7 @@ type Bond = {
   series?: string;
   issue_date?: string;
   maturity_date?: string;
+  soroban_contract_id?: string | null;
   parties?: { name?: string };
 };
 
@@ -42,15 +45,21 @@ const fmtDate = (d?: string) => d ? new Date(d).toLocaleDateString('es-CR', { da
 export default function PartidoMisBonosPage() {
   const { token, me, loading, error } = useSession();
   const [bonds, setBonds] = useState<Bond[]>([]);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
   const [busy, setBusy] = useState<string | null>(null);
   
 
-  const load = (tok: string) =>
-    apiFetch(tok, 'GET', '/bonds')
-      .then((bs) => { if (Array.isArray(bs)) setBonds(bs); })
+  const load = (tok: string, p = page) =>
+    apiFetch(tok, 'GET', `/bonds?${paginatedQuery(p, limit)}`)
+      .then((res) => {
+        setBonds(unwrapPaginated(res));
+        setTotal(paginationMeta(res).total);
+      })
       .catch(() => setBonds([]));
 
-  useEffect(() => { if (token) load(token); /* eslint-disable-next-line */ }, [token]);
+  useEffect(() => { if (token) load(token, page); /* eslint-disable-next-line */ }, [token, page]);
 
   if (loading || !token || !me) {
     return (
@@ -66,7 +75,7 @@ export default function PartidoMisBonosPage() {
     try {
       await apiFetch(token, 'PATCH', `/bonds/${tokenId}/publish`);
       notify.ok('Bono publicado en el marketplace.');
-      load(token);
+      load(token, page);
     } catch (e: any) { notify.err(e.message); } finally { setBusy(null); }
   }
 
@@ -89,7 +98,7 @@ export default function PartidoMisBonosPage() {
         {/* Stats */}
         <div className="mb-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
           {([
-            ['Total de bonos', bonds.length, <Boxes size={20} key="a" />],
+            ['Total de bonos', total, <Boxes size={20} key="a" />],
             ['Valor total (CRC)', fmtMoney(totalCRC), <Wallet size={20} key="b" />],
             ['En marketplace', enVenta, <ShoppingCart size={20} key="c" />],
           ] as const).map(([label, val, icon]: any) => (
@@ -150,6 +159,7 @@ export default function PartidoMisBonosPage() {
               })}
             </tbody>
           </table>
+          <PaginationControls page={page} limit={limit} total={total} onPageChange={setPage} />
         </div>
       </div>
     </PartidoShell>

--- a/apps/web/app/partido/negociaciones/page.tsx
+++ b/apps/web/app/partido/negociaciones/page.tsx
@@ -1,9 +1,11 @@
 'use client';
-import { notify } from '../../components/Toast';
+import { notify } from '../../../components/Toast';
 import { useEffect, useState } from 'react';
 import { Handshake, ArrowRight, Clock, CheckCircle2, XCircle } from 'lucide-react';
 import { PartidoShell } from '../../../components/PartidoShell';
+import { PaginationControls } from '../../../components/PaginationControls';
 import { useSession, apiFetch, type Me } from '../../../lib/api';
+import { paginatedQuery, paginationMeta, unwrapPaginated } from '../../../lib/pagination';
 
 type Transfer = {
   id: string; status: string; amount: number | null;
@@ -31,11 +33,19 @@ const fmtDate = (d?: string) => d ? new Date(d).toLocaleDateString('es-CR', { da
 export default function PartidoNegociacionesPage() {
   const { token, me, loading, error } = useSession();
   const [transfers, setTransfers] = useState<Transfer[]>([]);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
   const [busy, setBusy] = useState<string | null>(null);
   
 
-  const load = (tok: string) => apiFetch(tok, 'GET', '/transfers').then(setTransfers).catch((e: any) => notify.err(e.message));
-  useEffect(() => { if (token) load(token); /* eslint-disable-next-line */ }, [token]);
+  const load = (tok: string, p = page) => apiFetch(tok, 'GET', `/transfers?${paginatedQuery(p, limit)}`)
+    .then((res) => {
+      setTransfers(unwrapPaginated(res));
+      setTotal(paginationMeta(res).total);
+    })
+    .catch((e: any) => notify.err(e.message));
+  useEffect(() => { if (token) load(token, page); /* eslint-disable-next-line */ }, [token, page]);
 
   if (loading || !token || !me) {
     return (
@@ -57,7 +67,7 @@ export default function PartidoNegociacionesPage() {
     try {
       await apiFetch(token, 'PATCH', `/transfers/${id}/${action}`, body);
       notify.ok(action === 'request-return' ? 'Solicitud enviada al TSE' : 'Acción realizada');
-      load(token);
+      load(token, page);
     } catch (e: any) { notify.err(e.message); }
     finally { setBusy(null); }
   }
@@ -160,6 +170,7 @@ export default function PartidoNegociacionesPage() {
             <div className="flex flex-col gap-3 opacity-80">{historial.map((t) => <Card key={t.id} t={t} />)}</div>
           </>
         )}
+        <PaginationControls page={page} limit={limit} total={total} onPageChange={setPage} />
       </div>
     </PartidoShell>
   );

--- a/apps/web/app/partido/reportes/page.tsx
+++ b/apps/web/app/partido/reportes/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { FileText, Send, CheckCircle, AlertCircle, Clock } from 'lucide-react';
 import { PartidoShell } from '../../../components/PartidoShell';
 import { useSession, apiFetch } from '../../../lib/api';
+import { unwrapPaginated } from '../../../lib/pagination';
 
 const fmtDate = (d?: string) => d ? new Date(d).toLocaleString('es-CR', { day: '2-digit', month: 'short', year: 'numeric' }) : ':';
 const fmtCRC = (n?: number | null) => n == null ? 'Sin dato' : new Intl.NumberFormat('es-CR', { style: 'currency', currency: 'CRC', maximumFractionDigits: 0 }).format(n);
@@ -28,7 +29,7 @@ export default function PartidoReportesPage() {
   const load = () =>
     Promise.all([
       apiFetch(token, 'GET', '/reports').then(setReports).catch(() => {}),
-      apiFetch(token, 'GET', '/bonds').then(setBonds).catch(() => {}),
+      apiFetch(token, 'GET', '/bonds?page=1&limit=100').then((res) => setBonds(unwrapPaginated(res))).catch(() => {}),
     ]);
 
   useEffect(() => { if (token) load(); /* eslint-disable-next-line */ }, [token]);

--- a/apps/web/app/partido/trazabilidad/page.tsx
+++ b/apps/web/app/partido/trazabilidad/page.tsx
@@ -3,9 +3,10 @@ import { useEffect, useState } from 'react';
 import { Waypoints, ArrowRight, ExternalLink, User } from 'lucide-react';
 import { PartidoShell } from '../../../components/PartidoShell';
 import { useSession, apiFetch } from '../../../lib/api';
+import { unwrapPaginated } from '../../../lib/pagination';
 import { bondExplorerUrl } from '../../../lib/stellar';
 
-type Bond = { token_id: string; bond_id: string; status: string; face_value: number | null };
+type Bond = { token_id: string; bond_id: string; status: string; face_value: number | null; soroban_contract_id?: string | null };
 type Transfer = {
   id: string; status: string; bond_token_id: string; created_at?: string;
   from_profile?: { full_name?: string }; to_profile?: { full_name?: string };
@@ -31,10 +32,13 @@ export default function PartidoTrazabilidadPage() {
   useEffect(() => {
     if (!token) return;
     Promise.all([
-      apiFetch(token, 'GET', '/bonds').catch(() => []),
-      apiFetch(token, 'GET', '/transfers').catch(() => []),
+      apiFetch(token, 'GET', '/bonds?page=1&limit=100').catch(() => []),
+      apiFetch(token, 'GET', '/transfers?page=1&limit=100').catch(() => []),
     ]).then(([bs, trs]) => {
-      setBonds(bs); setTransfers(trs); if (bs[0]) setSel(bs[0].token_id);
+      const bonds = unwrapPaginated<Bond>(bs);
+      setBonds(bonds);
+      setTransfers(unwrapPaginated<Transfer>(trs));
+      if (bonds[0]) setSel(bonds[0].token_id);
     });
     /* eslint-disable-next-line */
   }, [token]);

--- a/apps/web/app/trazabilidad/page.tsx
+++ b/apps/web/app/trazabilidad/page.tsx
@@ -4,9 +4,10 @@ import { GitBranch, ArrowRight, Boxes } from 'lucide-react';
 import { AppShell } from '../../components/AppShell';
 import { StellarExpertButton, StatusBadge, EmptyState, fmtDate } from '../../components/ui';
 import { apiFetch } from '../../lib/api';
+import { unwrapPaginated } from '../../lib/pagination';
 import { bondExplorerUrl } from '../../lib/stellar';
 
-type Bond = { token_id: string; bond_id: string; status: string };
+type Bond = { token_id: string; bond_id: string; status: string; soroban_contract_id?: string | null };
 type Transfer = { id: string; status: string; bond_token_id: string; created_at?: string; from_profile?: { full_name?: string }; to_profile?: { full_name?: string } };
 
 export default function TrazabilidadPage() {
@@ -20,9 +21,14 @@ function Content({ token }: { token: string }) {
 
   useEffect(() => {
     Promise.all([
-      apiFetch(token, 'GET', '/bonds').catch(() => []),
-      apiFetch(token, 'GET', '/transfers').catch(() => []),
-    ]).then(([b, t]) => { setBonds(b); setTransfers(t); if (b[0]) setSel(b[0].token_id); });
+      apiFetch(token, 'GET', '/bonds?page=1&limit=100').catch(() => []),
+      apiFetch(token, 'GET', '/transfers?page=1&limit=100').catch(() => []),
+    ]).then(([b, t]) => {
+      const bonds = unwrapPaginated<Bond>(b);
+      setBonds(bonds);
+      setTransfers(unwrapPaginated<Transfer>(t));
+      if (bonds[0]) setSel(bonds[0].token_id);
+    });
     /* eslint-disable-next-line */
   }, []);
 

--- a/apps/web/app/tse/TSEPageClient.tsx
+++ b/apps/web/app/tse/TSEPageClient.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { ClipboardCheck, BadgeCheck, Send, Activity, ArrowRight, CheckCircle, Clock } from 'lucide-react';
 import { TSEShell } from '../../components/TSEShell';
 import { useSession, apiFetch } from '../../lib/api';
+import { paginationMeta, unwrapPaginated } from '../../lib/pagination';
 
 const fmtDate = (s?: string) =>
   s ? new Date(s).toLocaleString('es-CR', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' }) : '—';
@@ -24,19 +25,25 @@ const CHIP: Record<string, string> = {
 export default function TSEPageClient() {
   const { token, me, loading, error } = useSession();
   const [bonds, setBonds] = useState<any[]>([]);
+  const [bondsTotal, setBondsTotal] = useState(0);
   const [requests, setRequests] = useState<any[]>([]);
   const [transfers, setTransfers] = useState<any[]>([]);
+  const [transfersTotal, setTransfersTotal] = useState(0);
 
   useEffect(() => {
     if (!token) return;
     Promise.all([
-      apiFetch(token, 'GET', '/bonds').catch(() => null),
+      apiFetch(token, 'GET', '/bonds?page=1&limit=20').catch(() => null),
       apiFetch(token, 'GET', '/bonds/requests').catch(() => null),
-      apiFetch(token, 'GET', '/transfers').catch(() => null),
+      apiFetch(token, 'GET', '/transfers?page=1&limit=20').catch(() => null),
     ]).then(([bs, rqs, trs]) => {
-      setBonds(Array.isArray(bs) ? bs : []);
+      const bondRows = unwrapPaginated(bs ?? []);
+      const transferRows = unwrapPaginated(trs ?? []);
+      setBonds(bondRows);
+      setBondsTotal(paginationMeta(bs, bondRows.length).total);
       setRequests(Array.isArray(rqs) ? rqs : []);
-      setTransfers(Array.isArray(trs) ? trs : []);
+      setTransfers(transferRows);
+      setTransfersTotal(paginationMeta(trs, transferRows.length).total);
     });
   }, [token]); // eslint-disable-line
 
@@ -76,8 +83,8 @@ export default function TSEPageClient() {
           {([
             { label: 'Pendientes de revisión', value: pendientes.length, Icon: ClipboardCheck, bg: 'bg-primary/10', color: 'text-primary', delta: '+6 desde ayer' },
             { label: 'Aprobados', value: aprobados, Icon: BadgeCheck, bg: 'bg-emerald-50', color: 'text-emerald-600', delta: '+18 desde ayer' },
-            { label: 'Bonos emitidos', value: bonds.length, Icon: Send, bg: 'bg-blue-50', color: 'text-blue-500', delta: '+12 desde ayer' },
-            { label: 'Movimientos registrados', value: transfers.length, Icon: Activity, bg: 'bg-teal-50', color: 'text-teal-500', delta: '+27 desde ayer' },
+            { label: 'Bonos emitidos', value: bondsTotal, Icon: Send, bg: 'bg-blue-50', color: 'text-blue-500', delta: '+12 desde ayer' },
+            { label: 'Movimientos registrados', value: transfersTotal, Icon: Activity, bg: 'bg-teal-50', color: 'text-teal-500', delta: '+27 desde ayer' },
           ] as const).map(({ label, value, Icon, bg, color, delta }: any) => (
             <div key={label} className="glass-card flex items-center gap-4 rounded-xl p-5 transition-transform hover:-translate-y-0.5">
               <div className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full ${bg}`}>

--- a/apps/web/app/tse/auditoria/page.tsx
+++ b/apps/web/app/tse/auditoria/page.tsx
@@ -2,7 +2,9 @@
 import { useEffect, useState } from 'react';
 import { CheckCircle, ArrowRightLeft, Send, FileText, Shield } from 'lucide-react';
 import { TSEShell } from '../../../components/TSEShell';
+import { PaginationControls } from '../../../components/PaginationControls';
 import { useSession, apiFetch } from '../../../lib/api';
+import { paginatedQuery, paginationMeta, unwrapPaginated } from '../../../lib/pagination';
 
 const ICON_MAP: Record<string, any> = {
   bond_aprobado: CheckCircle, bond_emitido: Send, transfer: ArrowRightLeft,
@@ -21,12 +23,21 @@ const fmtDate = (s: string) => new Date(s).toLocaleString('es-CR', { day: '2-dig
 export default function AuditoriaPage() {
   const { token, me, loading, error } = useSession();
   const [events, setEvents] = useState<any[]>([]);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
   const [filterType, setFilterType] = useState('');
   const [filterParty, setFilterParty] = useState('');
 
   useEffect(() => {
-    if (token) apiFetch(token, 'GET', '/audit/events').then((ev) => { if (Array.isArray(ev)) setEvents(ev); }).catch(() => {});
-  }, [token]);
+    if (!token) return;
+    apiFetch(token, 'GET', `/audit/events?${paginatedQuery(page, limit)}`)
+      .then((res) => {
+        setEvents(unwrapPaginated(res));
+        setTotal(paginationMeta(res).total);
+      })
+      .catch(() => {});
+  }, [token, page, limit]);
 
   if (loading || !token || !me) {
     return (
@@ -71,7 +82,7 @@ export default function AuditoriaPage() {
             {parties.map((p) => <option key={p} value={p}>{p}</option>)}
           </select>
           {(filterType || filterParty) && (
-            <button onClick={() => { setFilterType(''); setFilterParty(''); }} className="rounded-xl border border-outline-variant/40 px-3 py-1.5 text-xs font-medium text-on-surface-variant hover:bg-surface-container-low">
+            <button onClick={() => { setFilterType(''); setFilterParty(''); setPage(1); }} className="rounded-xl border border-outline-variant/40 px-3 py-1.5 text-xs font-medium text-on-surface-variant hover:bg-surface-container-low">
               Limpiar filtros
             </button>
           )}
@@ -79,7 +90,7 @@ export default function AuditoriaPage() {
 
         <div className="glass-card overflow-hidden rounded-2xl">
           <div className="border-b border-surface-variant/30 bg-surface-container-low/40 px-6 py-3 text-[11px] font-semibold uppercase tracking-wide text-on-surface-variant">
-            {filtered.length} evento{filtered.length !== 1 ? 's' : ''}
+            {filtered.length} evento{filtered.length !== 1 ? 's' : ''} en esta página · {total} en total
           </div>
           <div className="divide-y divide-surface-variant/20">
             {filtered.map((ev) => {
@@ -111,6 +122,7 @@ export default function AuditoriaPage() {
             })}
             {filtered.length === 0 && <p className="py-10 text-center text-sm text-on-surface-variant">Sin eventos registrados.</p>}
           </div>
+          <PaginationControls page={page} limit={limit} total={total} onPageChange={setPage} />
         </div>
       </div>
     </TSEShell>

--- a/apps/web/app/tse/escrows/page.tsx
+++ b/apps/web/app/tse/escrows/page.tsx
@@ -2,7 +2,9 @@
 import { useEffect, useState } from 'react';
 import { Shield, ExternalLink, ArrowRight, CheckCircle, Clock } from 'lucide-react';
 import { TSEShell } from '../../../components/TSEShell';
+import { PaginationControls } from '../../../components/PaginationControls';
 import { useSession, apiFetch } from '../../../lib/api';
+import { paginatedQuery, paginationMeta, unwrapPaginated } from '../../../lib/pagination';
 
 const fmtCRC = (n: number | null) => n == null ? 'Sin dato' : new Intl.NumberFormat('es-CR', { style: 'currency', currency: 'CRC', maximumFractionDigits: 0 }).format(n);
 const fmtDate = (d?: string) => d ? new Date(d).toLocaleString('es-CR', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' }) : ':';
@@ -19,13 +21,21 @@ const STATUS_LBL: Record<string, [string, string, any]> = {
 export default function EscrowsPage() {
   const { token, me, loading, error } = useSession();
   const [transfers, setTransfers] = useState<any[]>([]);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
   const [tab, setTab] = useState<'all' | 'with' | 'without'>('all');
   const [statusFilter, setStatusFilter] = useState<string>('');
 
   useEffect(() => {
     if (!token) return;
-    apiFetch(token, 'GET', '/transfers').then(setTransfers).catch(() => {});
-  }, [token]);
+    apiFetch(token, 'GET', `/transfers?${paginatedQuery(page, limit)}`)
+      .then((res) => {
+        setTransfers(unwrapPaginated(res));
+        setTotal(paginationMeta(res).total);
+      })
+      .catch(() => {});
+  }, [token, page, limit]);
 
   if (loading || !token || !me) {
     return (
@@ -57,7 +67,7 @@ export default function EscrowsPage() {
           <p className="text-sm text-on-surface-variant">
             <span className="font-semibold text-amber-700">{enCanasta.length}</span> token{enCanasta.length !== 1 ? 's' : ''} en canasta ahora
             · <span className="font-semibold text-emerald-700">{withEscrow.length}</span> con Trustless Work
-            · <span className="text-on-surface-variant">{transfers.length}</span> totales
+            · <span className="text-on-surface-variant">{total}</span> totales
           </p>
         </div>
       </header>
@@ -85,7 +95,7 @@ export default function EscrowsPage() {
         <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
           <div className="inline-flex overflow-hidden rounded-xl border border-outline-variant/40 bg-white">
             {([
-              ['all',     'Todas',          transfers.length],
+              ['all',     'Todas',          total],
               ['with',    'En canasta',     enCanasta.length],
               ['without', 'Cerradas',       liberadas.length + canceladas.length],
             ] as const).map(([key, label, count]) => (
@@ -125,6 +135,7 @@ export default function EscrowsPage() {
             </p>
           </div>
         ) : (
+          <>
           <div className="flex flex-col gap-3">
             {list.map((t) => {
               const [cls, lbl, Icon] = STATUS_LBL[t.status] ?? ['bg-gray-100 text-gray-600 border-gray-200', t.status, Clock];
@@ -179,7 +190,9 @@ export default function EscrowsPage() {
               );
             })}
           </div>
+          </>
         )}
+        <PaginationControls page={page} limit={limit} total={total} onPageChange={setPage} />
       </div>
     </TSEShell>
   );

--- a/apps/web/app/tse/registros/page.tsx
+++ b/apps/web/app/tse/registros/page.tsx
@@ -4,7 +4,9 @@ import { useEffect, useState, Fragment } from 'react';
 import { Filter, Search, ExternalLink, ChevronDown, ChevronUp, FileCheck, Link2 } from 'lucide-react';
 import Link from 'next/link';
 import { TSEShell } from '../../../components/TSEShell';
+import { PaginationControls } from '../../../components/PaginationControls';
 import { useSession, apiFetch } from '../../../lib/api';
+import { paginatedQuery, paginationMeta, unwrapPaginated } from '../../../lib/pagination';
 import { bondExplorerUrl } from '../../../lib/stellar';
 
 type Bond = {
@@ -34,6 +36,10 @@ const shortContract = (id?: string | null) => id ? `${id.slice(0, 2)}…${id.sli
 export default function RegistrosPage() {
   const { token, me, loading, error } = useSession();
   const [bonds, setBonds] = useState<Bond[]>([]);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
+  const [partyOptions, setPartyOptions] = useState<string[]>([]);
   const [expanded, setExpanded] = useState<string | null>(null);
   const [busyOnchain, setBusyOnchain] = useState<string | null>(null);
   
@@ -47,12 +53,21 @@ export default function RegistrosPage() {
   const [sortBy, setSortBy] = useState<'date' | 'amount'>('date');
   const [sortAsc, setSortAsc] = useState(false);
 
-  const load = (tok: string) =>
-    apiFetch(tok, 'GET', '/bonds').then((bs) => {
-      setBonds(Array.isArray(bs) ? bs : []);
-    }).catch(() => setBonds([]));
+  const load = (tok: string, p = page) =>
+    apiFetch(tok, 'GET', `/bonds?${paginatedQuery(p, limit)}`)
+      .then((res) => {
+        setBonds(unwrapPaginated(res));
+        setTotal(paginationMeta(res).total);
+      })
+      .catch(() => { setBonds([]); setTotal(0); });
 
-  useEffect(() => { if (token) load(token); }, [token]); // eslint-disable-line
+  useEffect(() => { if (token) load(token, page); }, [token, page]); // eslint-disable-line
+  useEffect(() => {
+    if (!token) return;
+    apiFetch(token, 'GET', '/parties')
+      .then((rows) => setPartyOptions((Array.isArray(rows) ? rows : []).map((p: { name?: string }) => p.name).filter(Boolean)))
+      .catch(() => {});
+  }, [token]);
 
   async function issueOnchain(tokenId: string) {
     if (!token) return;
@@ -60,7 +75,7 @@ export default function RegistrosPage() {
     try {
       const res = await apiFetch(token, 'PATCH', `/bonds/${tokenId}/issue-onchain`);
       notify.ok(`Token emitido on-chain. TX: ${res.txHash ?? 'ok'}`);
-      load(token);
+      load(token, page);
     } catch (e: any) { notify.err(e.message); } finally { setBusyOnchain(null); }
   }
 
@@ -72,7 +87,7 @@ export default function RegistrosPage() {
     );
   }
 
-  const parties = Array.from(new Set(bonds.map((b) => b.parties?.name).filter(Boolean))) as string[];
+  const parties = partyOptions;
 
   const filtered = bonds
     .filter((b) => {
@@ -106,7 +121,7 @@ export default function RegistrosPage() {
       <header className="sticky top-0 z-30 flex h-20 items-center justify-between border-b border-surface-variant/40 bg-[#FAFCFF]/85 px-8 backdrop-blur-md">
         <div>
           <h1 className="text-2xl font-bold" style={{ fontFamily: 'Geist' }}>Registros de bonos</h1>
-          <p className="text-sm text-on-surface-variant">{filtered.length} de {bonds.length} bonos</p>
+          <p className="text-sm text-on-surface-variant">{filtered.length} en esta página · {total} bonos en total</p>
         </div>
       </header>
 
@@ -250,6 +265,7 @@ export default function RegistrosPage() {
             </tbody>
           </table>
           </div>
+          <PaginationControls page={page} limit={limit} total={total} onPageChange={setPage} />
         </div>
       </div>
     </TSEShell>

--- a/apps/web/app/tse/reportes/page.tsx
+++ b/apps/web/app/tse/reportes/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { CheckCircle, AlertCircle, Eye, X, ExternalLink, User, Waypoints, Coins } from 'lucide-react';
 import { TSEShell } from '../../../components/TSEShell';
 import { useSession, apiFetch } from '../../../lib/api';
+import { unwrapPaginated } from '../../../lib/pagination';
 import { bondExplorerUrl } from '../../../lib/stellar';
 
 const fmtDate = (d?: string) => d ? new Date(d).toLocaleString('es-CR', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' }) : '—';
@@ -30,8 +31,8 @@ export default function TSEReportesPage() {
   const load = () =>
     Promise.all([
       apiFetch(token, 'GET', '/reports').then(setReports).catch(() => {}),
-      apiFetch(token, 'GET', '/bonds').then(setAllBonds).catch(() => {}),
-      apiFetch(token, 'GET', '/transfers').then(setAllTransfers).catch(() => {}),
+      apiFetch(token, 'GET', '/bonds?page=1&limit=100').then((res) => setAllBonds(unwrapPaginated(res))).catch(() => {}),
+      apiFetch(token, 'GET', '/transfers?page=1&limit=100').then((res) => setAllTransfers(unwrapPaginated(res))).catch(() => {}),
     ]);
 
   useEffect(() => { if (token) load(); /* eslint-disable-next-line */ }, [token]);

--- a/apps/web/app/tse/retiros/page.tsx
+++ b/apps/web/app/tse/retiros/page.tsx
@@ -3,7 +3,9 @@ import { notify } from '../../../components/Toast';
 import { useEffect, useState } from 'react';
 import { ArrowRight, AlertTriangle, CheckCircle, XCircle, Shield } from 'lucide-react';
 import { TSEShell } from '../../../components/TSEShell';
+import { PaginationControls } from '../../../components/PaginationControls';
 import { useSession, apiFetch } from '../../../lib/api';
+import { paginatedQuery, paginationMeta, unwrapPaginated } from '../../../lib/pagination';
 
 const fmtCRC = (n: number | null) => n == null ? 'Sin dato' : new Intl.NumberFormat('es-CR', { style: 'currency', currency: 'CRC', maximumFractionDigits: 0 }).format(n);
 const fmtDate = (d?: string) => d ? new Date(d).toLocaleString('es-CR', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' }) : ':';
@@ -11,12 +13,20 @@ const fmtDate = (d?: string) => d ? new Date(d).toLocaleString('es-CR', { day: '
 export default function RetirosPage() {
   const { token, me, loading, error } = useSession();
   const [transfers, setTransfers] = useState<any[]>([]);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
   const [busy, setBusy] = useState<string | null>(null);
   
   const [notes, setNotes] = useState<Record<string, string>>({});
 
-  const load = () => apiFetch(token, 'GET', '/transfers').then(setTransfers).catch(() => {});
-  useEffect(() => { if (token) load(); /* eslint-disable-next-line */ }, [token]);
+  const load = (p = page) => apiFetch(token, 'GET', `/transfers?${paginatedQuery(p, limit)}`)
+    .then((res) => {
+      setTransfers(unwrapPaginated(res));
+      setTotal(paginationMeta(res).total);
+    })
+    .catch(() => {});
+  useEffect(() => { if (token) load(page); /* eslint-disable-next-line */ }, [token, page]);
 
   if (loading || !token || !me) {
     return (
@@ -31,7 +41,7 @@ export default function RetirosPage() {
     try {
       await apiFetch(token, 'PATCH', `/transfers/${id}/${action}`, { notes: notes[id] });
       notify.ok(action === 'approve-return' ? 'Bono devuelto al dueño on-chain' : 'Solicitud rechazada');
-      load();
+      load(page);
     } catch (e: any) { notify.err(e.message); }
     finally { setBusy(null); }
   }
@@ -145,6 +155,7 @@ export default function RetirosPage() {
             </div>
           </>
         )}
+        <PaginationControls page={page} limit={limit} total={total} onPageChange={setPage} />
       </div>
     </TSEShell>
   );

--- a/apps/web/app/tse/trazabilidad/page.tsx
+++ b/apps/web/app/tse/trazabilidad/page.tsx
@@ -6,6 +6,7 @@ import { ArrowRight, ExternalLink, User, Clock, CheckCircle } from 'lucide-react
 import Link from 'next/link';
 import { TSEShell } from '../../../components/TSEShell';
 import { useSession, apiFetch } from '../../../lib/api';
+import { unwrapPaginated } from '../../../lib/pagination';
 import { bondExplorerUrl } from '../../../lib/stellar';
 
 const fmtDate = (s?: string) => s ? new Date(s).toLocaleString('es-CR', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit' }) : '—';
@@ -34,11 +35,11 @@ function TrazabilidadContent({ token, me }: { token: string; me: any }) {
 
   useEffect(() => {
     Promise.all([
-      apiFetch(token, 'GET', '/bonds').catch(() => null),
-      apiFetch(token, 'GET', '/transfers').catch(() => null),
+      apiFetch(token, 'GET', '/bonds?page=1&limit=100').catch(() => null),
+      apiFetch(token, 'GET', '/transfers?page=1&limit=100').catch(() => null),
     ]).then(([bs, trs]) => {
-      const b = Array.isArray(bs) ? bs : [];
-      const t = Array.isArray(trs) ? trs : [];
+      const b = unwrapPaginated<any>(bs ?? []);
+      const t = unwrapPaginated<any>(trs ?? []);
       setBonds(b); setTransfers(t);
       const init = initialBono ? b.find((x: any) => x.bond_id === initialBono)?.token_id : b[0]?.token_id;
       setSel(init ?? b[0]?.token_id ?? '');

--- a/apps/web/components/AppShell.tsx
+++ b/apps/web/components/AppShell.tsx
@@ -61,8 +61,8 @@ export function AppShell({ children }: { children: (ctx: { token: string; me: Me
         {/* Tabs */}
         <nav className="border-t border-outline-variant/20 bg-white/50">
           <div className="mx-auto flex h-12 max-w-[1440px] items-center gap-1 overflow-x-auto px-2 md:justify-center md:gap-6 md:px-8">
-            {TABS.map(({ href, label, Icon, exact }) => {
-              const active = exact ? pathname === href : (pathname === href || pathname.startsWith(href + '/'));
+            {TABS.map(({ href, label, Icon }) => {
+              const active = pathname === href || pathname.startsWith(`${href}/`);
               return (
                 <Link key={href} href={href} className={`flex h-full shrink-0 items-center gap-2 border-b-2 px-3 pb-[2px] text-sm transition-colors ${active ? 'border-primary-container font-bold text-primary-container' : 'border-transparent font-medium text-on-surface-variant hover:text-primary-container'}`}>
                   <Icon size={18} /> {label}

--- a/apps/web/components/PaginationControls.tsx
+++ b/apps/web/components/PaginationControls.tsx
@@ -1,0 +1,40 @@
+import { paginationLabel } from '../lib/pagination';
+
+type Props = {
+  page: number;
+  limit: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  disabled?: boolean;
+};
+
+export function PaginationControls({ page, limit, total, onPageChange, disabled }: Props) {
+  const totalPages = Math.max(1, Math.ceil(total / limit) || 1);
+  const canPrev = page > 1;
+  const canNext = page < totalPages;
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-surface-variant/30 px-4 py-3 text-sm">
+      <p className="text-xs text-on-surface-variant">{paginationLabel(page, limit, total)}</p>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          disabled={disabled || !canPrev}
+          onClick={() => onPageChange(page - 1)}
+          className="rounded-lg border border-outline-variant/40 px-3 py-1.5 text-xs font-semibold text-on-surface-variant transition hover:bg-surface-container-low disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Anterior
+        </button>
+        <span className="text-xs text-on-surface-variant">Página {page} de {totalPages}</span>
+        <button
+          type="button"
+          disabled={disabled || !canNext}
+          onClick={() => onPageChange(page + 1)}
+          className="rounded-lg border border-outline-variant/40 px-3 py-1.5 text-xs font-semibold text-on-surface-variant transition hover:bg-surface-container-low disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Siguiente
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/pagination.ts
+++ b/apps/web/lib/pagination.ts
@@ -1,0 +1,47 @@
+import { PaginatedResponse } from '@velar/types';
+
+export const DEFAULT_PAGE = 1;
+export const DEFAULT_LIMIT = 20;
+
+export function paginatedQuery(page = DEFAULT_PAGE, limit = DEFAULT_LIMIT) {
+  const p = Math.max(1, page);
+  const l = Math.max(1, limit);
+  return `page=${p}&limit=${l}`;
+}
+
+export function isPaginated<T>(value: unknown): value is PaginatedResponse<T> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    Array.isArray((value as PaginatedResponse<T>).data) &&
+    typeof (value as PaginatedResponse<T>).total === 'number'
+  );
+}
+
+export function unwrapPaginated<T>(value: T[] | PaginatedResponse<T> | unknown): T[] {
+  if (isPaginated<T>(value)) return value.data;
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+export function paginationMeta(value: unknown, fallbackLength = 0) {
+  if (isPaginated(value)) {
+    return { page: value.page, limit: value.limit, total: value.total };
+  }
+  const total = fallbackLength;
+  return { page: DEFAULT_PAGE, limit: total || DEFAULT_LIMIT, total };
+}
+
+export function paginationLabel(page: number, limit: number, total: number) {
+  if (total === 0) return 'Mostrando 0 de 0';
+  const start = (page - 1) * limit + 1;
+  const end = Math.min(page * limit, total);
+  return `Mostrando ${start}–${end} de ${total}`;
+}
+
+export function hasNextPage(page: number, limit: number, total: number) {
+  return page * limit < total;
+}
+
+export function hasPrevPage(page: number) {
+  return page > 1;
+}

--- a/packages/types/src/api.ts
+++ b/packages/types/src/api.ts
@@ -1,3 +1,10 @@
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
 export interface ApiResponse<T> {
   data: T;
   message: string;

--- a/packages/types/types/api.d.ts
+++ b/packages/types/types/api.d.ts
@@ -1,3 +1,9 @@
+export interface PaginatedResponse<T> {
+    data: T[];
+    total: number;
+    page: number;
+    limit: number;
+}
 export interface ApiResponse<T> {
     data: T;
     message: string;


### PR DESCRIPTION
## Summary

- Agrega \PaginatedResponse<T>\ en \@velar/types\ con forma \{ data, total, page, limit }\.
- Pagina \GET /bonds\, \GET /transfers\ y \GET /audit/events\ con \?page=1&limit=20\ (defaults) usando Supabase \.range()\.
- Nuevo componente \PaginationControls\ y helpers en \lib/pagination.ts\.
- Tablas principales (registros, auditoria, escrows, retiros, historial, mis-bonos, negociaciones) muestran Anterior/Siguiente y etiqueta **Mostrando X–Y de Z**.
- Resto de consumidores actualizados para leer \.data\ / \.total\.

Closes #7

## Test plan

- [x] \
pm run build --workspace packages/types\`n- [x] \
pm run build --workspace apps/api\`n- [x] \
pm run test --workspace apps/api\ (5 tests, incluye \pagination.spec.ts\)
- [x] TypeScript de \pps/web\ pasa (\
ext build\ falla en prerender por falta de env Supabase local, preexistente)
- [ ] \GET /api/bonds?page=2&limit=5\ devuelve slice correcto y \	otal\ del conteo completo
- [ ] Verificar controles Anterior/Siguiente en \/tse/registros\, \/tse/auditoria\, \/tse/escrows\`n- [ ] Confirmar que filtros/orden local en registros siguen funcionando sobre la pagina visible

## Notas

- Se corrigen imports rotos de \Toast\ en paginas de partido tocadas por este PR.
- Dashboards y trazabilidad usan \limit=100\ donde necesitan mas contexto sin paginar toda la UI.

Made with [Cursor](https://cursor.com)