### PR TITLE
[backend] Role-Based Access Control (RBAC) Guard

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
 import { ReportsModule } from './reports/reports.module';
 import { ExplorerModule } from './explorer/explorer.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { RolesGuard } from './auth/roles.guard';
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   const parsed = Number(value);
@@ -49,10 +50,8 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
   ],
   controllers: [AppController],
   providers: [
-    {
-      provide: APP_GUARD,
-      useClass: ThrottlerGuard,
-    },
+    { provide: APP_GUARD, useClass: ThrottlerGuard },
+    { provide: APP_GUARD, useClass: RolesGuard },
   ],
 })
 export class AppModule {}

--- a/apps/api/src/auth/roles.decorator.ts
+++ b/apps/api/src/auth/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '@velar/types';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/apps/api/src/auth/roles.guard.ts
+++ b/apps/api/src/auth/roles.guard.ts
@@ -1,0 +1,24 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Role } from '@velar/types';
+import { ROLES_KEY } from './roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(ctx: ExecutionContext): boolean {
+    const required = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      ctx.getHandler(),
+      ctx.getClass(),
+    ]);
+    if (!required || required.length === 0) return true;
+
+    const { user } = ctx.switchToHttp().getRequest();
+    const role: Role | undefined = user?.profile?.role;
+    if (!role || !required.includes(role)) {
+      throw new ForbiddenException('No tenés permiso para esta acción');
+    }
+    return true;
+  }
+}

--- a/apps/api/src/bonds/bonds.controller.ts
+++ b/apps/api/src/bonds/bonds.controller.ts
@@ -8,6 +8,7 @@ import { Response } from 'express';
 import { BondsService } from './bonds.service';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
+import { Roles } from '../auth/roles.decorator';
 import { RegisterBondInput, BondRequestInput, Role } from '@velar/types';
 
 @Controller('bonds')
