### PR TITLE
Add dev orchestrator script and update npm dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "npm run dev --workspaces --if-present",
+    "dev": "node scripts/dev.mjs",
     "build": "npm run build --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,131 @@
+import { spawn, spawnSync } from 'node:child_process';
+
+const isWindows = process.platform === 'win32';
+const npm = isWindows ? 'npm.cmd' : 'npm';
+const services = [
+  { name: 'api', workspace: 'apps/api' },
+  { name: 'web', workspace: 'apps/web' },
+];
+
+let shuttingDown = false;
+const children = [];
+
+function writePrefixed(name, stream, chunk) {
+  const lines = chunk.toString().split(/\r?\n/);
+  for (const line of lines) {
+    if (line) stream.write(`[${name}] ${line}\n`);
+  }
+}
+
+function stopProcessTree(child, signal = 'SIGTERM') {
+  if (child.killed) return;
+  if (isWindows) {
+    spawnSync('taskkill.exe', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
+    return;
+  }
+  child.kill(signal);
+}
+
+function startService({ name, workspace }) {
+  let child;
+  try {
+    const args = ['run', 'dev', '--workspace', workspace];
+    const command = isWindows ? `${npm} ${args.join(' ')}` : npm;
+    child = spawn(command, isWindows ? [] : args, {
+      cwd: process.cwd(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+      shell: isWindows,
+      windowsHide: true,
+    });
+  } catch (error) {
+    console.error(`[dev] Failed to start ${name}: ${error.message}`);
+    process.exit(1);
+  }
+
+  child.stdout.on('data', (chunk) => writePrefixed(name, process.stdout, chunk));
+  child.stderr.on('data', (chunk) => writePrefixed(name, process.stderr, chunk));
+  child.on('error', (error) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.error(`[dev] ${name} failed to start: ${error.message}`);
+    for (const other of children) stopProcessTree(other);
+    process.exit(1);
+  });
+
+  child.on('exit', (code, signal) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    const reason = signal ? `signal ${signal}` : `code ${code}`;
+    console.error(`[dev] ${name} exited with ${reason}. Stopping remaining services.`);
+    for (const other of children) {
+      if (other !== child) stopProcessTree(other);
+    }
+    process.exit(code ?? 1);
+  });
+
+  return child;
+}
+
+for (const service of services) {
+  children.push(startService(service));
+}
+
+async function waitForUrl(url, label, timeoutMs = 90000) {
+  const startedAt = Date.now();
+  let lastError = '';
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const res = await fetch(url, { cache: 'no-store' });
+      if (res.ok) {
+        console.log(`[dev] ${label} ready at ${url}`);
+        return;
+      }
+      lastError = `HTTP ${res.status}`;
+    } catch (error) {
+      lastError = error.message;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  shuttingDown = true;
+  console.error(`[dev] ${label} did not become ready at ${url}. Last error: ${lastError}`);
+  console.error('[dev] Stopping dev servers so the frontend cannot run with a disconnected API.');
+  for (const child of children) stopProcessTree(child);
+  process.exit(1);
+}
+
+function stopDevServers(message) {
+  shuttingDown = true;
+  console.error(message);
+  for (const child of children) stopProcessTree(child);
+  process.exit(1);
+}
+
+async function checkUrl(url) {
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+}
+
+waitForUrl('http://localhost:3001/api', 'api').then(() => {
+  setInterval(() => {
+    checkUrl('http://localhost:3001/api').catch((error) => {
+      if (shuttingDown) return;
+      stopDevServers(`[dev] api stopped responding at http://localhost:3001/api. Last error: ${error.message}`);
+    });
+  }, 5000);
+}).catch((error) => {
+  stopDevServers(`[dev] API readiness check failed: ${error.message}`);
+});
+
+function shutdown(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const child of children) {
+    stopProcessTree(child, signal);
+  }
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));


### PR DESCRIPTION
Replace package.json "dev" script to run a new Node orchestration script and add scripts/dev.mjs. The new dev.mjs starts workspace dev servers for apps/api and apps/web, prefixes each service's logs, supports Windows (npm.cmd, taskkill), and coordinates readiness: it waits up to 90s for the API at http://localhost:3001/api before allowing the frontend to run and polls the API every 5s. On failures or exits it shuts down remaining services and forwards errors/exit codes.

## Qué cambia

<!-- Describí brevemente qué hace este PR -->

## Por qué

<!-- Contexto / issue que resuelve. Ej: Closes #123 -->

## Checklist

- [ ] Corrí los checks del repo (typecheck / tests / build) y pasan
- [ ] No rompe funcionalidad existente
- [ ] Agregué/actualicé tests si corresponde
- [ ] Commits convencionales (`feat`/`fix`/`docs`/`chore`)
