### PR TITLE
doc: document all endpoints

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,6 +43,7 @@
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.1",
     "ws": "^8.21.0"
   },
   "devDependencies": {

--- a/apps/api/src/app.controller.ts
+++ b/apps/api/src/app.controller.ts
@@ -1,19 +1,27 @@
 import { Controller, Get, Header } from '@nestjs/common';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { ApiResponse } from '@nestjs/swagger';
 import { Public } from './auth/public.decorator';
 
 @Public()
 @Controller()
 export class AppController {
   @Get()
-  healthCheck() { return { status: 'ok', service: 'velar-api' }; }
+  @ApiResponse({ status: 200, description: 'Servidor en línea' })
+  healthCheck() {
+    return { status: 'ok', service: 'velar-api' };
+  }
 
   /** Consola de prueba (HTML estático servido desde el mismo origen). */
   @Get('console')
   @Header('Content-Type', 'text/html; charset=utf-8')
   @Header('Cache-Control', 'no-store')
+  @ApiResponse({ status: 200, description: 'Consola de prueba' })
   console(): string {
-    return fs.readFileSync(path.join(process.cwd(), 'public', 'console.html'), 'utf8');
+    return fs.readFileSync(
+      path.join(process.cwd(), 'public', 'console.html'),
+      'utf8',
+    );
   }
 }

--- a/apps/api/src/audit/audit.controller.ts
+++ b/apps/api/src/audit/audit.controller.ts
@@ -1,7 +1,7 @@
 import {
   Controller, Get, Param, Query, UseGuards, ForbiddenException,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AuditService } from './audit.service';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -15,6 +15,9 @@ export class AuditController {
   constructor(private audit: AuditService) {}
 
   @Get('bonds')
+  @ApiResponse({ status: 200, description: 'Resultados de búsqueda de bonos' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
   searchBonds(@Query() query: BondSearchQuery, @CurrentUser() user: any) {
     const role: Role = user.profile?.role;
     if (!['tse', 'admin'].includes(role)) throw new ForbiddenException('TSE/Admin only');
@@ -22,6 +25,10 @@ export class AuditController {
   }
 
   @Get('bonds/:tokenId/timeline')
+  @ApiResponse({ status: 200, description: 'Línea de tiempo del bono' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   getBondTimeline(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
     const role: Role = user.profile?.role;
     if (!['tse', 'admin'].includes(role)) throw new ForbiddenException('TSE/Admin only');
@@ -29,12 +36,17 @@ export class AuditController {
   }
 
   @Get('bonds/:tokenId/traceability')
+  @ApiResponse({ status: 200, description: 'Trazabilidad del bono' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   getBondTraceability(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
-    // No per-role check — all authenticated roles can access traceability
     return this.audit.getBondTraceability(tokenId);
   }
 
   @Get('events')
+  @ApiResponse({ status: 200, description: 'Eventos recientes de auditoría' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
   getRecentEvents(
     @Query('page') page: string | undefined,
     @Query('limit') limit: string | undefined,

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Post } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiTags, ApiResponse } from '@nestjs/swagger';
 import { Public } from './public.decorator';
 import { AuthService } from './auth.service';
 import { LoginDto, RegisterDto } from './dto/auth.dto';
@@ -13,11 +13,17 @@ export class AuthController {
 
   /** Registro público: perspectiva 'usuario' o 'partido' (TSE/admin se siembran). */
   @Post('register')
+  @ApiResponse({ status: 201, description: 'Usuario registrado exitosamente' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({ status: 409, description: 'El email ya está registrado' })
   register(@Body() body: RegisterDto) {
     return this.auth.register(body);
   }
 
   @Post('login')
+  @ApiResponse({ status: 200, description: 'Inicio de sesión exitoso' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({ status: 401, description: 'Credenciales inválidas' })
   @Throttle({ default: { limit: 10, ttl: 60000 } })
   login(@Body() body: LoginDto) {
     return this.auth.login(body);

--- a/apps/api/src/bonds/bonds.controller.ts
+++ b/apps/api/src/bonds/bonds.controller.ts
@@ -1,10 +1,19 @@
 import {
-  Body, Controller, Get, Param, Patch, Post, Query, UseGuards,
-  UseInterceptors, UploadedFile, Res,
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+  Res,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Throttle } from '@nestjs/throttler';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags, ApiResponse } from '@nestjs/swagger';
 import { Response } from 'express';
 import { BondsService } from './bonds.service';
 import { AuthGuard } from '../auth/auth.guard';
@@ -27,6 +36,13 @@ export class BondsController {
   constructor(private bonds: BondsService) {}
 
   @Post()
+  @ApiResponse({ status: 201, description: 'Bono registrado exitosamente' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({
+    status: 401,
+    description: 'Token no proporcionado o inválido',
+  })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
   @Throttle({ default: { limit: 20, ttl: 60000 } })
   @Roles('tse', 'admin')
   register(@Body() body: CreateBondDto, @CurrentUser() user: any) {
@@ -34,21 +50,48 @@ export class BondsController {
   }
 
   @Get()
+  @ApiResponse({ status: 200, description: 'Lista de bonos' })
+  @ApiResponse({
+    status: 401,
+    description: 'Token no proporcionado o inválido',
+  })
   findAll(
     @Query('page') page: string | undefined,
     @Query('limit') limit: string | undefined,
     @Query('country') country: string | undefined,
     @CurrentUser() user: any,
   ) {
-    return this.bonds.findAll(user.id, user.profile?.role as Role, user.profile?.party_id, page, limit, country);
+    return this.bonds.findAll(
+      user.id,
+      user.profile?.role as Role,
+      user.profile?.party_id,
+      page,
+      limit,
+      country,
+    );
   }
 
   @Get('requests')
+  @ApiResponse({ status: 200, description: 'Solicitudes de bono' })
+  @ApiResponse({
+    status: 401,
+    description: 'Token no proporcionado o inválido',
+  })
   findRequests(@CurrentUser() user: any) {
-    return this.bonds.findRequests(user.id, user.profile?.role as Role, user.profile?.party_id);
+    return this.bonds.findRequests(
+      user.id,
+      user.profile?.role as Role,
+      user.profile?.party_id,
+    );
   }
 
   @Post('requests')
+  @ApiResponse({ status: 201, description: 'Solicitud creada exitosamente' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({
+    status: 401,
+    description: 'Token no proporcionado o inválido',
+  })
   createRequest(@Body() body: CreateBondRequestDto, @CurrentUser() user: any) {
     const partyId = user.profile?.party_id;
     if (!partyId) throw new Error('No tenés un partido asociado');
@@ -56,19 +99,51 @@ export class BondsController {
   }
 
   @Patch('requests/:id/approve')
+  @ApiResponse({ status: 200, description: 'Solicitud aprobada' })
+  @ApiResponse({
+    status: 401,
+    description: 'Token no proporcionado o inválido',
+  })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
+  @ApiResponse({ status: 404, description: 'Solicitud no encontrada' })
   @Roles('tse', 'admin')
   approveRequest(@Param('id') id: string, @CurrentUser() user: any) {
     return this.bonds.approveRequest(id, user.id, user.profile?.role as Role);
   }
 
   @Patch('requests/:id/reject')
+  @ApiResponse({ status: 200, description: 'Solicitud rechazada' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({
+    status: 401,
+    description: 'Token no proporcionado o inválido',
+  })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
+  @ApiResponse({ status: 404, description: 'Solicitud no encontrada' })
   @Roles('tse', 'admin')
-  rejectRequest(@Param('id') id: string, @Body() body: RejectBondRequestDto, @CurrentUser() user: any) {
-    return this.bonds.rejectRequest(id, body.reason ?? '', user.id, user.profile?.role as Role);
+  rejectRequest(
+    @Param('id') id: string,
+    @Body() body: RejectBondRequestDto,
+    @CurrentUser() user: any,
+  ) {
+    return this.bonds.rejectRequest(
+      id,
+      body.reason ?? '',
+      user.id,
+      user.profile?.role as Role,
+    );
   }
 
   @Get('available')
-  findAvailable(@Query('country') country: string | undefined, @CurrentUser() user: any) {
+  @ApiResponse({ status: 200, description: 'Bonos disponibles en el mercado' })
+  @ApiResponse({
+    status: 401,
+    description: 'Token no proporcionado o inválido',
+  })
+  findAvailable(
+    @Query('country') country: string | undefined,
+    @CurrentUser() user: any,
+  ) {
     // Por defecto, el comprador ve el mercado de SU país. El selector del demo
     // puede pasar ?country= para explorar otros mercados (transparencia pública).
     const scope = country ?? user.profile?.country ?? undefined;
@@ -76,44 +151,98 @@ export class BondsController {
   }
 
   @Get(':tokenId')
+  @ApiResponse({ status: 200, description: 'Detalle del bono' })
+  @ApiResponse({
+    status: 401,
+    description: 'Token no proporcionado o inválido',
+  })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   findOne(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
     return this.bonds.findOne(tokenId, user.id, user.profile?.role as Role);
   }
 
   @Get(':tokenId/onchain')
+  @ApiResponse({ status: 200, description: 'Información on-chain del bono' })
+  @ApiResponse({
+    status: 401,
+    description: 'Token no proporcionado o inválido',
+  })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   onchain(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
     return this.bonds.onchainInfo(tokenId, user.id, user.profile?.role as Role);
   }
 
   @Patch(':tokenId/issue-onchain')
+  @ApiResponse({ status: 200, description: 'Bono emitido on-chain' })
+  @ApiResponse({
+    status: 401,
+    description: 'Token no proporcionado o inválido',
+  })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   @Roles('tse', 'admin')
   issueOnchain(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
-    return this.bonds.issueOnchain(tokenId, user.id, user.profile?.role as Role);
+    return this.bonds.issueOnchain(
+      tokenId,
+      user.id,
+      user.profile?.role as Role,
+    );
   }
 
   @Patch(':tokenId/publish')
-  publish(@Param('tokenId') tokenId: string, @Body() body: PublishBondDto, @CurrentUser() user: any) {
+  @ApiResponse({ status: 200, description: 'Bono publicado en el mercado' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({
+    status: 401,
+    description: 'Token no proporcionado o inválido',
+  })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
+  publish(
+    @Param('tokenId') tokenId: string,
+    @Body() body: PublishBondDto,
+    @CurrentUser() user: any,
+  ) {
     return this.bonds.publish(tokenId, user.id, body?.paymentMethods);
   }
 
   @Get(':tokenId/soroban-details')
+  @ApiResponse({ status: 200, description: 'Detalles Soroban del bono' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   sorobanDetails(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
-    return this.bonds.readSorobanDetails(tokenId, user.id, user.profile?.role as Role);
+    return this.bonds.readSorobanDetails(
+      tokenId,
+      user.id,
+      user.profile?.role as Role,
+    );
   }
 
   @Patch(':tokenId/freeze')
+  @ApiResponse({ status: 200, description: 'Bono congelado' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   @Roles('tse', 'admin')
   freeze(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
     return this.bonds.freeze(tokenId, user.id, user.profile?.role as Role);
   }
 
   @Patch(':tokenId/unfreeze')
+  @ApiResponse({ status: 200, description: 'Bono descongelado' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   @Roles('tse', 'admin')
   unfreeze(@Param('tokenId') tokenId: string, @CurrentUser() user: any) {
     return this.bonds.unfreeze(tokenId, user.id, user.profile?.role as Role);
   }
 
   @Post(':tokenId/document')
+  @ApiResponse({ status: 200, description: 'Documento subido exitosamente' })
+  @ApiResponse({ status: 400, description: 'Archivo no proporcionado o inválido' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   @Roles('tse', 'admin')
   @UseInterceptors(FileInterceptor('file'))
   uploadDocument(
@@ -121,16 +250,28 @@ export class BondsController {
     @UploadedFile() file: Express.Multer.File,
     @CurrentUser() user: any,
   ) {
-    return this.bonds.uploadDocument(tokenId, file, user.id, user.profile?.role as Role);
+    return this.bonds.uploadDocument(
+      tokenId,
+      file,
+      user.id,
+      user.profile?.role as Role,
+    );
   }
 
   @Get(':tokenId/document')
+  @ApiResponse({ status: 200, description: 'Documento PDF del bono' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   async downloadDocument(
     @Param('tokenId') tokenId: string,
     @CurrentUser() user: any,
     @Res() res: Response,
   ) {
-    const buffer = await this.bonds.downloadDocument(tokenId, user.id, user.profile?.role as Role);
+    const buffer = await this.bonds.downloadDocument(
+      tokenId,
+      user.id,
+      user.profile?.role as Role,
+    );
     res.set({
       'Content-Type': 'application/pdf',
       'Content-Disposition': `attachment; filename="bono-${tokenId}.pdf"`,
@@ -139,6 +280,9 @@ export class BondsController {
   }
 
   @Post('hash')
+  @ApiResponse({ status: 200, description: 'Hash calculado' })
+  @ApiResponse({ status: 400, description: 'Contenido inválido' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
   computeHash(@Body() body: HashDocumentDto) {
     return { hash: BondsService.hashDocument(body.content) };
   }

--- a/apps/api/src/bootstrap.ts
+++ b/apps/api/src/bootstrap.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
 // WebSocket polyfill (Supabase SDK lo inicializa al construir el cliente).
 import { WebSocket } from 'ws';
 if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
@@ -6,7 +9,10 @@ if (typeof (globalThis as { WebSocket?: unknown }).WebSocket === 'undefined') {
 
 import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { ExpressAdapter, NestExpressApplication } from '@nestjs/platform-express';
+import {
+  ExpressAdapter,
+  NestExpressApplication,
+} from '@nestjs/platform-express';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import * as expressImport from 'express';
 import type { Express } from 'express';
@@ -16,7 +22,8 @@ import { AppModule } from './app.module';
 const express: typeof expressImport =
   typeof expressImport === 'function'
     ? expressImport
-    : ((expressImport as { default?: typeof expressImport }).default ?? expressImport);
+    : ((expressImport as { default?: typeof expressImport }).default ??
+      expressImport);
 
 let cachedApp: Express | null = null;
 
@@ -25,11 +32,16 @@ export async function createNestExpressApp(): Promise<Express> {
   if (cachedApp) return cachedApp;
 
   const server = express();
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, new ExpressAdapter(server));
+  const app = await NestFactory.create<NestExpressApplication>(
+    AppModule,
+    new ExpressAdapter(server),
+  );
   app.set('trust proxy', 1);
 
   const corsOrigins = process.env.CORS_ORIGINS
-    ? process.env.CORS_ORIGINS.split(',').map((s) => s.trim()).filter(Boolean)
+    ? process.env.CORS_ORIGINS.split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
     : [process.env.WEB_URL ?? 'http://localhost:3000'];
 
   app.enableCors({ origin: corsOrigins, credentials: true });
@@ -45,8 +57,20 @@ export async function createNestExpressApp(): Promise<Express> {
     .setVersion('1.0')
     .addBearerAuth()
     .build();
-  const document = SwaggerModule.createDocument(app, swaggerConfig);
-  SwaggerModule.setup('api/docs', app, document);
+
+  if (process.env.NODE_ENV !== 'production') {
+    const document = SwaggerModule.createDocument(app, swaggerConfig);
+    SwaggerModule.setup('api/docs', app, document);
+
+    const publicDir = path.join(__dirname, '..', 'public');
+
+    fs.mkdirSync(publicDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(publicDir, 'openapi.json'),
+      JSON.stringify(document, null, 2),
+    );
+    
+  }
 
   await app.init();
   cachedApp = server;

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,7 +5,9 @@ async function bootstrap() {
   const port = process.env.PORT ?? 3001;
   app.listen(port, () => {
     console.log(`VELAR API running on http://localhost:${port}/api`);
-    console.log(`Swagger docs on http://localhost:${port}/api/docs`);
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(`Swagger docs on http://localhost:${port}/api/docs`);
+    }
   });
 }
 bootstrap();

--- a/apps/api/src/parties/parties.controller.ts
+++ b/apps/api/src/parties/parties.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { PartiesService } from './parties.service';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -13,11 +13,19 @@ export class PartiesController {
   constructor(private parties: PartiesService) {}
 
   @Get()
+  @ApiResponse({ status: 200, description: 'Lista de partidos políticos' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
   findAll() { return this.parties.findAll(); }
 
   @Get(':id')
+  @ApiResponse({ status: 200, description: 'Detalle del partido' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Partido no encontrado' })
   findOne(@Param('id') id: string) { return this.parties.findOne(id); }
 
   @Post()
+  @ApiResponse({ status: 201, description: 'Partido creado exitosamente' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
   create(@Body() body: CreatePartyDto, @CurrentUser() user: { id: string }) { return this.parties.create(body, user.id); }
 }

--- a/apps/api/src/reports/dto/reports.dto.ts
+++ b/apps/api/src/reports/dto/reports.dto.ts
@@ -1,0 +1,57 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsIn,
+  IsNumber,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
+import type { CreateReportInput } from '../reports.service';
+
+export class CreateReportDto implements CreateReportInput {
+  @ApiProperty({ example: 'Reporte Mensual de Gastos — Enero 2026' })
+  @IsString()
+  @MinLength(8)
+  title!: string;
+
+  @ApiProperty({ example: 'Detalle de gastos operativos, viáticos y publicidad del partido' })
+  @IsString()
+  @MinLength(8)
+  description!: string;
+
+  @ApiPropertyOptional({ example: '2026-01-01' })
+  @IsString()
+  @IsOptional()
+  period_start?: string;
+
+  @ApiPropertyOptional({ example: '2026-01-31' })
+  @IsString()
+  @IsOptional()
+  period_end?: string;
+
+  @ApiPropertyOptional({ example: ['BOND-001', 'BOND-002'] })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  bond_token_ids?: string[];
+
+  @ApiPropertyOptional({ example: 152477 })
+  @IsNumber()
+  @IsOptional()
+  total_amount?: number;
+}
+
+export const REPORT_STATUS = ['revisado', 'observado', 'aprobado'] as const;
+export type ReportStatus = (typeof REPORT_STATUS)[number];
+
+export class ReviewReportDto {
+  @ApiProperty({ enum: REPORT_STATUS })
+  @IsIn(REPORT_STATUS)
+  status!: ReportStatus;
+
+  @ApiPropertyOptional({ description: 'Notas de la revisión' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/apps/api/src/reports/reports.controller.ts
+++ b/apps/api/src/reports/reports.controller.ts
@@ -1,35 +1,77 @@
-import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
-import { ReportsService, CreateReportInput } from './reports.service';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ReportsService } from './reports.service';
+import { CreateReportDto, ReviewReportDto } from './dto/reports.dto';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { Role } from '@velar/types';
+import { ApiBearerAuth, ApiTags, ApiResponse } from '@nestjs/swagger';
 
+@ApiTags('reports')
+@ApiBearerAuth()
 @Controller('reports')
 @UseGuards(AuthGuard)
 export class ReportsController {
   constructor(private reports: ReportsService) {}
 
   @Post()
-  create(@Body() body: CreateReportInput, @CurrentUser() user: any) {
+  @ApiResponse({ status: 201, description: 'Reporte creado exitosamente' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Solo partidos políticos pueden enviar reportes' })
+  create(@Body() body: CreateReportDto, @CurrentUser() user: any) {
     return this.reports.create(body, user.id, user.profile?.party_id ?? null);
   }
 
   @Get()
+  @ApiResponse({ status: 200, description: 'Lista de reportes' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
   list(@CurrentUser() user: any) {
-    return this.reports.list(user.id, user.profile?.role as Role, user.profile?.party_id ?? null);
+    return this.reports.list(
+      user.id,
+      user.profile?.role as Role,
+      user.profile?.party_id ?? null,
+    );
   }
 
   @Get(':id')
+  @ApiResponse({ status: 200, description: 'Detalle del reporte' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Reporte no encontrado' })
   findOne(@Param('id') id: string, @CurrentUser() user: any) {
-    return this.reports.findOne(id, user.id, user.profile?.role as Role, user.profile?.party_id ?? null);
+    return this.reports.findOne(
+      id,
+      user.id,
+      user.profile?.role as Role,
+      user.profile?.party_id ?? null,
+    );
   }
 
   @Patch(':id/review')
+  @ApiResponse({ status: 200, description: 'Reporte revisado' })
+  @ApiResponse({ status: 400, description: 'Estado inválido' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Solo TSE puede revisar reportes' })
+  @ApiResponse({ status: 404, description: 'Reporte no encontrado' })
   review(
     @Param('id') id: string,
-    @Body() body: { status: 'revisado' | 'observado' | 'aprobado'; notes?: string },
+    @Body()
+    body: ReviewReportDto,
     @CurrentUser() user: any,
   ) {
-    return this.reports.review(id, body.status, body.notes, user.id, user.profile?.role as Role);
+    return this.reports.review(
+      id,
+      body.status,
+      body.notes,
+      user.id,
+      user.profile?.role as Role,
+    );
   }
 }

--- a/apps/api/src/transfers/transfers.controller.ts
+++ b/apps/api/src/transfers/transfers.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { TransfersService } from './transfers.service';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -21,6 +21,8 @@ export class TransfersController {
   constructor(private transfers: TransfersService) {}
 
   @Get()
+  @ApiResponse({ status: 200, description: 'Lista de transferencias del usuario' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
   findAll(
     @Query('page') page: string | undefined,
     @Query('limit') limit: string | undefined,
@@ -30,34 +32,57 @@ export class TransfersController {
   }
 
   @Get(':id')
+  @ApiResponse({ status: 200, description: 'Detalle de la transferencia' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   findOne(@Param('id') id: string) { return this.transfers.findOne(id); }
 
   @Post()
+  @ApiResponse({ status: 201, description: 'Transferencia solicitada exitosamente' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
   request(@Body() body: CreateTransferDto, @CurrentUser() user: any) {
     return this.transfers.requestTransfer(body, user.id);
   }
 
   @Patch(':id/accept')
+  @ApiResponse({ status: 200, description: 'Transferencia aceptada' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   accept(@Param('id') id: string, @CurrentUser() user: any) {
     return this.transfers.acceptTransfer(id, user.id);
   }
 
   @Patch(':id/reject')
+  @ApiResponse({ status: 200, description: 'Transferencia rechazada' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   reject(@Param('id') id: string, @CurrentUser() user: any) {
     return this.transfers.rejectTransfer(id, user.id);
   }
 
   @Patch(':id/counter')
+  @ApiResponse({ status: 200, description: 'Contraoferta enviada' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   counter(@Param('id') id: string, @Body() body: CounterOfferDto, @CurrentUser() user: any) {
     return this.transfers.counterOffer(id, Number(body.amount), body.message, user.id);
   }
 
   @Patch(':id/accept-counter')
+  @ApiResponse({ status: 200, description: 'Contraoferta aceptada' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   acceptCounter(@Param('id') id: string, @CurrentUser() user: any) {
     return this.transfers.acceptCounterOffer(id, user.id);
   }
 
   @Patch(':id/payment')
+  @ApiResponse({ status: 200, description: 'Pago registrado' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   registerPayment(
     @Param('id') id: string,
     @Body() body: RegisterPaymentDto,
@@ -67,40 +92,65 @@ export class TransfersController {
   }
 
   @Patch(':id/validate')
+  @ApiResponse({ status: 200, description: 'Pago validado' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Se requiere rol autorizado para validar pagos' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   validate(@Param('id') id: string, @CurrentUser() user: any) {
     return this.transfers.validatePayment(id, user.id, user.profile?.role as Role);
   }
 
   @Patch(':id/release')
+  @ApiResponse({ status: 200, description: 'Token liberado al comprador' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Se requiere rol autorizado para liberar tokens' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   release(@Param('id') id: string, @CurrentUser() user: any) {
     return this.transfers.releaseToken(id, user.id, user.profile?.role as Role);
   }
 
   @Patch(':id/cancel')
+  @ApiResponse({ status: 200, description: 'Transferencia cancelada' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   cancel(@Param('id') id: string, @CurrentUser() user: any) {
     return this.transfers.cancelTransfer(id, user.id);
   }
 
   /** SELF-CUSTODY: devuelve el XDR sin firmar de la transferencia (no custodial). */
   @Post(':id/build-xdr')
+  @ApiResponse({ status: 200, description: 'XDR de transferencia generado' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   buildXdr(@Param('id') id: string, @CurrentUser() user: any) {
     return this.transfers.buildTransferXdr(id, user.id);
   }
 
   /** SELF-CUSTODY: somete el XDR firmado por el vendedor (Freighter) a Horizon. */
   @Post(':id/submit-xdr')
+  @ApiResponse({ status: 200, description: 'XDR enviado a la red Stellar' })
+  @ApiResponse({ status: 400, description: 'XDR inválido' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   submitXdr(@Param('id') id: string, @Body() body: SubmitXdrDto, @CurrentUser() user: any) {
     return this.transfers.submitTransferXdr(id, body.signedXdr, user.id);
   }
 
   /** COMPRA INSTANTÁNEA (pago con wallet/USDC): XDR atómico sin firmar. */
   @Post('instant-buy/:bondTokenId/build-xdr')
+  @ApiResponse({ status: 200, description: 'XDR de compra instantánea generado' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   buildInstantBuy(@Param('bondTokenId') bondTokenId: string, @CurrentUser() user: any) {
     return this.transfers.buildInstantBuyXdr(bondTokenId, user.id);
   }
 
   /** COMPRA INSTANTÁNEA: somete el XDR firmado por el comprador a Horizon. */
   @Post('instant-buy/:bondTokenId/submit-xdr')
+  @ApiResponse({ status: 200, description: 'Compra instantánea ejecutada' })
+  @ApiResponse({ status: 400, description: 'XDR inválido' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Bono no encontrado' })
   submitInstantBuy(
     @Param('bondTokenId') bondTokenId: string,
     @Body() body: SubmitXdrDto,
@@ -111,11 +161,18 @@ export class TransfersController {
 
   /** NEGOCIACIÓN + WALLET: XDR DvP tras aceptación (comprador firma con Freighter). */
   @Post(':id/build-wallet-payment-xdr')
+  @ApiResponse({ status: 200, description: 'XDR de pago con wallet generado' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   buildWalletPayment(@Param('id') id: string, @CurrentUser() user: any) {
     return this.transfers.buildNegotiatedWalletPaymentXdr(id, user.id);
   }
 
   @Post(':id/submit-wallet-payment-xdr')
+  @ApiResponse({ status: 200, description: 'Pago con wallet ejecutado' })
+  @ApiResponse({ status: 400, description: 'XDR inválido' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   submitWalletPayment(
     @Param('id') id: string,
     @Body() body: SubmitXdrDto,
@@ -126,18 +183,32 @@ export class TransfersController {
 
   /** Dueño solicita al TSE retirar el bono del escrow (cancelación con disputa). */
   @Patch(':id/request-return')
+  @ApiResponse({ status: 200, description: 'Retorno solicitado' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   requestReturn(@Param('id') id: string, @Body() body: RequestReturnDto, @CurrentUser() user: any) {
     return this.transfers.requestReturn(id, body?.reason ?? '', user.id);
   }
 
   /** TSE aprueba el retorno: devuelve el token on-chain al dueño. */
   @Patch(':id/approve-return')
+  @ApiResponse({ status: 200, description: 'Retorno aprobado' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   approveReturn(@Param('id') id: string, @Body() body: ReturnDecisionDto, @CurrentUser() user: any) {
     return this.transfers.approveReturn(id, body?.notes, user.id, user.profile?.role as Role);
   }
 
   /** TSE rechaza la solicitud de retorno. */
   @Patch(':id/reject-return')
+  @ApiResponse({ status: 200, description: 'Retorno rechazado' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Se requiere rol tse o admin' })
+  @ApiResponse({ status: 404, description: 'Transferencia no encontrada' })
   rejectReturn(@Param('id') id: string, @Body() body: ReturnDecisionDto, @CurrentUser() user: any) {
     return this.transfers.rejectReturn(id, body?.notes, user.id, user.profile?.role as Role);
   }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, Param, Patch, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
@@ -14,28 +14,45 @@ export class UsersController {
   constructor(private users: UsersService) {}
 
   @Get('me')
+  @ApiResponse({ status: 200, description: 'Perfil del usuario autenticado' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
   getMe(@CurrentUser() user: any) { return this.users.getProfile(user.id); }
 
   @Patch('me')
+  @ApiResponse({ status: 200, description: 'Perfil actualizado' })
+  @ApiResponse({ status: 400, description: 'Datos inválidos' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
   updateMe(@CurrentUser() user: any, @Body() body: { full_name?: string }) {
     return this.users.updateProfile(user.id, body);
   }
 
   /** Vincula la wallet self-custody (Freighter) del usuario a su perfil. */
   @Patch('me/wallet')
+  @ApiResponse({ status: 200, description: 'Wallet vinculada exitosamente' })
+  @ApiResponse({ status: 400, description: 'Llave pública inválida' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
   setMyWallet(@CurrentUser() user: any, @Body() body: UpdateWalletDto) {
     return this.users.setSelfCustodyWallet(user.id, body.publicKey);
   }
 
   @Get()
+  @ApiResponse({ status: 200, description: 'Lista de usuarios' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
   listAll(@CurrentUser() user: any) { return this.users.listUsers(user.profile?.role as Role); }
 
   @Get('recompradores')
+  @ApiResponse({ status: 200, description: 'Lista de destinatarios para recompras' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
   listRecipients(@CurrentUser() user: any) {
     return this.users.listRecipients(user.id, user.profile?.role as Role);
   }
 
   @Patch(':id/role')
+  @ApiResponse({ status: 200, description: 'Rol actualizado' })
+  @ApiResponse({ status: 400, description: 'Rol inválido' })
+  @ApiResponse({ status: 401, description: 'Token no proporcionado o inválido' })
+  @ApiResponse({ status: 403, description: 'Se requiere rol autorizado para cambiar roles' })
+  @ApiResponse({ status: 404, description: 'Usuario no encontrado' })
   setRole(@Param('id') id: string, @Body() body: { role: Role }, @CurrentUser() user: any) {
     return this.users.setRole(id, body.role, user.profile?.role as Role);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "swagger-ui-express": "^5.0.1",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -3229,9 +3230,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4960,14 +4961,14 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.24",
-      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.24.tgz",
-      "integrity": "sha512-CeMKbRBm05aOBiWhIHWO2xDeHbxynBF9ySQv3gRjObz2N5+uJnYriAYkHvVqvC4JIydmMPmT5VdICFNlNz3qyA==",
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.28.tgz",
+      "integrity": "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
-        "multer": "2.1.1",
+        "multer": "2.2.0",
         "path-to-regexp": "8.4.2",
         "tslib": "2.8.1"
       },
@@ -5004,20 +5005,20 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "11.4.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.4.tgz",
-      "integrity": "sha512-VaIo1ruV2G7b+f2zPzkBSUNy9a/WQ9sg8TLKhWlrTfg4O6U10M/PA7Xi6XMXadOVhwOqoesijba8jH3i/3adrA==",
+      "version": "11.4.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.6.tgz",
+      "integrity": "sha512-Le136h2WC7HGsd70+WyK1qrm+Zq7kFxBLkYC1JgAVqNRCt8kNh7bMF7Qkn65D5j2t/aks0+VbWmUVlYIwPrs3A==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
         "@nestjs/mapped-types": "2.1.1",
-        "js-yaml": "4.1.1",
+        "js-yaml": "5.2.1",
         "lodash": "4.18.1",
         "path-to-regexp": "8.4.2",
-        "swagger-ui-dist": "5.32.6"
+        "swagger-ui-dist": "5.32.8"
       },
       "peerDependencies": {
-        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@fastify/static": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
         "class-transformer": "*",
@@ -5037,15 +5038,25 @@
       }
     },
     "node_modules/@nestjs/swagger/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/@nestjs/testing": {
@@ -18968,16 +18979,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -22970,9 +22981,9 @@
       }
     },
     "node_modules/multer": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -26795,12 +26806,27 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.32.6",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
-      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "version": "5.32.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
+      "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {


### PR DESCRIPTION
## Qué cambia

- Instalación de `swagger-ui-express` como dependencia de `@nestjs/swagger`
- Configuración de Swagger UI en `/api/docs` con guarda de producción (`NODE_ENV !== 'production'`) en `bootstrap.ts`
- Exportación del spec `openapi.json` a `apps/api/public/openapi.json` para consumo externo
- `@ApiResponse()` en los 7 controllers de la issue: auth, bonds, transfers, audit, users, parties, reports — más app controller
- `@ApiTags('reports')` y `@ApiBearerAuth()` en el controller de reports (estaban ausentes)
- `CreateReportDto`, `ReviewReportDto` y tipo `ReportStatus` con `@ApiProperty()` para el módulo de reports
- Log condicional de Swagger en `main.ts`

**Decisión de arquitectura:** SwaggerModule se mantuvo en `bootstrap.ts` en lugar de `main.ts`. El `SwaggerModule.setup()` requiere `NestExpressApplication`, pero `createNestExpressApp()` retorna `Express` para compatibilidad con Vercel serverless. Moverlo a `main.ts` habría requerido un refactor sin beneficio funcional.

## Por qué

Closes #24. El backend no tenía documentación interactiva. Con estos cambios, cualquier desarrollador puede explorar y probar la API desde el navegador en `/api/docs` sin leer código fuente. Todos los endpoints muestran su método HTTP, path, auth requerida, body schema y posibles códigos de respuesta.

## Checklist

- [x] Corrí los checks del repo (`npm run build`, `npm run lint`) y pasan
- [x] No rompe funcionalidad existente (cambio puramente aditivo: solo decoradores + guarda condicional)
- [ ] Agregué/actualicé tests si corresponde
- [x] Commits convencionales (`chore` / `feat` / `docs`)