@@ -17,6 +18,7 @@ export class BondsController {
 
   @Post()
   @Throttle({ default: { limit: 20, ttl: 60000 } })
+  @Roles('tse', 'admin')
   register(@Body() body: RegisterBondInput, @CurrentUser() user: any) {
     return this.bonds.register(body, user.id, user.profile?.role as Role);
   }
@@ -43,11 +45,13 @@ export class BondsController {
   }
 
   @Patch('requests/:id/approve')
+  @Roles('tse', 'admin')
   approveRequest(@Param('id') id: string, @CurrentUser() user: any) {
     return this.bonds.approveRequest(id, user.id, user.profile?.role as Role);
   }
 
   @Patch('requests/:id/reject')
+  @Roles('tse', 'admin')
   rejectRequest(@Param('id') id: string, @Body() body: { reason?: string }, @CurrentUser() user: any) {
     return this.bonds.rejectRequest(id, body.reason ?? '', user.id, user.profile?.role as Role);
   }
@@ -68,6 +72,7 @@ export class BondsController {
   }
 
   @Patch(':tokenId/issue-onchain')
+  @Roles('tse', 'admin')
   issueOnchain(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
     return this.bonds.issueOnchain(tokenId, user.id, user.profile?.role as Role);
   }
@@ -77,24 +82,25 @@ export class BondsController {
     return this.bonds.publish(tokenId, user.id);
   }
 
-  /** Lee el contrato Soroban del bono directamente de la cadena y lo devuelve legible. */
   @Get(':tokenId/soroban-details')
   sorobanDetails(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
     return this.bonds.readSorobanDetails(tokenId, user.id, user.profile?.role as Role);
   }
 
   @Patch(':tokenId/freeze')
+  @Roles('tse', 'admin')
   freeze(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
     return this.bonds.freeze(tokenId, user.id, user.profile?.role as Role);
   }
 
   @Patch(':tokenId/unfreeze')
+  @Roles('tse', 'admin')
   unfreeze(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
     return this.bonds.unfreeze(tokenId, user.id, user.profile?.role as Role);
   }
 
-  /** Sube el certificado PDF del bono y almacena su SHA-256 on-chain. Solo TSE. */
   @Post(':tokenId/document')
+  @Roles('tse', 'admin')
   @UseInterceptors(FileInterceptor('file'))
   uploadDocument(
     @Param('tokenId') tokenId: string,
@@ -104,7 +110,6 @@ export class BondsController {
     return this.bonds.uploadDocument(tokenId, file, user.id, user.profile?.role as Role);
   }
 
-  /** Descarga el certificado PDF. Solo el dueño actual del bono o TSE/admin. */
   @Get(':tokenId/document')
   async downloadDocument(
     @Param('tokenId') tokenId: string,

--- a/apps/api/src/bonds/bonds.service.ts
+++ b/apps/api/src/bonds/bonds.service.ts
@@ -218,10 +218,6 @@ export class BondsService {
   }
 
   async register(input: RegisterBondInput, actorId: string, actorRole: Role) {
-    // Solo el TSE (autoridad) emite bonos, a nombre de un partido.
-    if (!AUTHORITY.includes(actorRole)) {
-      throw new ForbiddenException('Solo el TSE puede emitir bonos');
-    }
     // El bono se emite A NOMBRE de un partido: dueño inicial = la cuenta del partido.
     const party = await this.partyOwner(input.issuerPartyId);
     if (!party) {
@@ -349,10 +345,6 @@ export class BondsService {
   /** TSE aprueba una solicitud  a  crea el bono con los datos del partido. */
   async approveRequest(requestId: string, actorId: string, actorRole: Role) {
     this.logger.log(`approveRequest: actorId=${actorId} actorRole=${JSON.stringify(actorRole)}`);
-    // Normaliza por si el role viene con mayúsculas o espacios desde la BD
-    const roleNorm = (actorRole as string)?.trim().toLowerCase() as Role;
-    if (!AUTHORITY.includes(roleNorm)) throw new ForbiddenException(`Solo el TSE puede aprobar solicitudes (rol actual: ${actorRole})`);
-
     const { data: req, error: reqErr } = await this.supabase.admin
       .from('bond_requests').select('*, parties(*)').eq('id', requestId).single();
     if (reqErr || !req) throw new NotFoundException('Solicitud no encontrada');
@@ -437,8 +429,6 @@ export class BondsService {
 
   /** TSE rechaza una solicitud. */
   async rejectRequest(requestId: string, reason: string, actorId: string, actorRole: Role) {
-    const roleNorm = (actorRole as string)?.trim().toLowerCase() as Role;
-    if (!AUTHORITY.includes(roleNorm)) throw new ForbiddenException(`Solo el TSE puede rechazar solicitudes (rol actual: ${actorRole})`);
     const { data: req, error: findError } = await this.supabase.admin
       .from('bond_requests')
       .select('id, bond_token_id, requested_by')
@@ -494,9 +484,6 @@ export class BondsService {
 
   /** Re-emite el token on-chain para un bono que existe en BD pero no en Stellar. */
   async issueOnchain(tokenId: string, actorId: string, actorRole: Role) {
-    if (!AUTHORITY.includes((actorRole as string)?.trim().toLowerCase() as Role)) {
-      throw new ForbiddenException('Solo el TSE puede emitir on-chain');
-    }
     const { data: bond } = await this.supabase.admin
       .from('bonds').select('*, profiles!bonds_current_owner_fkey(id, stellar_wallet)').eq('token_id', tokenId).single();
     if (!bond) throw new NotFoundException('Bono no encontrado');
@@ -659,7 +646,6 @@ export class BondsService {
   }
 
   async freeze(tokenId: string, actorId: string, actorRole: Role) {
-    if (!['tse', 'admin'].includes(actorRole)) throw new ForbiddenException('TSE/Admin only');
     const { data, error } = await this.supabase.admin
       .from('bonds').update({ status: BondStatus.CONGELADO }).eq('token_id', tokenId).select().single();
     if (error) throw new BadRequestException(error.message);
@@ -668,7 +654,6 @@ export class BondsService {
   }
 
   async unfreeze(tokenId: string, actorId: string, actorRole: Role) {
-    if (!['tse', 'admin'].includes(actorRole)) throw new ForbiddenException('TSE/Admin only');
     const { data, error } = await this.supabase.admin
       .from('bonds').update({ status: BondStatus.ACTIVO }).eq('token_id', tokenId).select().single();
     if (error) throw new BadRequestException(error.message);


### PR DESCRIPTION
## Summary

Closes #25

Implements a `@Roles()` decorator and `RolesGuard` for NestJS so route-level role restrictions are declared at the controller layer — no more manual `ForbiddenException` checks scattered across service methods.

## Changes

- `apps/api/src/auth/roles.decorator.ts` — `@Roles(...roles)` decorator using `SetMetadata`
- `apps/api/src/auth/roles.guard.ts` — `RolesGuard` reads route metadata via `Reflector`, rejects with 403 if role does not match
- `apps/api/src/app.module.ts` — registers `RolesGuard` globally via `APP_GUARD`
- `apps/api/src/bonds/bonds.controller.ts` — annotates `POST /bonds`, approve/reject requests, `issue-onchain`, `freeze`, `unfreeze` with `@Roles("tse", "admin")`
- `apps/api/src/bonds/bonds.service.ts` — removes redundant `ForbiddenException` role checks from all service methods

## Test plan

- [ ] `POST /bonds` with a `comprador` token returns `403 Forbidden`
- [ ] `POST /bonds` with a `tse` token proceeds normally
- [ ] Route with no `@Roles()` only blocked by invalid token (401), not role (403)
- [ ] `npm run build` passes in `apps/api`
- [ ] `npm run lint` without new errors