### PR TITLE
Add request throttling and login endpoint

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -18,6 +18,8 @@ STELLAR_ENABLE_FRIENDBOT=true
 # Server
 PORT=3001
 WEB_URL=http://localhost:3000
+THROTTLE_TTL=60000
+THROTTLE_LIMIT=100
 
 # NOTA: para el escrow on-chain (custodia asistida en testnet) corré:
 #   npm run provision:wallets

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -29,6 +29,7 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/throttler": "^6.5.0",
     "@stellar/stellar-sdk": "^15.1.0",
     "@supabase/supabase-js": "^2.49.8",
     "@velar/types": "*",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { APP_GUARD } from '@nestjs/core';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { AppController } from './app.controller';
 import { SupabaseModule } from './common/supabase/supabase.module';
 import { AuthModule } from './auth/auth.module';
@@ -14,9 +16,24 @@ import { ReportsModule } from './reports/reports.module';
 import { ExplorerModule } from './explorer/explorer.module';
 import { NotificationsModule } from './notifications/notifications.module';
 
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    ThrottlerModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => [
+        {
+          ttl: parsePositiveInt(config.get<string>('THROTTLE_TTL'), 60000),
+          limit: parsePositiveInt(config.get<string>('THROTTLE_LIMIT'), 100),
+        },
+      ],
+    }),
     SupabaseModule,
     AuthModule,
     BondsModule,
@@ -31,5 +48,11 @@ import { NotificationsModule } from './notifications/notifications.module';
     NotificationsModule,
   ],
   controllers: [AppController],
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class AppModule {}

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Post } from '@nestjs/common';
-import { AuthService, RegisterInput } from './auth.service';
+import { Throttle } from '@nestjs/throttler';
+import { AuthService, LoginInput, RegisterInput } from './auth.service';
 
 @Controller('auth')
 export class AuthController {
@@ -9,5 +10,11 @@ export class AuthController {
   @Post('register')
   register(@Body() body: RegisterInput) {
     return this.auth.register(body);
+  }
+
+  @Post('login')
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  login(@Body() body: LoginInput) {
+    return this.auth.login(body);
   }
 }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, BadRequestException, Logger } from '@nestjs/common';
+import { Injectable, BadRequestException, Logger, UnauthorizedException } from '@nestjs/common';
 import { SupabaseService } from '../common/supabase/supabase.service';
 import { WalletService } from '../escrow/wallet.service';
 
@@ -21,6 +21,11 @@ export interface RegisterInput {
   cedulaJuridica?: string;
 }
 
