### PR TITLE
[backend] feat(api): GET /api/health — Supabase + Stellar health check endpoint

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { AnalyticsModule } from './analytics/analytics.module';
 import { ReportsModule } from './reports/reports.module';
 import { ExplorerModule } from './explorer/explorer.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { HealthModule } from './health/health.module';
 import { RolesGuard } from './auth/roles.guard';
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
@@ -47,6 +48,7 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
     ReportsModule,
     ExplorerModule,
     NotificationsModule,
+    HealthModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { HealthService } from './health.service';
+
+@Controller('api/health')
+export class HealthController {
+  constructor(private readonly healthService: HealthService) {}
+
+  @Get()
+  async check() {
+    return this.healthService.check();
+  }
+}

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+import { HealthService } from './health.service';
+
+@Module({
+  controllers: [HealthController],
+  providers: [HealthService],
+})
+export class HealthModule {}

--- a/apps/api/src/health/health.service.ts
+++ b/apps/api/src/health/health.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import { HORIZON_URL } from '../escrow/stellar.config';
+
+const TIMEOUT_MS = 3000;
+
+@Injectable()
+export class HealthService {
+  private readonly startTime = Date.now();
+
+  constructor(private readonly supabase: SupabaseService) {}
+
+  async check() {
+    const [supabaseStatus, stellarStatus] = await Promise.all([
+      this.checkSupabase(),
+      this.checkStellar(),
+    ]);
+
+    const allUp = supabaseStatus === 'up' && stellarStatus === 'up';
+    const body = {
+      status: allUp ? 'ok' : 'degraded',
+      supabase: supabaseStatus,
+      stellar: stellarStatus,
+      uptime: Math.floor((Date.now() - this.startTime) / 1000),
+    };
+
+    if (!allUp) {
+      throw new HttpException(body, HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+    return body;
+  }
+
+  private async checkSupabase(): Promise<'up' | 'down'> {
+    try {
+      const { error } = await Promise.race([
+        this.supabase.admin.from('bonds').select('id').limit(1),
+        this.timeout(),
+      ]) as { error: unknown };
+      return error ? 'down' : 'up';
+    } catch {
+      return 'down';
+    }
+  }
+
+  private async checkStellar(): Promise<'up' | 'down'> {
+    try {
+      const res = await Promise.race([
+        fetch(`${HORIZON_URL}/`),
+        this.timeout(),
+      ]) as Response;
+      return res.ok ? 'up' : 'down';
+    } catch {
+      return 'down';
+    }
+  }
+
+  private timeout(): Promise<never> {
+    return new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('timeout')), TIMEOUT_MS),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Closes #5

Adds `GET /api/health` endpoint with structured connectivity status for Supabase and Stellar Horizon, as described in issue [#5](https://github.com/Velar-Bonds/Velar/issues/5).

## Changes

- **`apps/api/src/health/health.module.ts`** — new NestJS module
- **`apps/api/src/health/health.controller.ts`** — `GET /api/health` controller, no authentication required
- **`apps/api/src/health/health.service.ts`** — pings Supabase (DB query) and Stellar Horizon (HTTP fetch) with 3s timeout each
- **`apps/api/src/app.module.ts`** — registers `HealthModule`

## Response shape

```json
{ "status": "ok", "supabase": "up", "stellar": "up", "uptime": 42 }
```

- HTTP **200** when all dependencies are up
- HTTP **503** when any dependency is down (`status: "degraded"`)

## Acceptance criteria

- [x] `GET /api/health` returns 200 with `{ status: "ok", ... }` in normal operation
- [x] Response includes `supabase` and `stellar` status fields
- [x] Response time is under 5s (3s timeout per dependency)
- [x] Endpoint is unauthenticated (no JWT required)
- [x] Follows Velar monorepo structure (`apps/api/src/health/` module)
- [x] No existing endpoints are affected