### PR TITLE
Portalize CountrySelector menu and add positioning

### DIFF
--- a/apps/web/components/CountrySelector.tsx
+++ b/apps/web/components/CountrySelector.tsx
@@ -1,48 +1,90 @@
 'use client';
 /**
- * Selector de país para el header. Cambiar el país reconfigura toda la UI
- * (autoridad, moneda, instrumento) sobre el mismo núcleo Stellar — es el gesto
- * central del demo multi-país.
+ * Selector de pais para el header. Cambiar el pais reconfigura toda la UI
+ * (autoridad, moneda, instrumento) sobre el mismo nucleo Stellar.
  */
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Check, ChevronDown, Globe } from 'lucide-react';
 import { useCountry } from '../lib/country';
 
 export function CountrySelector({ compact = false }: { compact?: boolean }) {
   const { country, profile, setCountry, profiles } = useCountry();
   const [open, setOpen] = useState(false);
+  const [menuStyle, setMenuStyle] = useState<{ top: number; left: number; width: number } | null>(null);
   const ref = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const onClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      const target = e.target as Node;
+      if (ref.current?.contains(target) || menuRef.current?.contains(target)) return;
+      setOpen(false);
     };
     document.addEventListener('mousedown', onClick);
     return () => document.removeEventListener('mousedown', onClick);
   }, []);
 
+  useEffect(() => {
+    if (!open) return;
+
+    const updatePosition = () => {
+      const button = buttonRef.current;
+      if (!button) return;
+
+      const rect = button.getBoundingClientRect();
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      const gutter = 12;
+      const width = Math.min(288, viewportWidth - gutter * 2);
+
+      let left = compact ? rect.left : rect.right - width;
+      if (left + width > viewportWidth - gutter) left = viewportWidth - width - gutter;
+      if (left < gutter) left = gutter;
+
+      let top = rect.bottom + 8;
+      if (top + 250 > viewportHeight - gutter) top = Math.max(gutter, rect.top - 258);
+
+      setMenuStyle({ top, left, width });
+    };
+
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [compact, open]);
+
   return (
     <div className="relative" ref={ref}>
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setOpen((o) => !o)}
-        aria-label="Cambiar país"
-        title={`${profile.name} · ${profile.authority.name}`}
+        aria-label="Cambiar pais"
+        title={`${profile.name} - ${profile.authority.name}`}
         className="flex items-center gap-2 rounded-full border border-outline-variant/40 bg-white px-2.5 py-1.5 text-sm font-medium text-on-surface transition hover:border-primary-container/50 hover:bg-surface-container-low"
       >
         <span className="text-base leading-none">{profile.flag}</span>
         {!compact && (
           <span className="hidden sm:inline">
-            {profile.authority.code} · {profile.currency.code}
+            {profile.authority.code} - {profile.currency.code}
           </span>
         )}
         <ChevronDown size={14} className="text-outline" />
       </button>
 
-      {open && (
-        <div className="absolute right-0 z-50 mt-2 w-72 overflow-hidden rounded-xl border border-outline-variant/30 bg-white shadow-xl">
+      {open && menuStyle && typeof document !== 'undefined' && createPortal(
+        <div
+          ref={menuRef}
+          className="fixed z-[120] overflow-hidden rounded-xl border border-outline-variant/30 bg-white shadow-xl"
+          style={{ top: menuStyle.top, left: menuStyle.left, width: menuStyle.width }}
+        >
           <div className="flex items-center gap-2 border-b border-outline-variant/20 px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wide text-on-surface-variant">
-            <Globe size={13} /> Jurisdicción
+            <Globe size={13} /> Jurisdiccion
           </div>
           {profiles.map((p) => {
             const active = p.code === country;
@@ -59,10 +101,10 @@ export function CountrySelector({ compact = false }: { compact?: boolean }) {
                 }`}
               >
                 <span className="text-lg leading-none">{p.flag}</span>
-                <span className="flex-1 min-w-0">
+                <span className="min-w-0 flex-1">
                   <span className="block font-semibold text-on-surface">{p.name}</span>
                   <span className="block truncate text-[11px] text-on-surface-variant">
-                    {p.authority.code} · {p.instrument.label} · {p.currency.code}
+                    {p.authority.code} - {p.instrument.label} - {p.currency.code}
                   </span>
                 </span>
                 {p.status === 'configured' && (
@@ -74,7 +116,8 @@ export function CountrySelector({ compact = false }: { compact?: boolean }) {
               </button>
             );
           })}
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );


### PR DESCRIPTION
Render the country dropdown via createPortal to document.body and compute a fixed top/left/width so the menu won't be clipped by parent containers. Add button/menu refs, reposition on resize/scroll, and improve outside-click handling to account for the portal. Also apply small UI/string tweaks (replace middot with hyphen, minor class reorder). 