+export interface LoginInput {
+  email: string;
+  password: string;
+}
+
 /**
  * Registro de cuentas con las 3 perspectivas:
  *  - usuario  -> rol 'comprador' (comprador = recomprador = usuario)
@@ -38,6 +43,29 @@ export class AuthService {
     private supabase: SupabaseService,
     private wallets: WalletService,
   ) {}
+
+  async login(input: LoginInput) {
+    if (!input.email || !input.password) {
+      throw new BadRequestException('email y password son obligatorios');
+    }
+
+    const { data, error } = await this.supabase.admin.auth.signInWithPassword({
+      email: input.email,
+      password: input.password,
+    });
+
+    if (error || !data.session) {
+      throw new UnauthorizedException(error?.message ?? 'Credenciales inválidas');
+    }
+
+    return {
+      access_token: data.session.access_token,
+      refresh_token: data.session.refresh_token,
+      expires_in: data.session.expires_in,
+      token_type: data.session.token_type,
+      user: data.user,
+    };
+  }
 
   async register(input: RegisterInput) {
     if (!input.email || !input.password) {

--- a/apps/api/src/bonds/bonds.controller.ts
+++ b/apps/api/src/bonds/bonds.controller.ts
@@ -3,6 +3,7 @@ import {
   UseInterceptors, UploadedFile, Res,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { Throttle } from '@nestjs/throttler';
 import { Response } from 'express';
 import { BondsService } from './bonds.service';
 import { AuthGuard } from '../auth/auth.guard';
@@ -15,6 +16,7 @@ export class BondsController {
   constructor(private bonds: BondsService) {}
 
   @Post()
+  @Throttle({ default: { limit: 20, ttl: 60000 } })
   register(@Body() body: RegisterBondInput, @CurrentUser() user: any) {
     return this.bonds.register(body, user.id, user.profile?.role as Role);
   }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -10,10 +10,12 @@ if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
 
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  app.set('trust proxy', 1);
 
   app.enableCors({
     origin: process.env.WEB_URL ?? 'http://localhost:3000',

--- a/apps/api/test/rate-limit.e2e-spec.ts
+++ b/apps/api/test/rate-limit.e2e-spec.ts
@@ -1,0 +1,82 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+import { SupabaseService } from './../src/common/supabase/supabase.service';
+
+describe('Rate limiting (e2e)', () => {
+  let app: INestApplication;
+
+  async function createApp(): Promise<INestApplication> {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(SupabaseService)
+      .useValue({
+        getUser: jest.fn(),
+        admin: {
+          auth: {
+            signInWithPassword: jest.fn().mockResolvedValue({
+              data: { session: null, user: null },
+              error: { message: 'Invalid login credentials' },
+            }),
+          },
+          from: jest.fn(),
+        },
+      })
+      .compile();
+
+    const nestApp = moduleFixture.createNestApplication<NestExpressApplication>();
+    nestApp.set('trust proxy', 1);
+    nestApp.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    nestApp.setGlobalPrefix('api');
+    await nestApp.init();
+
+    return nestApp;
+  }
+
+  beforeEach(async () => {
+    app = await createApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('allows normal requests to the default endpoint', async () => {
+    await request(app.getHttpServer()).get('/api').expect(200);
+  });
+
+  it('blocks the 101st request to a default endpoint and returns Retry-After', async () => {
+    for (let i = 0; i < 100; i += 1) {
+      await request(app.getHttpServer()).get('/api').expect(200);
+    }
+
+    const response = await request(app.getHttpServer()).get('/api').expect(429);
+    expect(response.headers['retry-after']).toBeDefined();
+  });
+
+  it('blocks the 21st unauthenticated POST /bonds request before auth handling', async () => {
+    for (let i = 0; i < 20; i += 1) {
+      await request(app.getHttpServer()).post('/api/bonds').send({}).expect(401);
+    }
+
+    const response = await request(app.getHttpServer()).post('/api/bonds').send({}).expect(429);
+    expect(response.headers['retry-after']).toBeDefined();
+  });
+
+  it('blocks the 11th POST /auth/login request', async () => {
+    const credentials = {
+      email: 'missing@example.com',
+      password: 'wrong-password',
+    };
+
+    for (let i = 0; i < 10; i += 1) {
+      await request(app.getHttpServer()).post('/api/auth/login').send(credentials).expect(401);
+    }
+
+    const response = await request(app.getHttpServer()).post('/api/auth/login').send(credentials).expect(429);
+    expect(response.headers['retry-after']).toBeDefined();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/throttler": "^6.5.0",
         "@stellar/stellar-sdk": "^15.1.0",
         "@supabase/supabase-js": "^2.49.8",
         "@velar/types": "*",
@@ -3304,6 +3305,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@next/eslint-plugin-next": {


### PR DESCRIPTION
### Adds NestJS API rate limiting with `@nestjs/throttler.`
Configures a global default limit of `100 req / 60s` per IP, configurable through`THROTTLE_TTL` and `THROTTLE_LIMIT`.
Adds stricter limits for sensitive endpoints: `POST /auth/login` is limited to `10 req / 60s`, and `POST /bonds` is limited to `20 req / 60s.`
Adds `POST /auth/login` backed by Supabase Auth so the login route can be protected directly.
Ensures abusive callers receive `429 Too Many Requests` with a `Retry-After` header.
Documents `THROTTLE_TTL` and `THROTTLE_LIMIT` in `apps/api/.env.example.`

Closes issue #6 

Test plan
`npm run build -w apps/api` passes without errors.
`npm run test:e2e -w apps/api -- rate-limit.e2e-spec.ts --runInBand` passes with 4 tests, covering:

- default endpoint blocked on request 101
- `POST /auth/login` blocked on request 11
- `POST /bonds` blocked on request 21
- `429` responses include `Retry-After`

Notes
The full e2e suite has pre-existing unrelated failures in `app.e2e-spec.ts` and `bonds-flow.e2e-spec.ts`; those were not introduced by this change.