### PR TITLE
feat(reports): monthly report lifecycle & compliance engine (party side) — closes #40

### DIFF
--- a/apps/api/src/common/contracts/contract-validation.interceptor.ts
+++ b/apps/api/src/common/contracts/contract-validation.interceptor.ts
@@ -14,6 +14,7 @@ import {
   zodIssuesToFieldErrors,
   type EndpointContract,
   type Locale,
+  type ValidationIssue,
 } from '@velar/types';
 import type { Request } from 'express';
 import { map, type Observable } from 'rxjs';
@@ -25,12 +26,29 @@ export interface ContractRequestParts {
   query: unknown;
 }
 
+/**
+ * Normaliza los issues de zod v4 (cuyo `path` puede incluir `symbol`) a la
+ * forma ValidationIssue esperada por @velar/types, descartando segmentos symbol.
+ */
+function toValidationIssues(
+  issues: ReadonlyArray<{ code: unknown; message: string; path: ReadonlyArray<PropertyKey> }>,
+): ValidationIssue[] {
+  return issues.map((issue) => ({
+    code: String(issue.code),
+    message: issue.message,
+    path: issue.path.filter(
+      (segment): segment is string | number =>
+        typeof segment === 'string' || typeof segment === 'number',
+    ),
+  }));
+}
+
 function parsePart(schema: ZodTypeAny, value: unknown, locale: Locale) {
   const result = schema.safeParse(value);
   if (result.success) return result.data;
   throw new BadRequestException(
     createApiError(ErrorCode.VALIDATION_ERROR, locale, {
-      fields: zodIssuesToFieldErrors(result.error.issues, locale),
+      fields: zodIssuesToFieldErrors(toValidationIssues(result.error.issues), locale),
       details: result.error.issues.map((issue) => ({ code: issue.code, path: issue.path })),
     }),
   );
@@ -57,7 +75,7 @@ export function validateContractResponse(
   if (result.success) return result.data;
   throw new InternalServerErrorException(
     createApiError(ErrorCode.RESPONSE_VALIDATION_ERROR, locale, {
-      fields: zodIssuesToFieldErrors(result.error.issues, locale),
+      fields: zodIssuesToFieldErrors(toValidationIssues(result.error.issues), locale),
       details: result.error.issues.map((issue) => ({ code: issue.code, path: issue.path })),
     }),
   );

--- a/apps/api/src/reports/domain/deadlines.spec.ts
+++ b/apps/api/src/reports/domain/deadlines.spec.ts
@@ -1,0 +1,86 @@
+import {
+  computeCompliance,
+  computeDueDate,
+  daysBetween,
+  computeComplianceForPeriods,
+} from './deadlines';
+import { ComplianceStatus, DeadlineConfig } from '@velar/types';
+
+const config: DeadlineConfig = { dueDayOfMonth: 15, graceDays: 5 };
+
+describe('computeDueDate', () => {
+  it('due date is the 15th of the following month', () => {
+    expect(computeDueDate(2026, 1, 15)).toBe('2026-02-15');
+  });
+  it('rolls over December → January next year', () => {
+    expect(computeDueDate(2026, 12, 15)).toBe('2027-01-15');
+  });
+});
+
+describe('daysBetween', () => {
+  it('counts whole UTC days, signed', () => {
+    expect(daysBetween('2026-02-10', '2026-02-15')).toBe(5);
+    expect(daysBetween('2026-02-20', '2026-02-15')).toBe(-5);
+    expect(daysBetween('2026-02-15', '2026-02-15')).toBe(0);
+  });
+});
+
+describe('computeCompliance', () => {
+  const base = { periodYear: 2026, periodMonth: 1, config }; // due 2026-02-15
+
+  it('on-time: submitted before the deadline', () => {
+    const r = computeCompliance({ ...base, submittedAt: '2026-02-10', now: '2026-02-20' });
+    expect(r.status).toBe(ComplianceStatus.ON_TIME);
+    expect(r.dueDate).toBe('2026-02-15');
+    expect(r.daysRemaining).toBeNull();
+  });
+
+  it('on-time: submitted exactly on the deadline', () => {
+    const r = computeCompliance({ ...base, submittedAt: '2026-02-15', now: '2026-02-16' });
+    expect(r.status).toBe(ComplianceStatus.ON_TIME);
+  });
+
+  it('late: submitted after the deadline', () => {
+    const r = computeCompliance({ ...base, submittedAt: '2026-02-18', now: '2026-02-20' });
+    expect(r.status).toBe(ComplianceStatus.LATE);
+    expect(r.daysRemaining).toBeNull();
+  });
+
+  it('not_due: no submission and deadline still ahead', () => {
+    const r = computeCompliance({ ...base, submittedAt: null, now: '2026-02-10' });
+    expect(r.status).toBe(ComplianceStatus.NOT_DUE);
+    expect(r.daysRemaining).toBe(5);
+  });
+
+  it('overdue: past deadline but within grace, not submitted', () => {
+    const r = computeCompliance({ ...base, submittedAt: null, now: '2026-02-18' });
+    expect(r.status).toBe(ComplianceStatus.OVERDUE);
+    expect(r.daysRemaining).toBe(-3);
+  });
+
+  it('overdue: on the last grace day', () => {
+    const r = computeCompliance({ ...base, submittedAt: null, now: '2026-02-20' });
+    expect(r.status).toBe(ComplianceStatus.OVERDUE);
+  });
+
+  it('missing: past deadline and past grace, not submitted', () => {
+    const r = computeCompliance({ ...base, submittedAt: null, now: '2026-02-21' });
+    expect(r.status).toBe(ComplianceStatus.MISSING);
+    expect(r.daysRemaining).toBeLessThan(0);
+  });
+});
+
+describe('computeComplianceForPeriods', () => {
+  it('maps each period independently', () => {
+    const results = computeComplianceForPeriods(
+      [
+        { periodYear: 2026, periodMonth: 1, submittedAt: '2026-02-10' }, // on-time
+        { periodYear: 2026, periodMonth: 2, submittedAt: null }, // due 2026-03-15
+      ],
+      config,
+      '2026-04-01',
+    );
+    expect(results[0].status).toBe(ComplianceStatus.ON_TIME);
+    expect(results[1].status).toBe(ComplianceStatus.MISSING);
+  });
+});

--- a/apps/api/src/reports/domain/deadlines.ts
+++ b/apps/api/src/reports/domain/deadlines.ts
@@ -1,0 +1,115 @@
+/**
+ * Lógica de vencimientos y cumplimiento — FUNCIONES PURAS, sin DB.
+ *
+ * Un reporte mensual vence el día `dueDayOfMonth` del mes SIGUIENTE al período.
+ * A partir de la config, la fecha de envío (si existe) y una fecha de referencia
+ * ("hoy"), se computa el estado de cumplimiento del período y los días restantes.
+ * Todo el cálculo es en UTC sobre fechas YYYY-MM-DD para evitar sesgos de zona.
+ */
+import {
+  ComplianceStatus,
+  DeadlineConfig,
+  PeriodCompliance,
+} from '@velar/types';
+
+const MS_PER_DAY = 86_400_000;
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+function isoDate(year: number, month: number, day: number): string {
+  return `${year}-${pad(month)}-${pad(day)}`;
+}
+
+/** Milisegundos UTC del inicio del día de una fecha ISO (ignora la hora). */
+function dayUtc(iso: string): number {
+  const [y, m, d] = iso.slice(0, 10).split('-').map(Number);
+  return Date.UTC(y, m - 1, d);
+}
+
+/** Días enteros entre dos fechas ISO (to - from). Negativo si `to` es anterior. */
+export function daysBetween(fromIso: string, toIso: string): number {
+  return Math.round((dayUtc(toIso) - dayUtc(fromIso)) / MS_PER_DAY);
+}
+
+/** Fecha de vencimiento (ISO) del reporte de un período. */
+export function computeDueDate(
+  periodYear: number,
+  periodMonth: number,
+  dueDayOfMonth: number,
+): string {
+  let year = periodYear;
+  let month = periodMonth + 1; // vence el mes siguiente
+  if (month > 12) {
+    month = 1;
+    year += 1;
+  }
+  return isoDate(year, month, dueDayOfMonth);
+}
+
+export interface ComplianceInput {
+  periodYear: number;
+  periodMonth: number;
+  config: DeadlineConfig;
+  /** Fecha de envío del reporte, o null si no se envió. */
+  submittedAt: string | null;
+  /** Fecha de referencia ("hoy"), ISO. */
+  now: string;
+}
+
+/** Computa el estado de cumplimiento de un período. Determinístico. */
+export function computeCompliance(input: ComplianceInput): PeriodCompliance {
+  const { periodYear, periodMonth, config, submittedAt, now } = input;
+  const dueDate = computeDueDate(periodYear, periodMonth, config.dueDayOfMonth);
+  const graceEnd = daysBetween('1970-01-01', dueDate) + config.graceDays;
+
+  let status: ComplianceStatus;
+  let daysRemaining: number | null;
+
+  if (submittedAt) {
+    // Ya enviado: on-time si fue en o antes del vencimiento, si no late.
+    status =
+      daysBetween(submittedAt, dueDate) >= 0
+        ? ComplianceStatus.ON_TIME
+        : ComplianceStatus.LATE;
+    daysRemaining = null;
+  } else {
+    const toDue = daysBetween(now, dueDate);
+    const nowDay = daysBetween('1970-01-01', now);
+    if (toDue >= 0) {
+      status = ComplianceStatus.NOT_DUE;
+    } else if (nowDay <= graceEnd) {
+      status = ComplianceStatus.OVERDUE;
+    } else {
+      status = ComplianceStatus.MISSING;
+    }
+    daysRemaining = toDue;
+  }
+
+  return {
+    periodYear,
+    periodMonth,
+    dueDate,
+    status,
+    daysRemaining,
+    submittedAt: submittedAt ?? null,
+  };
+}
+
+/** Computa cumplimiento para varios períodos de una vez (dashboard del partido). */
+export function computeComplianceForPeriods(
+  periods: Array<{ periodYear: number; periodMonth: number; submittedAt: string | null }>,
+  config: DeadlineConfig,
+  now: string,
+): PeriodCompliance[] {
+  return periods.map((p) =>
+    computeCompliance({
+      periodYear: p.periodYear,
+      periodMonth: p.periodMonth,
+      config,
+      submittedAt: p.submittedAt,
+      now,
+    }),
+  );
+}

--- a/apps/api/src/reports/domain/reconciliation.spec.ts
+++ b/apps/api/src/reports/domain/reconciliation.spec.ts
@@ -1,0 +1,126 @@
+import { reconcile, declaredRefsFromLineItems } from './reconciliation';
+import { DeclaredBondRef, DiscrepancyType, HeldBond } from '@velar/types';
+
+const held: HeldBond[] = [
+  { bondTokenId: 'bond-a', amount: 1000 },
+  { bondTokenId: 'bond-b', amount: 2500 },
+];
+
+describe('reconcile', () => {
+  it('clean match: declared == held → no discrepancies', () => {
+    const declared: DeclaredBondRef[] = [
+      { bondTokenId: 'bond-a', amount: 1000 },
+      { bondTokenId: 'bond-b', amount: 2500 },
+    ];
+    const res = reconcile(declared, held);
+    expect(res.status).toBe('clean');
+    expect(res.discrepancies).toHaveLength(0);
+    expect(res.matchedCount).toBe(2);
+    expect(res.declaredTotal).toBe(3500);
+    expect(res.actualTotal).toBe(3500);
+  });
+
+  it('amount mismatch: declared amount differs from held value', () => {
+    const declared: DeclaredBondRef[] = [
+      { bondTokenId: 'bond-a', amount: 999 },
+      { bondTokenId: 'bond-b', amount: 2500 },
+    ];
+    const res = reconcile(declared, held);
+    expect(res.status).toBe('discrepancies');
+    expect(res.discrepancies).toHaveLength(1);
+    expect(res.discrepancies[0]).toMatchObject({
+      type: DiscrepancyType.AMOUNT_MISMATCH,
+      bondTokenId: 'bond-a',
+      declaredAmount: 999,
+      actualAmount: 1000,
+    });
+    expect(res.matchedCount).toBe(1);
+  });
+
+  it('missing bond: party holds a bond that was not declared', () => {
+    const declared: DeclaredBondRef[] = [{ bondTokenId: 'bond-a', amount: 1000 }];
+    const res = reconcile(declared, held);
+    expect(res.status).toBe('discrepancies');
+    const missing = res.discrepancies.find((d) => d.type === DiscrepancyType.MISSING_BOND);
+    expect(missing).toMatchObject({
+      bondTokenId: 'bond-b',
+      declaredAmount: null,
+      actualAmount: 2500,
+    });
+    expect(res.matchedCount).toBe(1);
+  });
+
+  it('unknown reference: report cites a bond the party does not hold', () => {
+    const declared: DeclaredBondRef[] = [
+      { bondTokenId: 'bond-a', amount: 1000 },
+      { bondTokenId: 'bond-b', amount: 2500 },
+      { bondTokenId: 'ghost', amount: 50 },
+    ];
+    const res = reconcile(declared, held);
+    const unknown = res.discrepancies.find((d) => d.type === DiscrepancyType.UNKNOWN_REFERENCE);
+    expect(unknown).toMatchObject({
+      bondTokenId: 'ghost',
+      declaredAmount: 50,
+      actualAmount: null,
+    });
+    expect(res.matchedCount).toBe(2);
+  });
+
+  it('empty report against held bonds → all held flagged as missing', () => {
+    const res = reconcile([], held);
+    expect(res.status).toBe('discrepancies');
+    expect(res.discrepancies).toHaveLength(2);
+    expect(res.discrepancies.every((d) => d.type === DiscrepancyType.MISSING_BOND)).toBe(true);
+    expect(res.declaredTotal).toBe(0);
+    expect(res.actualTotal).toBe(3500);
+    expect(res.matchedCount).toBe(0);
+  });
+
+  it('empty report against no held bonds → clean', () => {
+    const res = reconcile([], []);
+    expect(res.status).toBe('clean');
+    expect(res.discrepancies).toHaveLength(0);
+    expect(res.matchedCount).toBe(0);
+  });
+
+  it('aggregates multiple line items citing the same bond', () => {
+    const declared: DeclaredBondRef[] = [
+      { bondTokenId: 'bond-a', amount: 600 },
+      { bondTokenId: 'bond-a', amount: 400 },
+      { bondTokenId: 'bond-b', amount: 2500 },
+    ];
+    const res = reconcile(declared, held);
+    expect(res.status).toBe('clean');
+    expect(res.matchedCount).toBe(2);
+  });
+
+  it('tolerates sub-cent floating point noise', () => {
+    const declared: DeclaredBondRef[] = [
+      { bondTokenId: 'bond-a', amount: 1000.004 },
+      { bondTokenId: 'bond-b', amount: 2500 },
+    ];
+    const res = reconcile(declared, held);
+    expect(res.status).toBe('clean');
+  });
+
+  it('produces a deterministic, stable ordering of discrepancies', () => {
+    const declared: DeclaredBondRef[] = [{ bondTokenId: 'zeta', amount: 10 }];
+    const a = reconcile(declared, held);
+    const b = reconcile(declared, held);
+    expect(a.discrepancies).toEqual(b.discrepancies);
+  });
+});
+
+describe('declaredRefsFromLineItems', () => {
+  it('keeps only line items with a bond reference', () => {
+    const refs = declaredRefsFromLineItems([
+      { bondTokenId: 'bond-a', amount: 100 },
+      { bondTokenId: null, amount: 50 },
+      { bondTokenId: 'bond-b', amount: 200 },
+    ]);
+    expect(refs).toEqual([
+      { bondTokenId: 'bond-a', amount: 100 },
+      { bondTokenId: 'bond-b', amount: 200 },
+    ]);
+  });
+});

--- a/apps/api/src/reports/domain/reconciliation.ts
+++ b/apps/api/src/reports/domain/reconciliation.ts
@@ -1,0 +1,121 @@
+/**
+ * Motor de conciliación — FUNCIONES PURAS, sin acceso a DB ni side-effects.
+ *
+ * Cruza los bonos declarados en un reporte contra los bonos que el partido
+ * realmente posee on-chain (alimentados por fixtures o por la capa de datos)
+ * y produce discrepancias tipadas. El núcleo es determinístico y testeable a
+ * partir de arrays; NO hace llamadas a Supabase.
+ */
+import {
+  DeclaredBondRef,
+  Discrepancy,
+  DiscrepancyType,
+  HeldBond,
+  ReconciliationResult,
+} from '@velar/types';
+
+/** Tolerancia monetaria (centavos) para comparar montos declarados vs reales. */
+const AMOUNT_EPSILON = 0.01;
+
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+/** Agrega montos declarados por bono (varias líneas pueden citar el mismo bono). */
+function aggregateDeclared(declared: DeclaredBondRef[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const ref of declared) {
+    if (!ref.bondTokenId) continue;
+    map.set(ref.bondTokenId, round2((map.get(ref.bondTokenId) ?? 0) + (ref.amount ?? 0)));
+  }
+  return map;
+}
+
+function aggregateHeld(held: HeldBond[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const bond of held) {
+    if (!bond.bondTokenId) continue;
+    map.set(bond.bondTokenId, round2((map.get(bond.bondTokenId) ?? 0) + (bond.amount ?? 0)));
+  }
+  return map;
+}
+
+/**
+ * Concilia lo declarado contra lo poseído. Determinístico: mismas entradas →
+ * misma salida. Las discrepancias se ordenan por tipo y token para estabilidad.
+ */
+export function reconcile(
+  declared: DeclaredBondRef[],
+  held: HeldBond[],
+): ReconciliationResult {
+  const declaredMap = aggregateDeclared(declared);
+  const heldMap = aggregateHeld(held);
+
+  const discrepancies: Discrepancy[] = [];
+  let matchedCount = 0;
+
+  // Recorrido de lo declarado: referencias desconocidas y montos que no cuadran.
+  for (const [tokenId, declaredAmount] of declaredMap) {
+    if (!heldMap.has(tokenId)) {
+      discrepancies.push({
+        type: DiscrepancyType.UNKNOWN_REFERENCE,
+        bondTokenId: tokenId,
+        declaredAmount,
+        actualAmount: null,
+        message: `El reporte referencia el bono ${tokenId}, que el partido no posee.`,
+      });
+      continue;
+    }
+    const actualAmount = heldMap.get(tokenId) as number;
+    if (Math.abs(declaredAmount - actualAmount) > AMOUNT_EPSILON) {
+      discrepancies.push({
+        type: DiscrepancyType.AMOUNT_MISMATCH,
+        bondTokenId: tokenId,
+        declaredAmount,
+        actualAmount,
+        message: `Monto declarado (${declaredAmount}) no coincide con el valor real (${actualAmount}) del bono ${tokenId}.`,
+      });
+    } else {
+      matchedCount += 1;
+    }
+  }
+
+  // Recorrido de lo poseído: bonos que el partido tiene pero no declaró.
+  for (const [tokenId, actualAmount] of heldMap) {
+    if (!declaredMap.has(tokenId)) {
+      discrepancies.push({
+        type: DiscrepancyType.MISSING_BOND,
+        bondTokenId: tokenId,
+        declaredAmount: null,
+        actualAmount,
+        message: `El partido posee el bono ${tokenId} pero no está declarado en el reporte.`,
+      });
+    }
+  }
+
+  discrepancies.sort((a, b) =>
+    a.type === b.type
+      ? a.bondTokenId.localeCompare(b.bondTokenId)
+      : a.type.localeCompare(b.type),
+  );
+
+  const declaredTotal = round2([...declaredMap.values()].reduce((s, n) => s + n, 0));
+  const actualTotal = round2([...heldMap.values()].reduce((s, n) => s + n, 0));
+
+  return {
+    status: discrepancies.length === 0 ? 'clean' : 'discrepancies',
+    discrepancies,
+    declaredTotal,
+    actualTotal,
+    matchedCount,
+  };
+}
+
+/** Extrae las referencias de bono declaradas a partir de las líneas del reporte. */
+export function declaredRefsFromLineItems(
+  lineItems: Array<{ bondTokenId: string | null; amount: number }>,
+): DeclaredBondRef[] {
+  return lineItems
+    .filter((li): li is { bondTokenId: string; amount: number } => !!li.bondTokenId)
+    .map((li) => ({ bondTokenId: li.bondTokenId, amount: li.amount ?? 0 }));
+}

--- a/apps/api/src/reports/domain/workflow.spec.ts
+++ b/apps/api/src/reports/domain/workflow.spec.ts
@@ -1,0 +1,73 @@
+import {
+  assertTransition,
+  canTransition,
+  isEditable,
+  isTerminal,
+  nextStatuses,
+  resolveSubmit,
+  InvalidTransitionError,
+} from './workflow';
+import { ReportStatus } from '@velar/types';
+
+describe('workflow transitions', () => {
+  it('allows the full happy path', () => {
+    expect(canTransition(ReportStatus.BORRADOR, ReportStatus.ENVIADO)).toBe(true);
+    expect(canTransition(ReportStatus.ENVIADO, ReportStatus.EN_REVISION)).toBe(true);
+    expect(canTransition(ReportStatus.EN_REVISION, ReportStatus.APROBADO)).toBe(true);
+  });
+
+  it('allows the correction loop', () => {
+    expect(canTransition(ReportStatus.EN_REVISION, ReportStatus.OBSERVADO)).toBe(true);
+    expect(canTransition(ReportStatus.OBSERVADO, ReportStatus.REENVIADO)).toBe(true);
+    expect(canTransition(ReportStatus.REENVIADO, ReportStatus.EN_REVISION)).toBe(true);
+  });
+
+  it('rejects illegal jumps', () => {
+    expect(canTransition(ReportStatus.BORRADOR, ReportStatus.APROBADO)).toBe(false);
+    expect(canTransition(ReportStatus.APROBADO, ReportStatus.ENVIADO)).toBe(false);
+    expect(canTransition(ReportStatus.ENVIADO, ReportStatus.APROBADO)).toBe(false);
+  });
+
+  it('assertTransition throws InvalidTransitionError on illegal moves', () => {
+    expect(() => assertTransition(ReportStatus.BORRADOR, ReportStatus.APROBADO)).toThrow(
+      InvalidTransitionError,
+    );
+    expect(() =>
+      assertTransition(ReportStatus.EN_REVISION, ReportStatus.OBSERVADO),
+    ).not.toThrow();
+  });
+
+  it('aprobado is terminal', () => {
+    expect(isTerminal(ReportStatus.APROBADO)).toBe(true);
+    expect(nextStatuses(ReportStatus.APROBADO)).toEqual([]);
+    expect(isTerminal(ReportStatus.BORRADOR)).toBe(false);
+  });
+
+  it('only borrador and observado are editable by the party', () => {
+    expect(isEditable(ReportStatus.BORRADOR)).toBe(true);
+    expect(isEditable(ReportStatus.OBSERVADO)).toBe(true);
+    expect(isEditable(ReportStatus.EN_REVISION)).toBe(false);
+    expect(isEditable(ReportStatus.APROBADO)).toBe(false);
+  });
+});
+
+describe('resolveSubmit', () => {
+  it('first submission: borrador → enviado, not a resubmission', () => {
+    expect(resolveSubmit(ReportStatus.BORRADOR)).toEqual({
+      next: ReportStatus.ENVIADO,
+      isResubmission: false,
+    });
+  });
+
+  it('correction: observado → reenviado, marked as resubmission', () => {
+    expect(resolveSubmit(ReportStatus.OBSERVADO)).toEqual({
+      next: ReportStatus.REENVIADO,
+      isResubmission: true,
+    });
+  });
+
+  it('cannot submit from a non-editable state', () => {
+    expect(() => resolveSubmit(ReportStatus.EN_REVISION)).toThrow();
+    expect(() => resolveSubmit(ReportStatus.APROBADO)).toThrow();
+  });
+});

--- a/apps/api/src/reports/domain/workflow.ts
+++ b/apps/api/src/reports/domain/workflow.ts
@@ -1,0 +1,75 @@
+/**
+ * Máquina de estados del reporte — FUNCIONES PURAS, sin DB ni framework.
+ *
+ * Ciclo legal:
+ *   borrador → enviado → en_revision → observado → reenviado → en_revision → aprobado
+ *
+ * `aprobado` es terminal. Solo se permiten transiciones declaradas aquí; el
+ * service las usa para rechazar cambios de estado ilegales antes de tocar la DB.
+ */
+import { EDITABLE_REPORT_STATUSES, ReportStatus } from '@velar/types';
+
+/** Transiciones legales por estado de origen. */
+const TRANSITIONS: Record<string, ReportStatus[]> = {
+  [ReportStatus.BORRADOR]: [ReportStatus.ENVIADO],
+  [ReportStatus.ENVIADO]: [ReportStatus.EN_REVISION],
+  [ReportStatus.EN_REVISION]: [ReportStatus.OBSERVADO, ReportStatus.APROBADO],
+  [ReportStatus.OBSERVADO]: [ReportStatus.REENVIADO],
+  [ReportStatus.REENVIADO]: [ReportStatus.EN_REVISION],
+  [ReportStatus.APROBADO]: [],
+  // Compat: estado legacy 'revisado' del módulo original se trata como en_revision.
+  revisado: [ReportStatus.OBSERVADO, ReportStatus.APROBADO],
+};
+
+export class InvalidTransitionError extends Error {
+  constructor(from: ReportStatus, to: ReportStatus) {
+    super(`Transición de estado ilegal: ${from} → ${to}`);
+    this.name = 'InvalidTransitionError';
+  }
+}
+
+/** Estados a los que se puede pasar desde `from`. */
+export function nextStatuses(from: ReportStatus): ReportStatus[] {
+  return TRANSITIONS[from] ?? [];
+}
+
+/** ¿Es legal la transición from → to? */
+export function canTransition(from: ReportStatus, to: ReportStatus): boolean {
+  return nextStatuses(from).includes(to);
+}
+
+/** Lanza InvalidTransitionError si la transición no es legal. */
+export function assertTransition(from: ReportStatus, to: ReportStatus): void {
+  if (!canTransition(from, to)) {
+    throw new InvalidTransitionError(from, to);
+  }
+}
+
+/** ¿El partido puede editar líneas/archivos en este estado? */
+export function isEditable(status: ReportStatus): boolean {
+  return EDITABLE_REPORT_STATUSES.includes(status);
+}
+
+/** ¿Es un estado terminal (no admite más transiciones)? */
+export function isTerminal(status: ReportStatus): boolean {
+  return nextStatuses(status).length === 0;
+}
+
+/**
+ * Resuelve el efecto de la acción "enviar/reenviar" del partido:
+ * - borrador  → enviado   (primer envío)
+ * - observado → reenviado (corrección: bumpea versión, preserva historial)
+ * Cualquier otro estado no admite envío.
+ */
+export function resolveSubmit(current: ReportStatus): {
+  next: ReportStatus;
+  isResubmission: boolean;
+} {
+  if (current === ReportStatus.BORRADOR) {
+    return { next: ReportStatus.ENVIADO, isResubmission: false };
+  }
+  if (current === ReportStatus.OBSERVADO) {
+    return { next: ReportStatus.REENVIADO, isResubmission: true };
+  }
+  throw new Error(`No se puede enviar un reporte en estado "${current}"`);
+}

--- a/apps/api/src/reports/dto/report-lifecycle.dto.ts
+++ b/apps/api/src/reports/dto/report-lifecycle.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsIn,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import { ReportLineCategory } from '@velar/types';
+
+const CATEGORIES = Object.values(ReportLineCategory);
+
+export class CreateDraftDto {
+  @ApiProperty({ example: 2026 })
+  @IsInt()
+  @Min(2000)
+  @Max(3000)
+  periodYear!: number;
+
+  @ApiProperty({ example: 1, minimum: 1, maximum: 12 })
+  @IsInt()
+  @Min(1)
+  @Max(12)
+  periodMonth!: number;
+
+  @ApiPropertyOptional({ example: 'Reporte enero 2026' })
+  @IsOptional()
+  @IsString()
+  title?: string;
+}
+
+export class AddLineItemDto {
+  @ApiProperty({ example: 'Bono SOL-2026-114' })
+  @IsString()
+  @IsNotEmpty()
+  concept!: string;
+
+  @ApiProperty({ example: 1000 })
+  @IsNumber()
+  amount!: number;
+
+  @ApiProperty({ enum: CATEGORIES, example: 'bono' })
+  @IsIn(CATEGORIES)
+  category!: ReportLineCategory;
+
+  @ApiPropertyOptional({ description: 'Token id del bono declarado', nullable: true })
+  @IsOptional()
+  @IsString()
+  bondTokenId?: string | null;
+}

--- a/apps/api/src/reports/files/file-scanner.ts
+++ b/apps/api/src/reports/files/file-scanner.ts
@@ -1,0 +1,40 @@
+/**
+ * Hook de antivirus detrás de una INTERFAZ + STUB. No hay vendor real: todo el
+ * flujo de subida corre localmente. En producción se inyecta una implementación
+ * concreta (ClamAV, VirusTotal, etc.) sin tocar el resto del módulo.
+ */
+import { FileScanStatus } from '@velar/types';
+
+/** Token de inyección de Nest para la implementación del scanner. */
+export const FILE_SCANNER = Symbol('FILE_SCANNER');
+
+export interface FileScanResult {
+  status: FileScanStatus;
+  /** Nombre de la amenaza detectada, si la hay. */
+  signature: string | null;
+}
+
+export interface FileScanner {
+  scan(input: { fileName: string; buffer: Buffer }): Promise<FileScanResult>;
+}
+
+/**
+ * Cadena de prueba estándar EICAR: cualquier antivirus real la marca como
+ * infectada. La usamos para ejercitar la rama "infected" sin malware real.
+ */
+export const EICAR_TEST_SIGNATURE =
+  'X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*';
+
+/**
+ * Stub determinístico: marca 'infected' si el contenido incluye la firma EICAR,
+ * de lo contrario 'clean'. Suficiente para probar ambas ramas end-to-end.
+ */
+export class StubFileScanner implements FileScanner {
+  async scan(input: { fileName: string; buffer: Buffer }): Promise<FileScanResult> {
+    const text = input.buffer.toString('latin1');
+    if (text.includes(EICAR_TEST_SIGNATURE)) {
+      return { status: FileScanStatus.INFECTED, signature: 'EICAR-Test-File' };
+    }
+    return { status: FileScanStatus.CLEAN, signature: null };
+  }
+}

--- a/apps/api/src/reports/files/file-validation.ts
+++ b/apps/api/src/reports/files/file-validation.ts
@@ -1,0 +1,65 @@
+/**
+ * Validación de subida + checksum — funciones puras. Sin DB, sin framework.
+ */
+import { createHash } from 'crypto';
+
+/** SHA-256 en hex del contenido del archivo (integridad). */
+export function sha256(buffer: Buffer): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+export const REPORT_FILE_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+
+export const REPORT_FILE_ALLOWED_MIME = [
+  'application/pdf',
+  'text/csv',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'image/png',
+  'image/jpeg',
+] as const;
+
+export interface UploadCandidate {
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+}
+
+export class FileValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FileValidationError';
+  }
+}
+
+/**
+ * Valida tipo y tamaño. Lanza FileValidationError si algo no cumple; el service
+ * lo mapea a BadRequestException.
+ */
+export function validateUpload(
+  file: UploadCandidate,
+  opts: { maxBytes?: number; allowedMime?: readonly string[] } = {},
+): void {
+  const maxBytes = opts.maxBytes ?? REPORT_FILE_MAX_BYTES;
+  const allowedMime = opts.allowedMime ?? REPORT_FILE_ALLOWED_MIME;
+
+  if (!file.fileName?.trim()) {
+    throw new FileValidationError('El archivo debe tener un nombre');
+  }
+  if (!allowedMime.includes(file.mimeType)) {
+    throw new FileValidationError(`Tipo de archivo no permitido: ${file.mimeType}`);
+  }
+  if (file.sizeBytes <= 0) {
+    throw new FileValidationError('El archivo está vacío');
+  }
+  if (file.sizeBytes > maxBytes) {
+    throw new FileValidationError(
+      `El archivo supera el máximo de ${Math.round(maxBytes / 1024 / 1024)} MB`,
+    );
+  }
+}
+
+/** Ruta canónica dentro del bucket privado: <party_id>/<report_id>/<file_name>. */
+export function reportFilePath(partyId: string, reportId: string, fileName: string): string {
+  const safeName = fileName.replace(/[^\w.\-]+/g, '_');
+  return `${partyId}/${reportId}/${safeName}`;
+}

--- a/apps/api/src/reports/files/file-validation.ts
+++ b/apps/api/src/reports/files/file-validation.ts
@@ -60,6 +60,6 @@ export function validateUpload(
 
 /** Ruta canónica dentro del bucket privado: <party_id>/<report_id>/<file_name>. */
 export function reportFilePath(partyId: string, reportId: string, fileName: string): string {
-  const safeName = fileName.replace(/[^\w.\-]+/g, '_');
+  const safeName = fileName.replace(/[^\w.-]+/g, '_');
   return `${partyId}/${reportId}/${safeName}`;
 }

--- a/apps/api/src/reports/files/files.spec.ts
+++ b/apps/api/src/reports/files/files.spec.ts
@@ -1,0 +1,78 @@
+import {
+  sha256,
+  validateUpload,
+  reportFilePath,
+  FileValidationError,
+  REPORT_FILE_MAX_BYTES,
+} from './file-validation';
+import {
+  StubFileScanner,
+  EICAR_TEST_SIGNATURE,
+} from './file-scanner';
+import { FileScanStatus } from '@velar/types';
+
+describe('sha256 checksum', () => {
+  it('is stable and matches a known vector', () => {
+    // sha256("") = e3b0c442...
+    expect(sha256(Buffer.from(''))).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+    );
+    const buf = Buffer.from('velar');
+    expect(sha256(buf)).toBe(sha256(buf));
+  });
+});
+
+describe('validateUpload', () => {
+  const ok = { fileName: 'reporte.pdf', mimeType: 'application/pdf', sizeBytes: 1024 };
+
+  it('accepts an allowed pdf under the size cap', () => {
+    expect(() => validateUpload(ok)).not.toThrow();
+  });
+
+  it('rejects a disallowed mime type', () => {
+    expect(() =>
+      validateUpload({ ...ok, mimeType: 'application/x-msdownload' }),
+    ).toThrow(FileValidationError);
+  });
+
+  it('rejects an empty file', () => {
+    expect(() => validateUpload({ ...ok, sizeBytes: 0 })).toThrow(FileValidationError);
+  });
+
+  it('rejects a file over the size cap', () => {
+    expect(() =>
+      validateUpload({ ...ok, sizeBytes: REPORT_FILE_MAX_BYTES + 1 }),
+    ).toThrow(/máximo/);
+  });
+
+  it('rejects a nameless file', () => {
+    expect(() => validateUpload({ ...ok, fileName: '  ' })).toThrow(FileValidationError);
+  });
+});
+
+describe('reportFilePath', () => {
+  it('builds <party>/<report>/<name> and sanitizes the name', () => {
+    expect(reportFilePath('p1', 'r1', 'mi reporte (final).pdf')).toBe(
+      'p1/r1/mi_reporte_final_.pdf',
+    );
+  });
+});
+
+describe('StubFileScanner', () => {
+  const scanner = new StubFileScanner();
+
+  it('marks clean content as clean', async () => {
+    const res = await scanner.scan({ fileName: 'a.pdf', buffer: Buffer.from('hola') });
+    expect(res.status).toBe(FileScanStatus.CLEAN);
+    expect(res.signature).toBeNull();
+  });
+
+  it('flags EICAR test content as infected', async () => {
+    const res = await scanner.scan({
+      fileName: 'virus.pdf',
+      buffer: Buffer.from(EICAR_TEST_SIGNATURE, 'latin1'),
+    });
+    expect(res.status).toBe(FileScanStatus.INFECTED);
+    expect(res.signature).toBe('EICAR-Test-File');
+  });
+});

--- a/apps/api/src/reports/report-lifecycle.controller.ts
+++ b/apps/api/src/reports/report-lifecycle.controller.ts
@@ -1,0 +1,121 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { ReportLifecycleService } from './report-lifecycle.service';
+import { AuthGuard } from '../auth/auth.guard';
+import { Roles } from '../auth/roles.decorator';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { Role } from '@velar/types';
+import { AddLineItemDto, CreateDraftDto } from './dto/report-lifecycle.dto';
+
+/**
+ * API del ciclo de vida estructurado del reporte del partido. Convive con
+ * ReportsController (metadata legacy) bajo el sub-path `reports/lifecycle`.
+ */
+@ApiTags('reports')
+@ApiBearerAuth()
+@Controller('reports/lifecycle')
+@UseGuards(AuthGuard)
+export class ReportLifecycleController {
+  constructor(private lifecycle: ReportLifecycleService) {}
+
+  @Post()
+  @Roles('emisor')
+  createDraft(@Body() body: CreateDraftDto, @CurrentUser() user: any) {
+    return this.lifecycle.createDraft(
+      body,
+      user.id,
+      user.profile?.party_id ?? null,
+      user.profile?.role as Role,
+    );
+  }
+
+  @Get(':id')
+  getDetail(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.lifecycle.getDetail(id, user.profile?.party_id ?? null, user.profile?.role as Role);
+  }
+
+  @Get(':id/line-items')
+  listLineItems(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.lifecycle.listLineItems(
+      id,
+      user.profile?.party_id ?? null,
+      user.profile?.role as Role,
+    );
+  }
+
+  @Post(':id/line-items')
+  @Roles('emisor')
+  addLineItem(@Param('id') id: string, @Body() body: AddLineItemDto, @CurrentUser() user: any) {
+    return this.lifecycle.addLineItem(
+      id,
+      body,
+      user.profile?.party_id ?? null,
+      user.profile?.role as Role,
+    );
+  }
+
+  @Delete(':id/line-items/:lineItemId')
+  @Roles('emisor')
+  removeLineItem(
+    @Param('id') id: string,
+    @Param('lineItemId') lineItemId: string,
+    @CurrentUser() user: any,
+  ) {
+    return this.lifecycle.removeLineItem(
+      id,
+      lineItemId,
+      user.profile?.party_id ?? null,
+      user.profile?.role as Role,
+    );
+  }
+
+  @Get(':id/reconciliation')
+  reconcile(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.lifecycle.previewReconciliation(
+      id,
+      user.profile?.party_id ?? null,
+      user.profile?.role as Role,
+    );
+  }
+
+  @Post(':id/files')
+  @Roles('emisor')
+  @UseInterceptors(FileInterceptor('file'))
+  uploadFile(
+    @Param('id') id: string,
+    @UploadedFile() file: Express.Multer.File,
+    @CurrentUser() user: any,
+  ) {
+    if (!file) throw new BadRequestException('Archivo requerido');
+    return this.lifecycle.uploadFile(
+      id,
+      { fileName: file.originalname, mimeType: file.mimetype, buffer: file.buffer },
+      user.id,
+      user.profile?.party_id ?? null,
+      user.profile?.role as Role,
+    );
+  }
+
+  @Post(':id/submit')
+  @Roles('emisor')
+  submit(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.lifecycle.submit(
+      id,
+      user.id,
+      user.profile?.party_id ?? null,
+      user.profile?.role as Role,
+    );
+  }
+}

--- a/apps/api/src/reports/report-lifecycle.service.spec.ts
+++ b/apps/api/src/reports/report-lifecycle.service.spec.ts
@@ -1,0 +1,280 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { ReportLifecycleService, computeTotal } from './report-lifecycle.service';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import { AuditService } from '../audit/audit.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { FILE_SCANNER, StubFileScanner, EICAR_TEST_SIGNATURE } from './files/file-scanner';
+import { ReportStatus } from '@velar/types';
+
+/** Chain mockeable de Supabase: awaitable y con .single(). */
+function chain(result: any) {
+  const p: any = {
+    select: () => p,
+    insert: () => p,
+    update: () => p,
+    delete: () => p,
+    eq: () => p,
+    order: () => p,
+    single: () => Promise.resolve(result),
+    then: (res: any, rej: any) => Promise.resolve(result).then(res, rej),
+  };
+  return p;
+}
+
+const PARTY = 'party-1';
+
+function lineRow(over: Partial<any> = {}) {
+  return {
+    id: 'li-1',
+    report_id: 'rep-1',
+    concept: 'Bono A',
+    amount: 1000,
+    category: 'bono',
+    bond_token_id: 'bond-a',
+    created_at: '2026-02-01T00:00:00Z',
+    ...over,
+  };
+}
+
+function reportRow(over: Partial<any> = {}) {
+  return {
+    id: 'rep-1',
+    party_id: PARTY,
+    period_year: 2026,
+    period_month: 1,
+    status: ReportStatus.BORRADOR,
+    current_version: 0,
+    title: 'Reporte 1/2026',
+    submitted_by: 'user-1',
+    created_at: '2026-02-01T00:00:00Z',
+    updated_at: '2026-02-01T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('ReportLifecycleService', () => {
+  let service: ReportLifecycleService;
+  let audit: { emit: jest.Mock };
+  let notifications: { emit: jest.Mock };
+  let fromMock: jest.Mock;
+  let uploadMock: jest.Mock;
+
+  beforeEach(async () => {
+    audit = { emit: jest.fn() };
+    notifications = { emit: jest.fn() };
+    fromMock = jest.fn();
+    uploadMock = jest.fn().mockResolvedValue({ error: null });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReportLifecycleService,
+        {
+          provide: SupabaseService,
+          useValue: {
+            admin: {
+              from: fromMock,
+              storage: { from: () => ({ upload: uploadMock }) },
+            },
+          },
+        },
+        { provide: AuditService, useValue: audit },
+        { provide: NotificationsService, useValue: notifications },
+        { provide: FILE_SCANNER, useValue: new StubFileScanner() },
+      ],
+    }).compile();
+
+    service = module.get(ReportLifecycleService);
+  });
+
+  // ── Autorización de envío ──────────────────────────────────────────────────
+  describe('submit authorization', () => {
+    it('rejects a non-emisor role', async () => {
+      await expect(
+        service.submit('rep-1', 'user-1', PARTY, 'comprador' as any),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('rejects an emisor from another party', async () => {
+      jest.spyOn(service as any, 'loadReportRow').mockResolvedValue(reportRow());
+      await expect(
+        service.submit('rep-1', 'user-1', 'other-party', 'emisor'),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
+
+    it('rejects an illegal state transition (en_revision cannot submit)', async () => {
+      jest
+        .spyOn(service as any, 'loadReportRow')
+        .mockResolvedValue(reportRow({ status: ReportStatus.EN_REVISION }));
+      await expect(
+        service.submit('rep-1', 'user-1', PARTY, 'emisor'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects submitting a report with no line items', async () => {
+      jest.spyOn(service as any, 'loadReportRow').mockResolvedValue(reportRow());
+      jest.spyOn(service as any, 'getLineItemRows').mockResolvedValue([]);
+      await expect(
+        service.submit('rep-1', 'user-1', PARTY, 'emisor'),
+      ).rejects.toThrow(/sin líneas/);
+    });
+  });
+
+  // ── Envío feliz: snapshot inmutable, versión, auditoría, notificaciones ─────
+  describe('submit happy path', () => {
+    beforeEach(() => {
+      jest.spyOn(service as any, 'loadReportRow').mockResolvedValue(reportRow());
+      jest.spyOn(service as any, 'getLineItemRows').mockResolvedValue([lineRow()]);
+      jest.spyOn(service as any, 'getFileRows').mockResolvedValue([]);
+      jest
+        .spyOn(service as any, 'getHeldBonds')
+        .mockResolvedValue([{ bondTokenId: 'bond-a', amount: 1000 }]);
+      jest.spyOn(service as any, 'tseUserIds').mockResolvedValue(['tse-1']);
+      fromMock.mockImplementation((table: string) => {
+        if (table === 'report_versions') return chain({ error: null });
+        if (table === 'reports')
+          return chain({ data: reportRow({ status: ReportStatus.ENVIADO, current_version: 1 }), error: null });
+        return chain({ data: [], error: null });
+      });
+    });
+
+    it('bumps version, moves to enviado, and reconciles clean', async () => {
+      const res = await service.submit('rep-1', 'user-1', PARTY, 'emisor');
+      expect(res.version).toBe(1);
+      expect(res.report.status).toBe(ReportStatus.ENVIADO);
+      expect(res.reconciliation.status).toBe('clean');
+    });
+
+    it('writes an immutable version snapshot with the reconciliation', async () => {
+      const insertSpy = jest.fn((_row: any) => chain({ error: null }));
+      fromMock.mockImplementation((table: string) => {
+        if (table === 'report_versions') return { insert: insertSpy };
+        if (table === 'reports')
+          return chain({ data: reportRow({ status: ReportStatus.ENVIADO, current_version: 1 }), error: null });
+        return chain({ data: [], error: null });
+      });
+      await service.submit('rep-1', 'user-1', PARTY, 'emisor');
+      expect(insertSpy).toHaveBeenCalledTimes(1);
+      const snap: any = insertSpy.mock.calls[0]![0];
+      expect(snap.version).toBe(1);
+      expect(snap.snapshot.declaredTotal).toBe(1000);
+      expect(snap.snapshot.reconciliation.status).toBe('clean');
+      expect(snap.snapshot.lineItems).toHaveLength(1);
+    });
+
+    it('emits version_created + submitted audit events', async () => {
+      await service.submit('rep-1', 'user-1', PARTY, 'emisor');
+      const types = audit.emit.mock.calls.map((c) => c[0].type);
+      expect(types).toContain('report_version_created');
+      expect(types).toContain('report_submitted');
+      expect(types).not.toContain('report_resubmitted');
+    });
+
+    it('notifies the party and the TSE on submission', async () => {
+      await service.submit('rep-1', 'user-1', PARTY, 'emisor');
+      const recipients = notifications.emit.mock.calls.map((c) => c[0]);
+      expect(recipients).toContain('user-1'); // party confirmation
+      expect(recipients).toContain('tse-1'); // TSE notice
+    });
+  });
+
+  // ── Reenvío (corrección tras observación) ──────────────────────────────────
+  describe('resubmit after observado', () => {
+    it('bumps to reenviado and emits report_resubmitted', async () => {
+      jest
+        .spyOn(service as any, 'loadReportRow')
+        .mockResolvedValue(reportRow({ status: ReportStatus.OBSERVADO, current_version: 1 }));
+      jest.spyOn(service as any, 'getLineItemRows').mockResolvedValue([lineRow()]);
+      jest.spyOn(service as any, 'getFileRows').mockResolvedValue([]);
+      jest
+        .spyOn(service as any, 'getHeldBonds')
+        .mockResolvedValue([{ bondTokenId: 'bond-a', amount: 1000 }]);
+      jest.spyOn(service as any, 'tseUserIds').mockResolvedValue([]);
+      fromMock.mockImplementation((table: string) => {
+        if (table === 'report_versions') return chain({ error: null });
+        return chain({ data: reportRow({ status: ReportStatus.REENVIADO, current_version: 2 }), error: null });
+      });
+
+      const res = await service.submit('rep-1', 'user-1', PARTY, 'emisor');
+      expect(res.version).toBe(2);
+      const types = audit.emit.mock.calls.map((c) => c[0].type);
+      expect(types).toContain('report_resubmitted');
+    });
+  });
+
+  // ── Subida de archivos: validación, checksum, antivirus ────────────────────
+  describe('uploadFile', () => {
+    beforeEach(() => {
+      jest.spyOn(service as any, 'loadReportRow').mockResolvedValue(reportRow());
+    });
+
+    it('stores a clean file with its checksum and emits audit', async () => {
+      const insertSpy = jest.fn((_row: any) =>
+        chain({ data: { id: 'f1', report_id: 'rep-1', file_path: 'p', file_name: 'r.pdf', mime_type: 'application/pdf', size_bytes: 4, checksum: 'x', scan_status: 'clean', created_at: 'now' }, error: null }),
+      );
+      fromMock.mockImplementation(() => ({ insert: insertSpy }));
+
+      const res = await service.uploadFile(
+        'rep-1',
+        { fileName: 'r.pdf', mimeType: 'application/pdf', buffer: Buffer.from('hola') },
+        'user-1',
+        PARTY,
+        'emisor',
+      );
+      expect(uploadMock).toHaveBeenCalledTimes(1);
+      expect(res.scanStatus).toBe('clean');
+      const inserted: any = insertSpy.mock.calls[0]![0];
+      expect(inserted.checksum).toHaveLength(64); // sha-256 hex
+      expect(audit.emit).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'report_file_uploaded' }),
+      );
+    });
+
+    it('rejects an infected file and never stores it', async () => {
+      await expect(
+        service.uploadFile(
+          'rep-1',
+          {
+            fileName: 'virus.pdf',
+            mimeType: 'application/pdf',
+            buffer: Buffer.from(EICAR_TEST_SIGNATURE, 'latin1'),
+          },
+          'user-1',
+          PARTY,
+          'emisor',
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(uploadMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects a disallowed mime type', async () => {
+      await expect(
+        service.uploadFile(
+          'rep-1',
+          { fileName: 'x.exe', mimeType: 'application/x-msdownload', buffer: Buffer.from('x') },
+          'user-1',
+          PARTY,
+          'emisor',
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  // ── Builder: edición solo en estados editables ─────────────────────────────
+  describe('addLineItem editability', () => {
+    it('rejects editing a report under review', async () => {
+      jest
+        .spyOn(service as any, 'loadReportRow')
+        .mockResolvedValue(reportRow({ status: ReportStatus.EN_REVISION }));
+      await expect(
+        service.addLineItem('rep-1', { concept: 'x', amount: 1, category: 'otro' }, PARTY, 'emisor'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('computeTotal', () => {
+    it('sums line item amounts to cents', () => {
+      expect(computeTotal([{ amount: 10.1 }, { amount: 20.2 }, { amount: 0.7 }])).toBe(31);
+    });
+  });
+});

--- a/apps/api/src/reports/report-lifecycle.service.ts
+++ b/apps/api/src/reports/report-lifecycle.service.ts
@@ -1,0 +1,474 @@
+import {
+  Injectable,
+  Inject,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import { AuditService } from '../audit/audit.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { FILE_SCANNER, FileScanner } from './files/file-scanner';
+import {
+  sha256,
+  validateUpload,
+  reportFilePath,
+  FileValidationError,
+} from './files/file-validation';
+import { reconcile, declaredRefsFromLineItems } from './domain/reconciliation';
+import { resolveSubmit, isEditable } from './domain/workflow';
+import {
+  AuditEventType,
+  NotificationType,
+  ReportStatus,
+  Role,
+  ReportLineItem,
+  ReportLineItemInput,
+  ReportFile,
+  ReportVersion,
+  ReconciliationResult,
+  ReportSnapshot,
+  HeldBond,
+  MonthlyReport,
+} from '@velar/types';
+
+const PARTY_ROLE: Role = 'emisor';
+const AUTHORITY: Role[] = ['tse', 'admin'];
+
+const REPORT_BUCKET = 'report-files';
+
+// ── Mappers snake_case (DB) → camelCase (@velar/types) ──────────────────────
+function mapReport(r: any): MonthlyReport {
+  return {
+    id: r.id,
+    partyId: r.party_id,
+    periodYear: r.period_year,
+    periodMonth: r.period_month,
+    status: r.status,
+    currentVersion: r.current_version ?? 0,
+    title: r.title,
+    submittedBy: r.submitted_by ?? null,
+    submittedAt: r.submitted_at ?? null,
+    reviewedBy: r.reviewed_by ?? null,
+    reviewedAt: r.reviewed_at ?? null,
+    tseNotes: r.tse_notes ?? null,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+function mapLineItem(r: any): ReportLineItem {
+  return {
+    id: r.id,
+    reportId: r.report_id,
+    concept: r.concept,
+    amount: Number(r.amount ?? 0),
+    category: r.category,
+    bondTokenId: r.bond_token_id ?? null,
+    createdAt: r.created_at,
+  };
+}
+
+function mapFile(r: any): ReportFile {
+  return {
+    id: r.id,
+    reportId: r.report_id,
+    filePath: r.file_path,
+    fileName: r.file_name,
+    mimeType: r.mime_type,
+    sizeBytes: Number(r.size_bytes ?? 0),
+    checksum: r.checksum,
+    scanStatus: r.scan_status,
+    createdAt: r.created_at,
+  };
+}
+
+function mapVersion(r: any): ReportVersion {
+  return {
+    id: r.id,
+    reportId: r.report_id,
+    version: r.version,
+    status: r.status,
+    snapshot: r.snapshot,
+    createdBy: r.created_by,
+    createdAt: r.created_at,
+  };
+}
+
+/**
+ * Ciclo de vida estructurado del reporte mensual: builder (borrador, líneas,
+ * archivos), conciliación on-chain, versionado inmutable y workflow de envío/
+ * corrección. Convive con ReportsService (metadata legacy) sin reescribirlo.
+ */
+@Injectable()
+export class ReportLifecycleService {
+  constructor(
+    private supabase: SupabaseService,
+    private audit: AuditService,
+    private notifications: NotificationsService,
+    @Inject(FILE_SCANNER) private scanner: FileScanner,
+  ) {}
+
+  // ── Autorización ──────────────────────────────────────────────────────────
+  private assertEmisor(role: Role) {
+    if (role !== PARTY_ROLE) {
+      throw new ForbiddenException('Solo un partido (emisor) puede operar reportes');
+    }
+  }
+
+  private assertOwner(report: any, partyId: string | null) {
+    if (!partyId || report.party_id !== partyId) {
+      throw new ForbiddenException('No autorizado sobre este reporte');
+    }
+  }
+
+  private assertEditable(report: any) {
+    if (!isEditable(report.status)) {
+      throw new BadRequestException(
+        `El reporte en estado "${report.status}" no admite ediciones`,
+      );
+    }
+  }
+
+  // ── Acceso a datos (aislado para test y claridad) ─────────────────────────
+  private async loadReportRow(reportId: string): Promise<any> {
+    const { data, error } = await this.supabase.admin
+      .from('reports')
+      .select('*')
+      .eq('id', reportId)
+      .single();
+    if (error || !data) throw new NotFoundException('Reporte no encontrado');
+    return data;
+  }
+
+  private async getLineItemRows(reportId: string): Promise<any[]> {
+    const { data } = await this.supabase.admin
+      .from('report_line_items')
+      .select('*')
+      .eq('report_id', reportId)
+      .order('created_at', { ascending: true });
+    return data ?? [];
+  }
+
+  private async getFileRows(reportId: string): Promise<any[]> {
+    const { data } = await this.supabase.admin
+      .from('report_files')
+      .select('*')
+      .eq('report_id', reportId)
+      .order('created_at', { ascending: true });
+    return data ?? [];
+  }
+
+  private async getVersionRows(reportId: string): Promise<any[]> {
+    const { data } = await this.supabase.admin
+      .from('report_versions')
+      .select('*')
+      .eq('report_id', reportId)
+      .order('version', { ascending: true });
+    return data ?? [];
+  }
+
+  /** Bonos que el partido posee on-chain (fixture-fed en tests). */
+  private async getHeldBonds(partyId: string): Promise<HeldBond[]> {
+    const { data } = await this.supabase.admin
+      .from('bonds')
+      .select('token_id, face_value')
+      .eq('issuer_party_id', partyId);
+    return (data ?? []).map((b: any) => ({
+      bondTokenId: b.token_id,
+      amount: Number(b.face_value ?? 0),
+    }));
+  }
+
+  private async tseUserIds(): Promise<string[]> {
+    const { data } = await this.supabase.admin
+      .from('profiles')
+      .select('id')
+      .eq('role', 'tse');
+    return (data ?? []).map((p: any) => p.id);
+  }
+
+  // ── Builder ───────────────────────────────────────────────────────────────
+  async createDraft(
+    input: { periodYear: number; periodMonth: number; title?: string },
+    actorId: string,
+    partyId: string | null,
+    role: Role,
+  ): Promise<MonthlyReport> {
+    this.assertEmisor(role);
+    if (!partyId) throw new ForbiddenException('El usuario no pertenece a un partido');
+    if (!input.periodYear || !input.periodMonth || input.periodMonth < 1 || input.periodMonth > 12) {
+      throw new BadRequestException('Período (año/mes) inválido');
+    }
+    const { data, error } = await this.supabase.admin
+      .from('reports')
+      .insert({
+        party_id: partyId,
+        submitted_by: actorId,
+        title: input.title?.trim() || `Reporte ${input.periodMonth}/${input.periodYear}`,
+        description: '',
+        period_year: input.periodYear,
+        period_month: input.periodMonth,
+        status: ReportStatus.BORRADOR,
+        current_version: 0,
+      })
+      .select()
+      .single();
+    if (error) throw new BadRequestException(error.message);
+    return mapReport(data);
+  }
+
+  async addLineItem(
+    reportId: string,
+    input: ReportLineItemInput,
+    partyId: string | null,
+    role: Role,
+  ): Promise<ReportLineItem> {
+    this.assertEmisor(role);
+    const report = await this.loadReportRow(reportId);
+    this.assertOwner(report, partyId);
+    this.assertEditable(report);
+    if (!input.concept?.trim()) throw new BadRequestException('El concepto es obligatorio');
+    if (typeof input.amount !== 'number' || Number.isNaN(input.amount)) {
+      throw new BadRequestException('El monto es inválido');
+    }
+    const { data, error } = await this.supabase.admin
+      .from('report_line_items')
+      .insert({
+        report_id: reportId,
+        concept: input.concept.trim(),
+        amount: input.amount,
+        category: input.category,
+        bond_token_id: input.bondTokenId ?? null,
+      })
+      .select()
+      .single();
+    if (error) throw new BadRequestException(error.message);
+    return mapLineItem(data);
+  }
+
+  async removeLineItem(
+    reportId: string,
+    lineItemId: string,
+    partyId: string | null,
+    role: Role,
+  ): Promise<{ ok: true }> {
+    this.assertEmisor(role);
+    const report = await this.loadReportRow(reportId);
+    this.assertOwner(report, partyId);
+    this.assertEditable(report);
+    await this.supabase.admin
+      .from('report_line_items')
+      .delete()
+      .eq('id', lineItemId)
+      .eq('report_id', reportId);
+    return { ok: true };
+  }
+
+  async listLineItems(
+    reportId: string,
+    partyId: string | null,
+    role: Role,
+  ): Promise<{ items: ReportLineItem[]; total: number }> {
+    const report = await this.loadReportRow(reportId);
+    if (!AUTHORITY.includes(role)) this.assertOwner(report, partyId);
+    const items = (await this.getLineItemRows(reportId)).map(mapLineItem);
+    return { items, total: computeTotal(items) };
+  }
+
+  // ── Archivos ──────────────────────────────────────────────────────────────
+  async uploadFile(
+    reportId: string,
+    file: { fileName: string; mimeType: string; buffer: Buffer },
+    actorId: string,
+    partyId: string | null,
+    role: Role,
+  ): Promise<ReportFile> {
+    this.assertEmisor(role);
+    const report = await this.loadReportRow(reportId);
+    this.assertOwner(report, partyId);
+    this.assertEditable(report);
+
+    try {
+      validateUpload({
+        fileName: file.fileName,
+        mimeType: file.mimeType,
+        sizeBytes: file.buffer.length,
+      });
+    } catch (e) {
+      if (e instanceof FileValidationError) throw new BadRequestException(e.message);
+      throw e;
+    }
+
+    const checksum = sha256(file.buffer);
+    const scan = await this.scanner.scan({ fileName: file.fileName, buffer: file.buffer });
+    if (scan.status === 'infected') {
+      throw new BadRequestException(
+        `Archivo rechazado por el antivirus (${scan.signature ?? 'amenaza'})`,
+      );
+    }
+
+    const path = reportFilePath(partyId as string, reportId, file.fileName);
+    const { error: upErr } = await this.supabase.admin.storage
+      .from(REPORT_BUCKET)
+      .upload(path, file.buffer, { contentType: file.mimeType, upsert: true });
+    if (upErr) throw new BadRequestException(`Fallo al subir el archivo: ${upErr.message}`);
+
+    const { data, error } = await this.supabase.admin
+      .from('report_files')
+      .insert({
+        report_id: reportId,
+        file_path: path,
+        file_name: file.fileName,
+        mime_type: file.mimeType,
+        size_bytes: file.buffer.length,
+        checksum,
+        scan_status: scan.status,
+      })
+      .select()
+      .single();
+    if (error) throw new BadRequestException(error.message);
+
+    await this.audit.emit({
+      type: AuditEventType.REPORT_FILE_UPLOADED,
+      actorId,
+      payload: { reportId, filePath: path, checksum, scanStatus: scan.status },
+    });
+    return mapFile(data);
+  }
+
+  // ── Conciliación ─────────────────────────────────────────────────────────
+  async previewReconciliation(
+    reportId: string,
+    partyId: string | null,
+    role: Role,
+  ): Promise<ReconciliationResult> {
+    const report = await this.loadReportRow(reportId);
+    if (!AUTHORITY.includes(role)) this.assertOwner(report, partyId);
+    return this.reconcileReport(report);
+  }
+
+  private async reconcileReport(report: any): Promise<ReconciliationResult> {
+    const items = (await this.getLineItemRows(report.id)).map(mapLineItem);
+    const held = await this.getHeldBonds(report.party_id);
+    return reconcile(declaredRefsFromLineItems(items), held);
+  }
+
+  // ── Envío / corrección (núcleo del workflow) ───────────────────────────────
+  async submit(
+    reportId: string,
+    actorId: string,
+    partyId: string | null,
+    role: Role,
+  ): Promise<{ report: MonthlyReport; version: number; reconciliation: ReconciliationResult }> {
+    this.assertEmisor(role);
+    const report = await this.loadReportRow(reportId);
+    this.assertOwner(report, partyId);
+
+    // Transición legal: borrador→enviado o observado→reenviado. Ilegal → error.
+    let next: ReportStatus;
+    let isResubmission: boolean;
+    try {
+      ({ next, isResubmission } = resolveSubmit(report.status));
+    } catch (e) {
+      throw new BadRequestException((e as Error).message);
+    }
+
+    const items = (await this.getLineItemRows(reportId)).map(mapLineItem);
+    if (items.length === 0) {
+      throw new BadRequestException('No se puede enviar un reporte sin líneas');
+    }
+    const files = (await this.getFileRows(reportId)).map(mapFile);
+    const held = await this.getHeldBonds(report.party_id);
+    const reconciliation = reconcile(declaredRefsFromLineItems(items), held);
+
+    const version = (report.current_version ?? 0) + 1;
+    const snapshot: ReportSnapshot = {
+      status: next,
+      title: report.title,
+      periodYear: report.period_year,
+      periodMonth: report.period_month,
+      lineItems: items.map(({ reportId: _r, createdAt: _c, ...rest }) => rest),
+      files: files.map(({ reportId: _r, createdAt: _c, ...rest }) => rest),
+      declaredTotal: computeTotal(items),
+      reconciliation,
+    };
+
+    // Snapshot inmutable (append-only por trigger en DB).
+    await this.supabase.admin.from('report_versions').insert({
+      report_id: reportId,
+      version,
+      status: next,
+      snapshot,
+      created_by: actorId,
+    });
+
+    const submittedAt = new Date().toISOString();
+    const { data: updated, error } = await this.supabase.admin
+      .from('reports')
+      .update({
+        status: next,
+        current_version: version,
+        submitted_by: actorId,
+        submitted_at: submittedAt,
+      })
+      .eq('id', reportId)
+      .select()
+      .single();
+    if (error) throw new BadRequestException(error.message);
+
+    // Auditoría: versión creada + envío/reenvío.
+    await this.audit.emit({
+      type: AuditEventType.REPORT_VERSION_CREATED,
+      actorId,
+      payload: { reportId, version, status: next },
+    });
+    await this.audit.emit({
+      type: isResubmission
+        ? AuditEventType.REPORT_RESUBMITTED
+        : AuditEventType.REPORT_SUBMITTED,
+      actorId,
+      payload: { reportId, version, reconciliationStatus: reconciliation.status },
+    });
+
+    // Notificaciones: confirmación al partido + aviso al TSE en el envío.
+    const notifType = isResubmission
+      ? NotificationType.REPORT_RESUBMITTED
+      : NotificationType.REPORT_SUBMITTED;
+    await this.notifications.emit(actorId, notifType, { reportId, version });
+    for (const tseId of await this.tseUserIds()) {
+      await this.notifications.emit(tseId, NotificationType.REPORT_SUBMITTED, {
+        reportId,
+        version,
+        partyId: report.party_id,
+      });
+    }
+
+    return { report: mapReport(updated), version, reconciliation };
+  }
+
+  // ── Detalle completo ───────────────────────────────────────────────────────
+  async getDetail(reportId: string, partyId: string | null, role: Role) {
+    const report = await this.loadReportRow(reportId);
+    if (!AUTHORITY.includes(role)) this.assertOwner(report, partyId);
+    const [items, files, versions] = await Promise.all([
+      this.getLineItemRows(reportId),
+      this.getFileRows(reportId),
+      this.getVersionRows(reportId),
+    ]);
+    const mappedItems = items.map(mapLineItem);
+    const held = await this.getHeldBonds(report.party_id);
+    return {
+      ...mapReport(report),
+      lineItems: mappedItems,
+      files: files.map(mapFile),
+      versions: versions.map(mapVersion),
+      reconciliation: reconcile(declaredRefsFromLineItems(mappedItems), held),
+    };
+  }
+}
+
+/** Suma de montos de las líneas (helper puro). */
+export function computeTotal(items: Array<{ amount: number }>): number {
+  return Math.round(items.reduce((s, i) => s + (i.amount ?? 0), 0) * 100) / 100;
+}

--- a/apps/api/src/reports/reports.module.ts
+++ b/apps/api/src/reports/reports.module.ts
@@ -1,11 +1,22 @@
 import { Module } from '@nestjs/common';
 import { ReportsController } from './reports.controller';
 import { ReportsService } from './reports.service';
+import { ReportLifecycleController } from './report-lifecycle.controller';
+import { ReportLifecycleService } from './report-lifecycle.service';
+import { FILE_SCANNER, StubFileScanner } from './files/file-scanner';
 import { SupabaseModule } from '../common/supabase/supabase.module';
+import { AuditModule } from '../audit/audit.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [SupabaseModule],
-  controllers: [ReportsController],
-  providers: [ReportsService],
+  imports: [SupabaseModule, AuditModule, NotificationsModule, AuthModule],
+  controllers: [ReportsController, ReportLifecycleController],
+  providers: [
+    ReportsService,
+    ReportLifecycleService,
+    // Antivirus: stub por defecto; se reemplaza por un vendor real vía este token.
+    { provide: FILE_SCANNER, useClass: StubFileScanner },
+  ],
 })
 export class ReportsModule {}

--- a/apps/web/app/partido/reportes/[id]/page.tsx
+++ b/apps/web/app/partido/reportes/[id]/page.tsx
@@ -1,0 +1,197 @@
+'use client';
+import { useEffect, useState, use as usePromise } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  ArrowLeft, History, CheckCircle, AlertTriangle, Send, Plus, FileText, Paperclip,
+} from 'lucide-react';
+import { PartidoShell } from '../../../../components/PartidoShell';
+import { useSession, apiFetch } from '../../../../lib/api';
+import {
+  STATUS_LABEL, STATUS_STYLE, CATEGORY_LABEL, COMPLIANCE_LABEL, COMPLIANCE_STYLE,
+  fmtCRC, fmtDate, periodLabel, clientCompliance,
+} from '../../../../lib/reports';
+import type {
+  MonthlyReportDetail, ReportLineCategory,
+} from '@velar/types';
+
+const CATEGORIES: ReportLineCategory[] = ['ingreso', 'egreso', 'donacion', 'bono', 'otro'];
+
+export default function ReporteDetallePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = usePromise(params);
+  const router = useRouter();
+  const { token, me, loading, error } = useSession();
+
+  const [detail, setDetail] = useState<MonthlyReportDetail | null>(null);
+  const [loadErr, setLoadErr] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ type: 'ok' | 'err'; text: string } | null>(null);
+  const [draft, setDraft] = useState({ concept: '', amount: '', category: 'otro' as ReportLineCategory });
+
+  const load = () =>
+    apiFetch(token!, 'GET', `/reports/lifecycle/${id}`)
+      .then(setDetail)
+      .catch((e) => setLoadErr(e.message));
+
+  useEffect(() => { if (token) load(); /* eslint-disable-next-line */ }, [token, id]);
+
+  if (loading || !token || !me) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        {error ? <p className="text-sm text-red-600">{error}</p> : <span className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />}
+      </div>
+    );
+  }
+
+  const canCorrect = detail?.status === 'observado';
+
+  async function addLine() {
+    if (!draft.concept.trim() || draft.amount === '') { setMsg({ type: 'err', text: 'Concepto y monto son obligatorios' }); return; }
+    setBusy(true); setMsg(null);
+    try {
+      await apiFetch(token!, 'POST', `/reports/lifecycle/${id}/line-items`, {
+        concept: draft.concept.trim(), amount: Number(draft.amount), category: draft.category, bondTokenId: null,
+      });
+      setDraft({ concept: '', amount: '', category: 'otro' });
+      await load();
+    } catch (e: any) { setMsg({ type: 'err', text: e.message }); } finally { setBusy(false); }
+  }
+
+  async function resubmit() {
+    setBusy(true); setMsg(null);
+    try {
+      await apiFetch(token!, 'POST', `/reports/lifecycle/${id}/submit`);
+      setMsg({ type: 'ok', text: 'Reporte reenviado al TSE.' });
+      await load();
+    } catch (e: any) { setMsg({ type: 'err', text: e.message }); } finally { setBusy(false); }
+  }
+
+  const comp = detail ? clientCompliance(detail.periodYear, detail.periodMonth, detail.submittedAt) : null;
+
+  return (
+    <PartidoShell me={me}>
+      <header className="sticky top-0 z-40 flex h-20 items-center gap-3 border-b border-outline-variant/30 bg-surface/70 px-10 shadow-sm backdrop-blur-xl">
+        <button onClick={() => router.push('/partido/reportes')} className="flex h-9 w-9 items-center justify-center rounded-full hover:bg-surface-container-low" aria-label="Volver">
+          <ArrowLeft size={18} />
+        </button>
+        <h1 className="text-2xl font-bold tracking-tight" style={{ fontFamily: 'Geist' }}>Detalle del reporte</h1>
+      </header>
+
+      <div className="mx-auto w-full max-w-[1000px] p-10 pb-24">
+        {loadErr && <div className="mb-5 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">{loadErr}</div>}
+        {msg && <div className={`mb-5 rounded-xl border px-4 py-3 text-sm ${msg.type === 'ok' ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-red-200 bg-red-50 text-red-600'}`}>{msg.text}</div>}
+
+        {!detail ? (
+          <p className="text-center text-sm text-on-surface-variant">Cargando…</p>
+        ) : (
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+            {/* Columna principal */}
+            <div className="lg:col-span-2 flex flex-col gap-6">
+              <div className="glass-card rounded-3xl p-6">
+                <div className="mb-3 flex items-center justify-between">
+                  <div>
+                    <p className="text-xs text-on-surface-variant">{periodLabel(detail.periodYear, detail.periodMonth)}</p>
+                    <h2 className="text-lg font-bold" style={{ fontFamily: 'Geist' }}>{detail.title}</h2>
+                  </div>
+                  <span className={`rounded-full border px-3 py-1 text-xs font-medium ${STATUS_STYLE[detail.status] ?? ''}`}>{STATUS_LABEL[detail.status] ?? detail.status}</span>
+                </div>
+                <div className="flex flex-wrap gap-2 text-xs">
+                  <span className="rounded-full bg-surface-container-low px-3 py-1">Versión {detail.currentVersion}</span>
+                  <span className="rounded-full bg-surface-container-low px-3 py-1">Enviado: {fmtDate(detail.submittedAt)}</span>
+                  {comp && <span className={`rounded-full border px-3 py-1 font-medium ${COMPLIANCE_STYLE[comp.status]}`}>{COMPLIANCE_LABEL[comp.status]} · vence {fmtDate(comp.dueDate)}</span>}
+                </div>
+              </div>
+
+              {/* Conciliación */}
+              <div className="glass-card rounded-3xl p-6">
+                <h3 className="mb-3 flex items-center gap-2 font-semibold"><FileText size={16} /> Conciliación on-chain</h3>
+                {detail.reconciliation.status === 'clean' ? (
+                  <p className="flex items-center gap-2 text-sm text-emerald-700"><CheckCircle size={16} /> Sin discrepancias · {fmtCRC(detail.reconciliation.declaredTotal)}</p>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    <p className="flex items-center gap-2 text-sm text-amber-700"><AlertTriangle size={16} /> {detail.reconciliation.discrepancies.length} discrepancia(s)</p>
+                    {detail.reconciliation.discrepancies.map((d, i) => (
+                      <p key={i} className="rounded-lg bg-surface-container-low p-2 text-xs text-on-surface-variant">{d.message}</p>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Líneas */}
+              <div className="glass-card rounded-3xl p-6">
+                <h3 className="mb-3 font-semibold">Líneas ({detail.lineItems.length})</h3>
+                {detail.lineItems.length === 0 ? (
+                  <p className="text-sm text-on-surface-variant">Sin líneas.</p>
+                ) : (
+                  <div className="overflow-hidden rounded-2xl border border-outline-variant/30">
+                    <table className="w-full text-sm">
+                      <tbody>
+                        {detail.lineItems.map((it) => (
+                          <tr key={it.id} className="border-b border-outline-variant/20 last:border-0">
+                            <td className="p-3">{it.concept}</td>
+                            <td className="p-3 text-on-surface-variant">{CATEGORY_LABEL[it.category]}</td>
+                            <td className="p-3 text-right font-mono">{fmtCRC(it.amount)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+                {detail.files.length > 0 && (
+                  <ul className="mt-4 flex flex-col gap-1 text-sm">
+                    {detail.files.map((f) => (
+                      <li key={f.id} className="flex items-center gap-2 text-on-surface-variant"><Paperclip size={13} /> {f.fileName}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+
+              {/* Corrección / reenvío */}
+              {canCorrect && (
+                <div className="glass-card rounded-3xl border border-red-200 p-6">
+                  <h3 className="mb-1 flex items-center gap-2 font-semibold text-red-600"><AlertTriangle size={16} /> El TSE observó este reporte</h3>
+                  {detail.tseNotes && <p className="mb-4 rounded-lg bg-amber-50 p-3 text-sm text-amber-700"><strong>Observación:</strong> {detail.tseNotes}</p>}
+                  <p className="mb-3 text-xs text-on-surface-variant">Corregí las líneas necesarias y reenviá. Se creará una nueva versión conservando el historial.</p>
+                  <div className="mb-3 grid grid-cols-1 gap-2 sm:grid-cols-4">
+                    <input value={draft.concept} onChange={(e) => setDraft({ ...draft, concept: e.target.value })} placeholder="Concepto" className="field-input sm:col-span-2" />
+                    <input type="number" value={draft.amount} onChange={(e) => setDraft({ ...draft, amount: e.target.value })} placeholder="Monto" className="field-input" />
+                    <select value={draft.category} onChange={(e) => setDraft({ ...draft, category: e.target.value as ReportLineCategory })} className="field-input">
+                      {CATEGORIES.map((c) => <option key={c} value={c}>{CATEGORY_LABEL[c]}</option>)}
+                    </select>
+                  </div>
+                  <div className="flex gap-3">
+                    <button onClick={addLine} disabled={busy} className="flex items-center gap-1 rounded-full border border-outline-variant/40 px-4 py-2 text-sm hover:bg-surface-container-low"><Plus size={14} /> Agregar línea</button>
+                    <button onClick={resubmit} disabled={busy} className="btn-action px-5 py-2">{busy ? <><span className="btn-spinner" /> Reenviando…</> : <><Send size={14} /> Reenviar al TSE</>}</button>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Timeline de versiones */}
+            <div className="lg:col-span-1">
+              <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold text-on-surface-variant"><History size={15} /> Historial de versiones</h3>
+              {detail.versions.length === 0 ? (
+                <p className="rounded-2xl border-2 border-dashed border-outline-variant/30 p-6 text-center text-xs text-on-surface-variant">Sin envíos todavía.</p>
+              ) : (
+                <ol className="relative ml-3 flex flex-col gap-5 border-l-2 border-outline-variant/30 pl-5">
+                  {[...detail.versions].reverse().map((v) => (
+                    <li key={v.id} className="relative">
+                      <span className="absolute -left-[27px] flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-white">{v.version}</span>
+                      <div className="rounded-xl border border-outline-variant/30 bg-white p-3">
+                        <div className="flex items-center justify-between">
+                          <span className={`rounded-full border px-2 py-0.5 text-[11px] font-medium ${STATUS_STYLE[v.status] ?? ''}`}>{STATUS_LABEL[v.status] ?? v.status}</span>
+                          <span className="text-[11px] text-on-surface-variant">{fmtDate(v.createdAt)}</span>
+                        </div>
+                        <p className="mt-2 text-xs text-on-surface-variant">Total: <span className="font-mono">{fmtCRC(v.snapshot?.declaredTotal)}</span></p>
+                        <p className="text-xs text-on-surface-variant">Conciliación: {v.snapshot?.reconciliation?.status === 'clean' ? 'limpia' : `${v.snapshot?.reconciliation?.discrepancies?.length ?? 0} disc.`}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </PartidoShell>
+  );
+}

--- a/apps/web/app/partido/reportes/nuevo/page.tsx
+++ b/apps/web/app/partido/reportes/nuevo/page.tsx
@@ -1,0 +1,366 @@
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  CalendarDays, ListChecks, Paperclip, ScanSearch, Send,
+  Plus, Trash2, CheckCircle, AlertTriangle, ArrowLeft, ArrowRight,
+} from 'lucide-react';
+import { PartidoShell } from '../../../../components/PartidoShell';
+import { useSession, apiFetch } from '../../../../lib/api';
+import { unwrapPaginated } from '../../../../lib/pagination';
+import {
+  CATEGORY_LABEL, fmtCRC, periodLabel, uploadReportFile,
+} from '../../../../lib/reports';
+import type {
+  ReportLineCategory, ReportLineItem, ReportFile, ReconciliationResult,
+} from '@velar/types';
+
+const STEPS = [
+  { key: 'periodo', label: 'Período', icon: CalendarDays },
+  { key: 'lineas', label: 'Líneas', icon: ListChecks },
+  { key: 'archivos', label: 'Archivos', icon: Paperclip },
+  { key: 'conciliacion', label: 'Conciliación', icon: ScanSearch },
+  { key: 'revisar', label: 'Revisar', icon: Send },
+];
+
+const CATEGORIES: ReportLineCategory[] = ['ingreso', 'egreso', 'donacion', 'bono', 'otro'];
+const now = new Date();
+
+export default function NuevoReportePage() {
+  const router = useRouter();
+  const { token, me, loading, error } = useSession();
+
+  const [step, setStep] = useState(0);
+  const [reportId, setReportId] = useState<string | null>(null);
+  const [year, setYear] = useState(now.getFullYear());
+  const [month, setMonth] = useState(now.getMonth() + 1); // mes actual
+  const [title, setTitle] = useState('');
+
+  const [bonds, setBonds] = useState<any[]>([]);
+  const [items, setItems] = useState<ReportLineItem[]>([]);
+  const [files, setFiles] = useState<ReportFile[]>([]);
+  const [recon, setRecon] = useState<ReconciliationResult | null>(null);
+
+  const [draft, setDraft] = useState({
+    concept: '', amount: '', category: 'bono' as ReportLineCategory, bondTokenId: '',
+  });
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ type: 'ok' | 'err'; text: string } | null>(null);
+
+  useEffect(() => {
+    if (token) apiFetch(token, 'GET', '/bonds?page=1&limit=100').then((r) => setBonds(unwrapPaginated(r))).catch(() => {});
+  }, [token]);
+
+  const total = useMemo(() => items.reduce((s, i) => s + i.amount, 0), [items]);
+
+  if (loading || !token || !me) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        {error ? <p className="text-sm text-red-600">{error}</p> : <span className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />}
+      </div>
+    );
+  }
+
+  const fail = (e: any) => setMsg({ type: 'err', text: e?.message ?? 'Ocurrió un error' });
+
+  async function ensureDraft() {
+    if (reportId) return reportId;
+    const body = { periodYear: year, periodMonth: month, title: title || undefined };
+    const rep = await apiFetch(token!, 'POST', '/reports/lifecycle', body);
+    setReportId(rep.id);
+    return rep.id as string;
+  }
+
+  async function goToLineItems() {
+    setBusy(true); setMsg(null);
+    try { await ensureDraft(); setStep(1); } catch (e) { fail(e); } finally { setBusy(false); }
+  }
+
+  async function addLine() {
+    if (!draft.concept.trim() || draft.amount === '') { setMsg({ type: 'err', text: 'Concepto y monto son obligatorios' }); return; }
+    setBusy(true); setMsg(null);
+    try {
+      const id = await ensureDraft();
+      const item = await apiFetch(token!, 'POST', `/reports/lifecycle/${id}/line-items`, {
+        concept: draft.concept.trim(),
+        amount: Number(draft.amount),
+        category: draft.category,
+        bondTokenId: draft.bondTokenId || null,
+      });
+      setItems((xs) => [...xs, item]);
+      setDraft({ concept: '', amount: '', category: 'bono', bondTokenId: '' });
+    } catch (e) { fail(e); } finally { setBusy(false); }
+  }
+
+  async function removeLine(lineItemId: string) {
+    if (!reportId) return;
+    setBusy(true);
+    try {
+      await apiFetch(token!, 'DELETE', `/reports/lifecycle/${reportId}/line-items/${lineItemId}`);
+      setItems((xs) => xs.filter((x) => x.id !== lineItemId));
+    } catch (e) { fail(e); } finally { setBusy(false); }
+  }
+
+  async function onUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file || !reportId) return;
+    setBusy(true); setMsg(null);
+    try {
+      const uploaded = await uploadReportFile(token!, reportId, file);
+      setFiles((xs) => [...xs, uploaded]);
+      setMsg({ type: 'ok', text: `Archivo "${file.name}" adjuntado.` });
+    } catch (err) { fail(err); } finally { setBusy(false); e.target.value = ''; }
+  }
+
+  async function loadReconciliation() {
+    if (!reportId) return;
+    setBusy(true); setMsg(null);
+    try {
+      const r = await apiFetch(token!, 'GET', `/reports/lifecycle/${reportId}/reconciliation`);
+      setRecon(r); setStep(3);
+    } catch (e) { fail(e); } finally { setBusy(false); }
+  }
+
+  async function submit() {
+    if (!reportId) return;
+    setBusy(true); setMsg(null);
+    try {
+      await apiFetch(token!, 'POST', `/reports/lifecycle/${reportId}/submit`);
+      router.push(`/partido/reportes/${reportId}`);
+    } catch (e) { fail(e); } finally { setBusy(false); }
+  }
+
+  const StepIcon = STEPS[step].icon;
+
+  return (
+    <PartidoShell me={me}>
+      <header className="sticky top-0 z-40 flex h-20 items-center gap-3 border-b border-outline-variant/30 bg-surface/70 px-10 shadow-sm backdrop-blur-xl">
+        <button onClick={() => router.push('/partido/reportes')} className="flex h-9 w-9 items-center justify-center rounded-full hover:bg-surface-container-low" aria-label="Volver">
+          <ArrowLeft size={18} />
+        </button>
+        <h1 className="text-2xl font-bold tracking-tight" style={{ fontFamily: 'Geist' }}>Nuevo reporte mensual</h1>
+      </header>
+
+      <div className="mx-auto w-full max-w-[900px] p-10 pb-24">
+        {/* Stepper */}
+        <ol className="mb-8 flex items-center justify-between">
+          {STEPS.map((s, i) => {
+            const Icon = s.icon;
+            const active = i === step, done = i < step;
+            return (
+              <li key={s.key} className="flex flex-1 items-center">
+                <div className="flex flex-col items-center gap-1">
+                  <span className={`flex h-10 w-10 items-center justify-center rounded-full border-2 ${active ? 'border-primary bg-primary/10 text-primary' : done ? 'border-emerald-500 bg-emerald-500 text-white' : 'border-outline-variant/40 text-on-surface-variant'}`}>
+                    {done ? <CheckCircle size={18} /> : <Icon size={18} />}
+                  </span>
+                  <span className={`text-[11px] ${active ? 'font-semibold text-primary' : 'text-on-surface-variant'}`}>{s.label}</span>
+                </div>
+                {i < STEPS.length - 1 && <span className={`mx-2 h-0.5 flex-1 ${done ? 'bg-emerald-500' : 'bg-outline-variant/30'}`} />}
+              </li>
+            );
+          })}
+        </ol>
+
+        {msg && (
+          <div className={`mb-5 rounded-xl border px-4 py-3 text-sm ${msg.type === 'ok' ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-red-200 bg-red-50 text-red-600'}`}>
+            {msg.text}
+          </div>
+        )}
+
+        <div className="glass-card rounded-3xl p-8" style={{ background: 'rgba(255,255,255,0.85)' }}>
+          <div className="mb-6 flex items-center gap-3">
+            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary"><StepIcon size={20} /></span>
+            <h2 className="font-semibold" style={{ fontFamily: 'Geist' }}>{STEPS[step].label}</h2>
+          </div>
+
+          {/* Paso 1: Período */}
+          {step === 0 && (
+            <div className="flex flex-col gap-4">
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <label className="field-label">Mes</label>
+                  <select value={month} onChange={(e) => setMonth(Number(e.target.value))} className="field-input" disabled={!!reportId}>
+                    {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (
+                      <option key={m} value={m}>{periodLabel(year, m).split(' ')[0]}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="field-label">Año</label>
+                  <input type="number" value={year} min={2020} max={2100} onChange={(e) => setYear(Number(e.target.value))} className="field-input" disabled={!!reportId} />
+                </div>
+              </div>
+              <div>
+                <label className="field-label">Título (opcional)</label>
+                <input value={title} onChange={(e) => setTitle(e.target.value)} placeholder={`Reporte ${periodLabel(year, month)}`} className="field-input" disabled={!!reportId} />
+              </div>
+              <p className="text-xs text-on-surface-variant">Al continuar se crea un borrador que podés editar hasta enviarlo.</p>
+            </div>
+          )}
+
+          {/* Paso 2: Líneas */}
+          {step === 1 && (
+            <div className="flex flex-col gap-4">
+              <div className="grid grid-cols-1 gap-3 rounded-2xl border border-outline-variant/30 p-4 sm:grid-cols-2">
+                <div className="sm:col-span-2">
+                  <label className="field-label">Concepto</label>
+                  <input value={draft.concept} onChange={(e) => setDraft({ ...draft, concept: e.target.value })} placeholder="Ej. Venta de bono SOL-2026-114" className="field-input" />
+                </div>
+                <div>
+                  <label className="field-label">Monto (CRC)</label>
+                  <input type="number" value={draft.amount} onChange={(e) => setDraft({ ...draft, amount: e.target.value })} className="field-input" />
+                </div>
+                <div>
+                  <label className="field-label">Categoría</label>
+                  <select value={draft.category} onChange={(e) => setDraft({ ...draft, category: e.target.value as ReportLineCategory })} className="field-input">
+                    {CATEGORIES.map((c) => <option key={c} value={c}>{CATEGORY_LABEL[c]}</option>)}
+                  </select>
+                </div>
+                <div className="sm:col-span-2">
+                  <label className="field-label">Bono declarado (opcional)</label>
+                  <select value={draft.bondTokenId} onChange={(e) => setDraft({ ...draft, bondTokenId: e.target.value })} className="field-input">
+                    <option value="">— Sin bono —</option>
+                    {bonds.map((b: any) => <option key={b.token_id} value={b.token_id}>{b.bond_id} · {fmtCRC(b.face_value)}</option>)}
+                  </select>
+                </div>
+                <div className="sm:col-span-2">
+                  <button onClick={addLine} disabled={busy} className="btn-action justify-center py-2.5"><Plus size={14} /> Agregar línea</button>
+                </div>
+              </div>
+
+              {items.length === 0 ? (
+                <p className="rounded-2xl border-2 border-dashed border-outline-variant/30 p-6 text-center text-sm text-on-surface-variant">Sin líneas todavía. Agregá al menos una para poder enviar.</p>
+              ) : (
+                <div className="overflow-hidden rounded-2xl border border-outline-variant/30">
+                  <table className="w-full text-sm">
+                    <thead className="bg-surface-container-low text-left text-xs text-on-surface-variant">
+                      <tr><th className="p-3">Concepto</th><th className="p-3">Categoría</th><th className="p-3 text-right">Monto</th><th className="p-3" /></tr>
+                    </thead>
+                    <tbody>
+                      {items.map((it) => (
+                        <tr key={it.id} className="border-t border-outline-variant/20">
+                          <td className="p-3">{it.concept}</td>
+                          <td className="p-3">{CATEGORY_LABEL[it.category]}</td>
+                          <td className="p-3 text-right font-mono">{fmtCRC(it.amount)}</td>
+                          <td className="p-3 text-right"><button onClick={() => removeLine(it.id)} className="text-red-500 hover:text-red-700" aria-label="Eliminar"><Trash2 size={15} /></button></td>
+                        </tr>
+                      ))}
+                      <tr className="border-t border-outline-variant/30 bg-surface-container-low font-semibold">
+                        <td className="p-3" colSpan={2}>Total declarado</td>
+                        <td className="p-3 text-right font-mono">{fmtCRC(total)}</td>
+                        <td />
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Paso 3: Archivos */}
+          {step === 2 && (
+            <div className="flex flex-col gap-4">
+              <label className="flex cursor-pointer flex-col items-center gap-2 rounded-2xl border-2 border-dashed border-outline-variant/40 p-8 text-center hover:bg-surface-container-low">
+                <Paperclip size={22} className="text-primary" />
+                <span className="text-sm font-medium">Adjuntar archivo (PDF, CSV, XLSX, imagen)</span>
+                <span className="text-xs text-on-surface-variant">Máx. 10 MB. Se valida con antivirus antes de guardar.</span>
+                <input type="file" className="hidden" onChange={onUpload} accept=".pdf,.csv,.xlsx,image/png,image/jpeg" disabled={busy} />
+              </label>
+              {files.length === 0 ? (
+                <p className="text-center text-sm text-on-surface-variant">No hay archivos adjuntos (opcional).</p>
+              ) : (
+                <ul className="flex flex-col gap-2">
+                  {files.map((f) => (
+                    <li key={f.id} className="flex items-center justify-between rounded-xl border border-outline-variant/30 bg-white px-4 py-2.5 text-sm">
+                      <span className="flex items-center gap-2"><Paperclip size={14} className="text-primary" /> {f.fileName}</span>
+                      <span className="flex items-center gap-1 text-xs text-emerald-600"><CheckCircle size={12} /> limpio</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {/* Paso 4: Conciliación */}
+          {step === 3 && (
+            <div className="flex flex-col gap-4">
+              {!recon ? (
+                <p className="text-center text-sm text-on-surface-variant">Cargando conciliación…</p>
+              ) : recon.status === 'clean' ? (
+                <div className="flex items-center gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-emerald-700">
+                  <CheckCircle size={22} />
+                  <div>
+                    <p className="font-semibold">Sin discrepancias</p>
+                    <p className="text-xs">Lo declarado coincide con los bonos que tenés en cadena ({fmtCRC(recon.actualTotal)}).</p>
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-center gap-3 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-amber-700">
+                    <AlertTriangle size={22} />
+                    <div>
+                      <p className="font-semibold">{recon.discrepancies.length} discrepancia(s) detectada(s)</p>
+                      <p className="text-xs">Declarado {fmtCRC(recon.declaredTotal)} · En cadena {fmtCRC(recon.actualTotal)}. Podés enviar igual; el TSE las verá.</p>
+                    </div>
+                  </div>
+                  <ul className="flex flex-col gap-2">
+                    {recon.discrepancies.map((d, i) => (
+                      <li key={i} className="rounded-xl border border-outline-variant/30 bg-white p-3 text-xs">
+                        <span className="font-mono font-semibold text-primary">{d.bondTokenId.slice(0, 8)}…</span>
+                        <span className="ml-2 text-on-surface-variant">{d.message}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
+            </div>
+          )}
+
+          {/* Paso 5: Revisar y enviar */}
+          {step === 4 && (
+            <div className="flex flex-col gap-4">
+              <dl className="grid grid-cols-2 gap-3 text-sm">
+                <div><dt className="text-xs text-on-surface-variant">Período</dt><dd className="font-semibold">{periodLabel(year, month)}</dd></div>
+                <div><dt className="text-xs text-on-surface-variant">Líneas</dt><dd className="font-semibold">{items.length}</dd></div>
+                <div><dt className="text-xs text-on-surface-variant">Total declarado</dt><dd className="font-mono font-semibold">{fmtCRC(total)}</dd></div>
+                <div><dt className="text-xs text-on-surface-variant">Archivos</dt><dd className="font-semibold">{files.length}</dd></div>
+                <div className="col-span-2">
+                  <dt className="text-xs text-on-surface-variant">Conciliación</dt>
+                  <dd className="font-semibold">{recon ? (recon.status === 'clean' ? 'Sin discrepancias' : `${recon.discrepancies.length} discrepancia(s)`) : 'No revisada'}</dd>
+                </div>
+              </dl>
+              {items.length === 0 && <p className="text-sm text-red-600">Agregá al menos una línea antes de enviar.</p>}
+              <button onClick={submit} disabled={busy || items.length === 0} className="btn-action justify-center py-3">
+                {busy ? <><span className="btn-spinner" /> Enviando…</> : <><Send size={14} /> Enviar al TSE</>}
+              </button>
+            </div>
+          )}
+
+          {/* Navegación */}
+          <div className="mt-8 flex items-center justify-between border-t border-outline-variant/20 pt-5">
+            <button
+              onClick={() => setStep((s) => Math.max(0, s - 1))}
+              disabled={step === 0 || busy}
+              className="flex items-center gap-1 rounded-full px-4 py-2 text-sm text-on-surface-variant hover:bg-surface-container-low disabled:opacity-40"
+            >
+              <ArrowLeft size={15} /> Atrás
+            </button>
+            {step < STEPS.length - 1 && (
+              <button
+                onClick={() => {
+                  if (step === 0) return goToLineItems();
+                  if (step === 2) return loadReconciliation();
+                  setStep((s) => s + 1);
+                }}
+                disabled={busy}
+                className="btn-action px-5 py-2"
+              >
+                Continuar <ArrowRight size={15} />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </PartidoShell>
+  );
+}

--- a/apps/web/app/partido/reportes/page.tsx
+++ b/apps/web/app/partido/reportes/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { FileText, Send, CheckCircle, AlertCircle, Clock } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { FileText, Send, CheckCircle, AlertCircle, Clock, ClipboardList, ArrowRight } from 'lucide-react';
 import { PartidoShell } from '../../../components/PartidoShell';
 import { useSession, apiFetch } from '../../../lib/api';
 import { unwrapPaginated } from '../../../lib/pagination';
+import { clientCompliance, COMPLIANCE_LABEL, COMPLIANCE_STYLE, periodLabel } from '../../../lib/reports';
 import { createReportRequestSchema, type FieldErrors } from '@velar/types';
 import { validateSchemaForm } from '../../../lib/forms/schema-form';
 import { SchemaFieldError, schemaFieldProps } from '../../../components/SchemaFieldError';
@@ -20,6 +22,7 @@ const STATUS: Record<string, [string, string, any]> = {
 };
 
 export default function PartidoReportesPage() {
+  const router = useRouter();
   const { token, me, loading, error } = useSession();
   const [reports, setReports] = useState<any[]>([]);
   const [bonds, setBonds] = useState<any[]>([]);
@@ -79,6 +82,22 @@ export default function PartidoReportesPage() {
       </header>
 
       <div className="mx-auto w-full max-w-[1100px] p-10 pb-20">
+        {/* Reporte mensual estructurado (ciclo de vida completo) */}
+        <button
+          onClick={() => router.push('/partido/reportes/nuevo')}
+          className="glass-card mb-8 flex w-full items-center justify-between rounded-3xl p-6 text-left transition hover:shadow-lg"
+          style={{ background: 'linear-gradient(135deg, rgba(59,130,246,0.08), rgba(255,255,255,0.9))' }}
+        >
+          <div className="flex items-center gap-4">
+            <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary"><ClipboardList size={24} /></span>
+            <div>
+              <h2 className="font-semibold" style={{ fontFamily: 'Geist' }}>Reporte mensual estructurado</h2>
+              <p className="text-xs text-on-surface-variant">Líneas, archivos, conciliación on-chain y control de vencimientos.</p>
+            </div>
+          </div>
+          <span className="flex items-center gap-1 rounded-full bg-primary px-4 py-2 text-sm font-medium text-white">Crear <ArrowRight size={15} /></span>
+        </button>
+
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-5">
           {/* Formulario */}
           <div className="lg:col-span-3">
@@ -162,19 +181,34 @@ export default function PartidoReportesPage() {
               <div className="flex flex-col gap-3">
                 {reports.map((r) => {
                   const [cls, lbl, Icon] = STATUS[r.status] ?? ['bg-gray-100 text-gray-600 border-gray-200', r.status, Clock];
+                  const comp = r.period_year && r.period_month
+                    ? clientCompliance(r.period_year, r.period_month, r.submitted_at ?? null)
+                    : null;
                   return (
-                    <div key={r.id} className="glass-card rounded-2xl p-4">
+                    <div
+                      key={r.id}
+                      onClick={() => router.push(`/partido/reportes/${r.id}`)}
+                      className="glass-card cursor-pointer rounded-2xl p-4 transition hover:shadow-md"
+                    >
                       <div className="mb-1 flex items-center justify-between">
                         <p className="font-semibold">{r.title}</p>
                         <span className={`flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium ${cls}`}>
                           <Icon size={11} /> {lbl}
                         </span>
                       </div>
+                      {r.period_year && r.period_month && (
+                        <p className="mb-1 text-[11px] font-medium text-primary">{periodLabel(r.period_year, r.period_month)}</p>
+                      )}
                       <p className="line-clamp-2 text-xs text-on-surface-variant">{r.description}</p>
-                      <div className="mt-2 flex justify-between text-[11px] text-on-surface-variant">
+                      <div className="mt-2 flex items-center justify-between text-[11px] text-on-surface-variant">
                         <span>{fmtDate(r.created_at)}</span>
                         {r.total_amount && <span className="font-mono font-semibold">{fmtCRC(r.total_amount)}</span>}
                       </div>
+                      {comp && (
+                        <span className={`mt-2 inline-block rounded-full border px-2 py-0.5 text-[10px] font-medium ${COMPLIANCE_STYLE[comp.status]}`}>
+                          {COMPLIANCE_LABEL[comp.status]}
+                        </span>
+                      )}
                       {r.tse_notes && (
                         <div className="mt-2 rounded-lg bg-amber-50 p-2 text-[11px] text-amber-700">
                           <strong>TSE:</strong> {r.tse_notes}

--- a/apps/web/components/NotificationBell.tsx
+++ b/apps/web/components/NotificationBell.tsx
@@ -24,6 +24,10 @@ const LABELS: Record<NotificationType, string> = {
   payment_confirmed: 'Pago confirmado',
   bond_approved: 'Bono aprobado',
   bond_rejected: 'Solicitud de bono rechazada',
+  report_submitted: 'Reporte enviado al TSE',
+  report_observed: 'Reporte observado por el TSE',
+  report_approved: 'Reporte aprobado',
+  report_resubmitted: 'Reporte reenviado',
 };
 
 function str(v: unknown): string | undefined {

--- a/apps/web/lib/contract-client.ts
+++ b/apps/web/lib/contract-client.ts
@@ -63,9 +63,29 @@ function appendQuery(path: string, query?: Record<string, unknown>): string {
   return suffix ? `${path}?${suffix}` : path;
 }
 
-function validationError(issues: Parameters<typeof zodIssuesToFieldErrors>[0], locale: Locale): ContractApiError {
+/**
+ * Normaliza issues de zod v4 (cuyo `path` puede incluir `symbol`) a la forma
+ * ValidationIssue esperada por @velar/types. Espejo del helper del backend.
+ */
+function toValidationIssues(
+  issues: ReadonlyArray<{ code: unknown; message: string; path: ReadonlyArray<PropertyKey> }>,
+): Parameters<typeof zodIssuesToFieldErrors>[0] {
+  return issues.map((issue) => ({
+    code: String(issue.code),
+    message: issue.message,
+    path: issue.path.filter(
+      (segment): segment is string | number =>
+        typeof segment === 'string' || typeof segment === 'number',
+    ),
+  }));
+}
+
+function validationError(
+  issues: ReadonlyArray<{ code: unknown; message: string; path: ReadonlyArray<PropertyKey> }>,
+  locale: Locale,
+): ContractApiError {
   return new ContractApiError(createApiError(ErrorCode.VALIDATION_ERROR, locale, {
-    fields: zodIssuesToFieldErrors(issues, locale),
+    fields: zodIssuesToFieldErrors(toValidationIssues(issues), locale),
   }).error);
 }
 
@@ -139,7 +159,7 @@ export async function requestContractPath(
   const output = match.contract.response.safeParse(json);
   if (!output.success) {
     throw new ContractApiError(createApiError(ErrorCode.RESPONSE_VALIDATION_ERROR, locale, {
-      fields: zodIssuesToFieldErrors(output.error.issues, locale),
+      fields: zodIssuesToFieldErrors(toValidationIssues(output.error.issues), locale),
       details: output.error.issues.map((issue) => ({ code: issue.code, path: issue.path })),
     }).error);
   }

--- a/apps/web/lib/reports.ts
+++ b/apps/web/lib/reports.ts
@@ -1,0 +1,140 @@
+'use client';
+/**
+ * Helpers de UI para el ciclo de vida del reporte mensual del partido.
+ * La lógica dura vive en el backend; acá solo hay formato, etiquetas y una
+ * copia mínima del cálculo de vencimiento para pintar badges sin ida al server.
+ */
+import { API_URL } from './api';
+import type {
+  ComplianceStatus,
+  ReportStatus,
+  ReportLineCategory,
+} from '@velar/types';
+
+export const MONTHS_ES = [
+  'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+  'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+];
+
+export const STATUS_LABEL: Record<string, string> = {
+  borrador: 'Borrador',
+  enviado: 'Enviado',
+  en_revision: 'En revisión',
+  revisado: 'Revisado',
+  observado: 'Observado',
+  reenviado: 'Reenviado',
+  aprobado: 'Aprobado',
+};
+
+export const STATUS_STYLE: Record<string, string> = {
+  borrador: 'bg-gray-100 text-gray-600 border-gray-200',
+  enviado: 'bg-blue-50 text-primary border-blue-200',
+  en_revision: 'bg-indigo-50 text-indigo-700 border-indigo-200',
+  revisado: 'bg-amber-50 text-amber-700 border-amber-200',
+  observado: 'bg-red-50 text-red-600 border-red-200',
+  reenviado: 'bg-blue-50 text-primary border-blue-200',
+  aprobado: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+};
+
+export const CATEGORY_LABEL: Record<ReportLineCategory, string> = {
+  ingreso: 'Ingreso',
+  egreso: 'Egreso',
+  donacion: 'Donación',
+  bono: 'Bono',
+  otro: 'Otro',
+};
+
+export const COMPLIANCE_LABEL: Record<ComplianceStatus, string> = {
+  not_due: 'A tiempo',
+  on_time: 'Enviado a tiempo',
+  late: 'Enviado tarde',
+  overdue: 'Vencido',
+  missing: 'Sin enviar',
+};
+
+export const COMPLIANCE_STYLE: Record<ComplianceStatus, string> = {
+  not_due: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  on_time: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  late: 'bg-amber-50 text-amber-700 border-amber-200',
+  overdue: 'bg-red-50 text-red-600 border-red-200',
+  missing: 'bg-red-50 text-red-600 border-red-200',
+};
+
+export const fmtCRC = (n?: number | null) =>
+  n == null
+    ? 'Sin dato'
+    : new Intl.NumberFormat('es-CR', {
+        style: 'currency',
+        currency: 'CRC',
+        maximumFractionDigits: 0,
+      }).format(n);
+
+export const fmtDate = (d?: string | null) =>
+  d
+    ? new Date(d).toLocaleDateString('es-CR', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+      })
+    : '—';
+
+export function periodLabel(year: number, month: number) {
+  return `${MONTHS_ES[(month - 1) % 12]} ${year}`;
+}
+
+/**
+ * Copia mínima del cálculo de cumplimiento (default: vence el 15 del mes
+ * siguiente, 5 días de gracia). Espejo de la lógica pura del backend para
+ * pintar badges en el cliente.
+ */
+export function clientCompliance(
+  periodYear: number,
+  periodMonth: number,
+  submittedAt: string | null,
+  now: Date = new Date(),
+): { status: ComplianceStatus; dueDate: string; daysRemaining: number | null } {
+  const dueYear = periodMonth === 12 ? periodYear + 1 : periodYear;
+  const dueMonth = periodMonth === 12 ? 1 : periodMonth + 1;
+  const due = new Date(Date.UTC(dueYear, dueMonth - 1, 15));
+  const graceEnd = new Date(due.getTime() + 5 * 86_400_000);
+  const dueDate = due.toISOString().slice(0, 10);
+  const dayMs = 86_400_000;
+  const nowUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+
+  if (submittedAt) {
+    const sub = new Date(submittedAt);
+    const subUtc = Date.UTC(sub.getUTCFullYear(), sub.getUTCMonth(), sub.getUTCDate());
+    return {
+      status: subUtc <= due.getTime() ? 'on_time' : 'late',
+      dueDate,
+      daysRemaining: null,
+    };
+  }
+  const daysRemaining = Math.round((due.getTime() - nowUtc) / dayMs);
+  let status: ComplianceStatus;
+  if (daysRemaining >= 0) status = 'not_due';
+  else if (nowUtc <= graceEnd.getTime()) status = 'overdue';
+  else status = 'missing';
+  return { status, dueDate, daysRemaining };
+}
+
+/** Subida multipart de un archivo del reporte (apiFetch usa JSON; esto usa FormData). */
+export async function uploadReportFile(token: string, reportId: string, file: File) {
+  const form = new FormData();
+  form.append('file', file);
+  const res = await fetch(
+    `${API_URL.replace(/\/$/, '')}/reports/lifecycle/${reportId}/files`,
+    { method: 'POST', headers: { Authorization: `Bearer ${token}` }, body: form },
+  );
+  if (!res.ok) {
+    const json = await res.json().catch(() => ({}));
+    const msg =
+      (json?.error?.message as string) ??
+      (json?.message as string) ??
+      `Error ${res.status} al subir el archivo`;
+    throw new Error(Array.isArray(msg) ? msg.join(', ') : msg);
+  }
+  return res.json();
+}
+
+export type { ReportStatus };

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -259,3 +259,60 @@ npm run test --workspace apps/api -- --runInBand
 
 Las pruebas `common/contracts/*.spec.ts` validan payloads válidos/inválidos por cada módulo,
 localización, drift de responses y que toda ruta JSON de los controladores cubiertos tenga contrato.
+
+## 7. Reporte mensual: ciclo de vida y motor de cumplimiento (issue #40)
+
+El módulo `reports` original solo guardaba metadata de texto libre. Se **extendió**
+(sin reescribir lo anterior) a un reporte estructurado, versionado, con archivos y
+conciliación contra los bonos que el partido posee on-chain. La lógica de negocio
+central vive en **funciones puras** (`apps/api/src/reports/domain/`), probadas por
+fixtures y sin acceso a DB.
+
+### Esquema (migración `20260701000000_report_lifecycle_compliance.sql`)
+- `reports`: se le agregan `period_year`, `period_month`, `current_version`,
+  `submitted_at`; el `CHECK` de `status` se amplía al workflow completo. Único por
+  `(party_id, period_year, period_month)`.
+- `report_line_items`: concepto, monto, categoría (`ingreso|egreso|donacion|bono|otro`)
+  y `bond_token_id` opcional (referencia declarada a un bono).
+- `report_files`: metadata del adjunto (`file_path`, `checksum` sha-256, `scan_status`).
+  El binario vive en el bucket privado `report-files` (`<party_id>/<report_id>/<file>`).
+- `report_versions`: snapshot inmutable por envío (**append-only** vía trigger
+  `deny_report_version_mutation`, igual que `audit_events`).
+- `report_deadlines`: config de vencimientos (`due_day_of_month`, `grace_days`).
+- RLS: el partido ve solo lo suyo; TSE/admin ven todo. Subida al bucket solo rol
+  `emisor` a su carpeta.
+
+### Workflow (`domain/workflow.ts`)
+`borrador → enviado → en_revision → observado → reenviado → en_revision → aprobado`.
+`aprobado` es terminal. `assertTransition` rechaza saltos ilegales; `resolveSubmit`
+codifica primer envío (`borrador→enviado`) vs corrección (`observado→reenviado`,
+que bumpea versión y preserva historial). Solo `borrador` y `observado` son editables.
+
+### Conciliación (`domain/reconciliation.ts`)
+Función pura `reconcile(declarados, poseídos)` que cruza las referencias de bono
+declaradas contra los bonos que el partido tiene en cadena y emite discrepancias
+tipadas: `amount_mismatch`, `missing_bond`, `unknown_reference`. Agrega montos por
+bono y tolera ruido flotante sub-centavo. Determinística.
+
+### Vencimientos (`domain/deadlines.ts`)
+`computeCompliance` deriva el estado del período (`not_due | on_time | late |
+overdue | missing`) y los días restantes a partir de la config, la fecha de envío y
+un "hoy" de referencia. Un reporte vence el `due_day_of_month` del mes siguiente.
+
+### Antivirus (`files/file-scanner.ts`)
+Hook detrás de la interfaz `FileScanner` (token DI `FILE_SCANNER`). El default es
+`StubFileScanner` (marca EICAR como infectado, el resto limpio) — sin vendor real.
+Se reemplaza por ClamAV/VirusTotal sin tocar el resto del módulo.
+
+### Endpoints (`reports/lifecycle`, todos con `@Roles('emisor')` en mutaciones)
+- `POST /reports/lifecycle` — crea borrador
+- `POST /reports/lifecycle/:id/line-items` · `DELETE .../:lineItemId` · `GET .../line-items`
+- `POST /reports/lifecycle/:id/files` (multipart, valida tipo/tamaño + checksum + antivirus)
+- `GET /reports/lifecycle/:id/reconciliation` — preview de discrepancias
+- `POST /reports/lifecycle/:id/submit` — envía/reenvía: snapshot inmutable, audita
+  (`report_version_created` + `report_submitted`/`report_resubmitted`) y notifica al
+  partido y al TSE
+- `GET /reports/lifecycle/:id` — detalle con líneas, archivos, versiones y conciliación
+
+El TSE (revisión/observación/aprobación) es un **epic aparte**; este issue cubre el
+lado del partido y el dominio compartido de reporte/conciliación.

--- a/docs/FRONTEND_GUIDE.md
+++ b/docs/FRONTEND_GUIDE.md
@@ -252,3 +252,37 @@ npm run build --workspace apps/web
 
 Las pruebas del cliente usan `fetch` simulado y las pruebas de formularios son puras; ninguna
 requiere Supabase, VELAR DB, wallets ni proveedores externos.
+
+## 11. Reporte mensual del partido (issue #40)
+
+Pantallas en `apps/web/app/partido/reportes/` (rol `emisor`). Helpers de UI en
+`lib/reports.ts` (etiquetas de estado/categoría/cumplimiento, formato CRC/fecha,
+espejo cliente del cálculo de vencimiento y `uploadReportFile` multipart).
+
+### Builder multi-paso — `reportes/nuevo`
+Cinco pasos: **Período → Líneas → Archivos → Conciliación → Revisar**.
+- Al pasar de "Período" se crea el borrador (`POST /reports/lifecycle`).
+- Líneas: alta/baja con total corriente y selector de bono declarado
+  (`POST`/`DELETE /reports/lifecycle/:id/line-items`).
+- Archivos: subida multipart (`uploadReportFile`); el backend valida tipo/tamaño,
+  calcula checksum y pasa el antivirus antes de guardar.
+- Conciliación: preview de discrepancias (`GET /reports/lifecycle/:id/reconciliation`)
+  antes de enviar. Se puede enviar con discrepancias; el TSE las verá.
+- Revisar → `POST /reports/lifecycle/:id/submit` y redirige al detalle.
+
+### Detalle e historial — `reportes/[id]`
+`GET /reports/lifecycle/:id` (líneas, archivos, versiones, conciliación).
+- Badge de estado + badge de cumplimiento (vence el 15 del mes siguiente, 5 días
+  de gracia; espejo de la lógica pura del backend).
+- **Timeline de versiones**: cada envío con su estado, fecha, total y resultado de
+  conciliación (los snapshots son inmutables).
+- **Corrección guiada**: si el estado es `observado`, se muestra la observación del
+  TSE, se pueden agregar líneas y **reenviar** (nueva versión, conserva historial).
+
+### Listado — `reportes`
+CTA hacia el builder estructurado, badges de cumplimiento por período y tarjetas
+que enlazan al detalle. Convive con el formulario legacy de reporte de texto libre.
+
+### Estados a manejar
+Localizado (es), responsive y accesible; con estados de carga, vacío y error en cada
+pantalla. Nunca se usa `service_role` ni secretos en el cliente.

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -21,6 +21,12 @@ export const AuditEventType = {
   WALLET_PROVISIONED: 'wallet_provisioned',
   BOND_PUBLISHED: 'bond_published',
   COUNTER_OFFER_SENT: 'counter_offer_sent',
+  REPORT_SUBMITTED: 'report_submitted',
+  REPORT_RESUBMITTED: 'report_resubmitted',
+  REPORT_VERSION_CREATED: 'report_version_created',
+  REPORT_OBSERVED: 'report_observed',
+  REPORT_APPROVED: 'report_approved',
+  REPORT_FILE_UPLOADED: 'report_file_uploaded',
 } as const;
 
 export type AuditEventType =

--- a/packages/types/src/errors.ts
+++ b/packages/types/src/errors.ts
@@ -91,7 +91,7 @@ export interface ValidationIssue {
 export const contractErrorSchema = z.object({
   code: errorCodeSchema,
   message: z.string().min(1),
-  fields: z.record(z.array(z.string())).optional(),
+  fields: z.record(z.string(), z.array(z.string())).optional(),
   details: z.unknown().optional(),
   requestId: z.string().optional(),
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,6 +3,7 @@ export * from './country';
 export * from './bond';
 export * from './transfer';
 export * from './audit';
+export * from './report';
 export * from './escrow';
 export * from './api';
 export * from './notification';

--- a/packages/types/src/notification.ts
+++ b/packages/types/src/notification.ts
@@ -10,6 +10,10 @@ export const NotificationType = {
   PAYMENT_CONFIRMED: 'payment_confirmed',
   BOND_APPROVED: 'bond_approved',
   BOND_REJECTED: 'bond_rejected',
+  REPORT_SUBMITTED: 'report_submitted',
+  REPORT_OBSERVED: 'report_observed',
+  REPORT_APPROVED: 'report_approved',
+  REPORT_RESUBMITTED: 'report_resubmitted',
 } as const;
 
 export type NotificationType = (typeof NotificationType)[keyof typeof NotificationType];

--- a/packages/types/src/report.ts
+++ b/packages/types/src/report.ts
@@ -1,0 +1,248 @@
+/**
+ * Reporte mensual del partido al TSE — ciclo de vida completo, versionado y
+ * motor de conciliación contra los bonos que el partido realmente posee on-chain.
+ *
+ * Esta es la FUENTE DE VERDAD del dominio de reportes: la comparten `apps/api`
+ * (lógica y persistencia) y `apps/web` (builder multi-paso e historial). El
+ * módulo `reports` original solo guardaba metadata de texto libre; esto lo
+ * extiende a un reporte estructurado, con archivos, líneas y conciliación.
+ */
+
+// ---------------------------------------------------------------------------
+// Estados del workflow
+// ---------------------------------------------------------------------------
+
+/**
+ * Ciclo legal del reporte:
+ *   borrador → enviado → en_revision → observado → reenviado → (en_revision) → aprobado
+ *
+ * `aprobado` es terminal. `observado` es la vía de corrección: el partido
+ * reenvía (nueva versión) y vuelve a revisión.
+ */
+export const ReportStatus = {
+  BORRADOR: 'borrador',
+  ENVIADO: 'enviado',
+  EN_REVISION: 'en_revision',
+  OBSERVADO: 'observado',
+  REENVIADO: 'reenviado',
+  APROBADO: 'aprobado',
+} as const;
+
+export type ReportStatus = (typeof ReportStatus)[keyof typeof ReportStatus];
+
+/** Estados en los que el partido todavía puede editar el borrador/corregir. */
+export const EDITABLE_REPORT_STATUSES: ReportStatus[] = [
+  ReportStatus.BORRADOR,
+  ReportStatus.OBSERVADO,
+];
+
+// ---------------------------------------------------------------------------
+// Líneas del reporte
+// ---------------------------------------------------------------------------
+
+/** Categoría contable de una línea del reporte. */
+export const ReportLineCategory = {
+  INGRESO: 'ingreso',
+  EGRESO: 'egreso',
+  DONACION: 'donacion',
+  BONO: 'bono',
+  OTRO: 'otro',
+} as const;
+
+export type ReportLineCategory =
+  (typeof ReportLineCategory)[keyof typeof ReportLineCategory];
+
+export interface ReportLineItem {
+  id: string;
+  reportId: string;
+  concept: string;
+  amount: number;
+  category: ReportLineCategory;
+  /** Referencia al bono declarado (si la línea corresponde a un bono). */
+  bondTokenId: string | null;
+  createdAt: string;
+}
+
+/** Payload para crear/editar una línea (sin ids ni timestamps). */
+export interface ReportLineItemInput {
+  concept: string;
+  amount: number;
+  category: ReportLineCategory;
+  bondTokenId?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Archivos adjuntos
+// ---------------------------------------------------------------------------
+
+/** Resultado del hook de antivirus (interfaz + stub, sin vendor real). */
+export const FileScanStatus = {
+  PENDING: 'pending',
+  CLEAN: 'clean',
+  INFECTED: 'infected',
+} as const;
+
+export type FileScanStatus =
+  (typeof FileScanStatus)[keyof typeof FileScanStatus];
+
+export interface ReportFile {
+  id: string;
+  reportId: string;
+  /** Ruta dentro del bucket privado de Storage. */
+  filePath: string;
+  fileName: string;
+  mimeType: string;
+  sizeBytes: number;
+  /** SHA-256 en hex del contenido, para integridad. */
+  checksum: string;
+  scanStatus: FileScanStatus;
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Versionado inmutable
+// ---------------------------------------------------------------------------
+
+/** Foto inmutable del reporte al momento de un envío. */
+export interface ReportSnapshot {
+  status: ReportStatus;
+  title: string;
+  periodYear: number;
+  periodMonth: number;
+  lineItems: Omit<ReportLineItem, 'reportId' | 'createdAt'>[];
+  files: Omit<ReportFile, 'reportId' | 'createdAt'>[];
+  declaredTotal: number;
+  reconciliation: ReconciliationResult;
+}
+
+export interface ReportVersion {
+  id: string;
+  reportId: string;
+  version: number;
+  status: ReportStatus;
+  snapshot: ReportSnapshot;
+  createdBy: string;
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Reporte mensual
+// ---------------------------------------------------------------------------
+
+export interface MonthlyReport {
+  id: string;
+  partyId: string;
+  /** Año del período reportado. */
+  periodYear: number;
+  /** Mes del período reportado, 1-12. */
+  periodMonth: number;
+  status: ReportStatus;
+  /** Número de la versión vigente (empieza en 0 mientras es borrador). */
+  currentVersion: number;
+  title: string;
+  submittedBy: string | null;
+  submittedAt: string | null;
+  reviewedBy: string | null;
+  reviewedAt: string | null;
+  tseNotes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Reporte con sus relaciones cargadas, para el detalle/builder. */
+export interface MonthlyReportDetail extends MonthlyReport {
+  lineItems: ReportLineItem[];
+  files: ReportFile[];
+  versions: ReportVersion[];
+  reconciliation: ReconciliationResult;
+}
+
+// ---------------------------------------------------------------------------
+// Motor de conciliación (funciones puras)
+// ---------------------------------------------------------------------------
+
+/** Tipo de discrepancia detectada al conciliar el reporte con la cadena. */
+export const DiscrepancyType = {
+  /** El monto declarado no coincide con el valor del bono en poder del partido. */
+  AMOUNT_MISMATCH: 'amount_mismatch',
+  /** El partido posee un bono que no está declarado en el reporte. */
+  MISSING_BOND: 'missing_bond',
+  /** El reporte referencia un bono que el partido no posee. */
+  UNKNOWN_REFERENCE: 'unknown_reference',
+} as const;
+
+export type DiscrepancyType =
+  (typeof DiscrepancyType)[keyof typeof DiscrepancyType];
+
+export interface Discrepancy {
+  type: DiscrepancyType;
+  bondTokenId: string;
+  /** Monto declarado en el reporte (null si el bono no fue declarado). */
+  declaredAmount: number | null;
+  /** Monto real según la tenencia on-chain (null si no se posee). */
+  actualAmount: number | null;
+  message: string;
+}
+
+/** Un bono declarado en una línea del reporte. */
+export interface DeclaredBondRef {
+  bondTokenId: string;
+  amount: number;
+}
+
+/** Un bono efectivamente en poder del partido (alimentado por fixtures/DB). */
+export interface HeldBond {
+  bondTokenId: string;
+  amount: number;
+}
+
+export interface ReconciliationResult {
+  status: 'clean' | 'discrepancies';
+  discrepancies: Discrepancy[];
+  /** Suma de montos declarados en el reporte. */
+  declaredTotal: number;
+  /** Suma de montos reales de los bonos en poder del partido. */
+  actualTotal: number;
+  /** Cantidad de bonos que coincidieron exactamente. */
+  matchedCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// Deadlines y cumplimiento (funciones puras)
+// ---------------------------------------------------------------------------
+
+/** Estado de cumplimiento de un período. */
+export const ComplianceStatus = {
+  /** Aún no vence. */
+  NOT_DUE: 'not_due',
+  /** Enviado antes del vencimiento. */
+  ON_TIME: 'on_time',
+  /** Enviado después del vencimiento pero dentro de la gracia. */
+  LATE: 'late',
+  /** Vencido y aún no enviado. */
+  OVERDUE: 'overdue',
+  /** Sin enviar y ya fuera de toda gracia. */
+  MISSING: 'missing',
+} as const;
+
+export type ComplianceStatus =
+  (typeof ComplianceStatus)[keyof typeof ComplianceStatus];
+
+/** Config del calendario de vencimientos mensuales. */
+export interface DeadlineConfig {
+  /** Día del mes SIGUIENTE en que vence el reporte de un período. Ej: 15. */
+  dueDayOfMonth: number;
+  /** Días de gracia tras el vencimiento antes de considerarlo "missing". */
+  graceDays: number;
+}
+
+export interface PeriodCompliance {
+  periodYear: number;
+  periodMonth: number;
+  /** Fecha de vencimiento calculada (ISO date, YYYY-MM-DD). */
+  dueDate: string;
+  status: ComplianceStatus;
+  /** Días hasta el vencimiento; negativo si ya pasó. null si ya se envió. */
+  daysRemaining: number | null;
+  submittedAt: string | null;
+}

--- a/packages/types/src/schemas/auth.ts
+++ b/packages/types/src/schemas/auth.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { requiredStringSchema } from './common';
 
-export const perspectiveSchema = z.enum(['usuario', 'partido'], { errorMap: () => ({ message: 'validation.enum' }) });
+export const perspectiveSchema = z.enum(['usuario', 'partido'], { error: 'validation.enum' });
 
 export const loginRequestSchema = z.object({
   email: requiredStringSchema.email('validation.email'),

--- a/packages/types/src/schemas/common.ts
+++ b/packages/types/src/schemas/common.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 import { Role } from '../roles';
 
-export const requiredStringSchema = z.string({ required_error: 'validation.required' }).trim().min(1, 'validation.required');
+export const requiredStringSchema = z.string({ error: 'validation.required' }).trim().min(1, 'validation.required');
 export const idSchema = requiredStringSchema;
 export const isoDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'validation.date');
 export const optionalIsoDateSchema = isoDateSchema.optional();
-export const positiveNumberSchema = z.coerce.number({ invalid_type_error: 'validation.positive' }).finite().positive('validation.positive');
-export const paymentMethodSchema = z.enum(['sinpe', 'transferencia', 'wallet'], { errorMap: () => ({ message: 'validation.enum' }) });
-export const roleSchema = z.nativeEnum(Role, { errorMap: () => ({ message: 'validation.enum' }) });
+export const positiveNumberSchema = z.coerce.number({ error: 'validation.positive' }).finite().positive('validation.positive');
+export const paymentMethodSchema = z.enum(['sinpe', 'transferencia', 'wallet'], { error: 'validation.enum' });
+export const roleSchema = z.nativeEnum(Role, { error: 'validation.enum' });
 export const paramsIdSchema = z.object({ id: idSchema });
 export const paramsTokenIdSchema = z.object({ tokenId: idSchema });
 export const paramsBondTokenIdSchema = z.object({ bondTokenId: idSchema });

--- a/packages/types/src/schemas/notifications.ts
+++ b/packages/types/src/schemas/notifications.ts
@@ -6,7 +6,7 @@ export const notificationRowSchema = z.object({
   id: idSchema,
   user_id: idSchema,
   type: z.nativeEnum(NotificationType),
-  payload: z.record(z.unknown()),
+  payload: z.record(z.string(), z.unknown()),
   read: z.boolean(),
   created_at: z.string(),
 }).passthrough();

--- a/packages/types/src/schemas/reports.ts
+++ b/packages/types/src/schemas/reports.ts
@@ -16,7 +16,7 @@ export const createReportRequestSchema = z.object({
 );
 
 export const reviewReportRequestSchema = z.object({
-  status: z.enum(['revisado', 'observado', 'aprobado'], { errorMap: () => ({ message: 'validation.enum' }) }),
+  status: z.enum(['revisado', 'observado', 'aprobado'], { error: 'validation.enum' }),
   notes: z.string().trim().max(2000).optional(),
 }).strict();
 

--- a/packages/types/types/audit.d.ts
+++ b/packages/types/types/audit.d.ts
@@ -21,6 +21,12 @@ export declare const AuditEventType: {
     readonly WALLET_PROVISIONED: "wallet_provisioned";
     readonly BOND_PUBLISHED: "bond_published";
     readonly COUNTER_OFFER_SENT: "counter_offer_sent";
+    readonly REPORT_SUBMITTED: "report_submitted";
+    readonly REPORT_RESUBMITTED: "report_resubmitted";
+    readonly REPORT_VERSION_CREATED: "report_version_created";
+    readonly REPORT_OBSERVED: "report_observed";
+    readonly REPORT_APPROVED: "report_approved";
+    readonly REPORT_FILE_UPLOADED: "report_file_uploaded";
 };
 export type AuditEventType = (typeof AuditEventType)[keyof typeof AuditEventType];
 export interface AuditEvent {

--- a/packages/types/types/audit.js
+++ b/packages/types/types/audit.js
@@ -24,4 +24,10 @@ exports.AuditEventType = {
     WALLET_PROVISIONED: 'wallet_provisioned',
     BOND_PUBLISHED: 'bond_published',
     COUNTER_OFFER_SENT: 'counter_offer_sent',
+    REPORT_SUBMITTED: 'report_submitted',
+    REPORT_RESUBMITTED: 'report_resubmitted',
+    REPORT_VERSION_CREATED: 'report_version_created',
+    REPORT_OBSERVED: 'report_observed',
+    REPORT_APPROVED: 'report_approved',
+    REPORT_FILE_UPLOADED: 'report_file_uploaded',
 };

--- a/packages/types/types/contracts.d.ts
+++ b/packages/types/types/contracts.d.ts
@@ -10,10 +10,13 @@ export declare const apiContracts: {
         path: string;
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
-        body: z.ZodEffects<z.ZodObject<{
+        body: z.ZodObject<{
             email: z.ZodString;
             password: z.ZodString;
-            perspectiva: z.ZodEnum<["usuario", "partido"]>;
+            perspectiva: z.ZodEnum<{
+                usuario: "usuario";
+                partido: "partido";
+            }>;
             nombres: z.ZodOptional<z.ZodString>;
             apellidos: z.ZodOptional<z.ZodString>;
             identificacion: z.ZodOptional<z.ZodString>;
@@ -23,83 +26,23 @@ export declare const apiContracts: {
             codigo: z.ZodOptional<z.ZodString>;
             representanteLegal: z.ZodOptional<z.ZodString>;
             cedulaJuridica: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            email: string;
-            password: string;
-            perspectiva: "usuario" | "partido";
-            nombres?: string | undefined;
-            apellidos?: string | undefined;
-            identificacion?: string | undefined;
-            telefono?: string | undefined;
-            direccion?: string | undefined;
-            nombrePartido?: string | undefined;
-            codigo?: string | undefined;
-            representanteLegal?: string | undefined;
-            cedulaJuridica?: string | undefined;
-        }, {
-            email: string;
-            password: string;
-            perspectiva: "usuario" | "partido";
-            nombres?: string | undefined;
-            apellidos?: string | undefined;
-            identificacion?: string | undefined;
-            telefono?: string | undefined;
-            direccion?: string | undefined;
-            nombrePartido?: string | undefined;
-            codigo?: string | undefined;
-            representanteLegal?: string | undefined;
-            cedulaJuridica?: string | undefined;
-        }>, {
-            email: string;
-            password: string;
-            perspectiva: "usuario" | "partido";
-            nombres?: string | undefined;
-            apellidos?: string | undefined;
-            identificacion?: string | undefined;
-            telefono?: string | undefined;
-            direccion?: string | undefined;
-            nombrePartido?: string | undefined;
-            codigo?: string | undefined;
-            representanteLegal?: string | undefined;
-            cedulaJuridica?: string | undefined;
-        }, {
-            email: string;
-            password: string;
-            perspectiva: "usuario" | "partido";
-            nombres?: string | undefined;
-            apellidos?: string | undefined;
-            identificacion?: string | undefined;
-            telefono?: string | undefined;
-            direccion?: string | undefined;
-            nombrePartido?: string | undefined;
-            codigo?: string | undefined;
-            representanteLegal?: string | undefined;
-            cedulaJuridica?: string | undefined;
-        }>;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             email: z.ZodString;
-            role: z.ZodEnum<["comprador", "emisor"]>;
-            perspectiva: z.ZodEnum<["usuario", "partido"]>;
+            role: z.ZodEnum<{
+                emisor: "emisor";
+                comprador: "comprador";
+            }>;
+            perspectiva: z.ZodEnum<{
+                usuario: "usuario";
+                partido: "partido";
+            }>;
             partyId: z.ZodNullable<z.ZodString>;
             wallet: z.ZodNullable<z.ZodString>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            email: z.ZodString;
-            role: z.ZodEnum<["comprador", "emisor"]>;
-            perspectiva: z.ZodEnum<["usuario", "partido"]>;
-            partyId: z.ZodNullable<z.ZodString>;
-            wallet: z.ZodNullable<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            email: z.ZodString;
-            role: z.ZodEnum<["comprador", "emisor"]>;
-            perspectiva: z.ZodEnum<["usuario", "partido"]>;
-            partyId: z.ZodNullable<z.ZodString>;
-            wallet: z.ZodNullable<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'auth.login': {
         method: HttpMethod;
@@ -109,34 +52,16 @@ export declare const apiContracts: {
         body: z.ZodObject<{
             email: z.ZodString;
             password: z.ZodString;
-        }, "strict", z.ZodTypeAny, {
-            email: string;
-            password: string;
-        }, {
-            email: string;
-            password: string;
-        }>;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             access_token: z.ZodString;
             refresh_token: z.ZodString;
             expires_in: z.ZodNumber;
             token_type: z.ZodString;
             user: z.ZodUnknown;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            access_token: z.ZodString;
-            refresh_token: z.ZodString;
-            expires_in: z.ZodNumber;
-            token_type: z.ZodString;
-            user: z.ZodUnknown;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            access_token: z.ZodString;
-            refresh_token: z.ZodString;
-            expires_in: z.ZodNumber;
-            token_type: z.ZodString;
-            user: z.ZodUnknown;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.list': {
         method: HttpMethod;
@@ -144,27 +69,19 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodUndefined;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        params: z.ZodObject<{}, z.core.$strict>;
         query: z.ZodObject<{
-            page: z.ZodOptional<z.ZodNumber>;
-            limit: z.ZodOptional<z.ZodNumber>;
+            page: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
+            limit: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
             country: z.ZodOptional<z.ZodString>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            page: z.ZodOptional<z.ZodNumber>;
-            limit: z.ZodOptional<z.ZodNumber>;
-            country: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            page: z.ZodOptional<z.ZodNumber>;
-            limit: z.ZodOptional<z.ZodNumber>;
-            country: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
         response: z.ZodObject<{
             data: z.ZodArray<z.ZodObject<{
                 token_id: z.ZodString;
                 bond_id: z.ZodString;
                 issuer_party_id: z.ZodString;
                 current_owner: z.ZodNullable<z.ZodString>;
-                status: z.ZodNativeEnum<{
+                status: z.ZodEnum<{
                     readonly EMITIDO: "emitido";
                     readonly PENDIENTE: "pendiente";
                     readonly APROBADO: "aprobado";
@@ -178,18 +95,22 @@ export declare const apiContracts: {
                 }>;
                 document_hash: z.ZodString;
                 metadata_uri: z.ZodNullable<z.ZodString>;
-                face_value: z.ZodNullable<z.ZodNumber>;
+                face_value: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
                 certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
                 currency: z.ZodOptional<z.ZodString>;
-                interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+                interest_rate: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
                 series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
                 issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
                 maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
                 country: z.ZodOptional<z.ZodString>;
-                payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
+                payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+                    sinpe: "sinpe";
+                    transferencia: "transferencia";
+                    wallet: "wallet";
+                }>>>;
                 stellar_status: z.ZodOptional<z.ZodString>;
                 stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+                stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
                 stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
                 stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
                 stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -197,173 +118,11 @@ export declare const apiContracts: {
                 stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
                 created_at: z.ZodString;
                 updated_at: z.ZodString;
-            }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-                token_id: z.ZodString;
-                bond_id: z.ZodString;
-                issuer_party_id: z.ZodString;
-                current_owner: z.ZodNullable<z.ZodString>;
-                status: z.ZodNativeEnum<{
-                    readonly EMITIDO: "emitido";
-                    readonly PENDIENTE: "pendiente";
-                    readonly APROBADO: "aprobado";
-                    readonly ACTIVO: "activo";
-                    readonly EN_VENTA: "en_venta";
-                    readonly EN_ESCROW: "en_escrow";
-                    readonly TRANSFERIDO: "transferido";
-                    readonly CANCELADO: "cancelado";
-                    readonly RECHAZADO: "rechazado";
-                    readonly CONGELADO: "congelado";
-                }>;
-                document_hash: z.ZodString;
-                metadata_uri: z.ZodNullable<z.ZodString>;
-                face_value: z.ZodNullable<z.ZodNumber>;
-                certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                currency: z.ZodOptional<z.ZodString>;
-                interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                country: z.ZodOptional<z.ZodString>;
-                payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-                stellar_status: z.ZodOptional<z.ZodString>;
-                stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-                token_id: z.ZodString;
-                bond_id: z.ZodString;
-                issuer_party_id: z.ZodString;
-                current_owner: z.ZodNullable<z.ZodString>;
-                status: z.ZodNativeEnum<{
-                    readonly EMITIDO: "emitido";
-                    readonly PENDIENTE: "pendiente";
-                    readonly APROBADO: "aprobado";
-                    readonly ACTIVO: "activo";
-                    readonly EN_VENTA: "en_venta";
-                    readonly EN_ESCROW: "en_escrow";
-                    readonly TRANSFERIDO: "transferido";
-                    readonly CANCELADO: "cancelado";
-                    readonly RECHAZADO: "rechazado";
-                    readonly CONGELADO: "congelado";
-                }>;
-                document_hash: z.ZodString;
-                metadata_uri: z.ZodNullable<z.ZodString>;
-                face_value: z.ZodNullable<z.ZodNumber>;
-                certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                currency: z.ZodOptional<z.ZodString>;
-                interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                country: z.ZodOptional<z.ZodString>;
-                payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-                stellar_status: z.ZodOptional<z.ZodString>;
-                stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">>, "many">;
+            }, z.core.$loose>>;
             total: z.ZodNumber;
             page: z.ZodNumber;
             limit: z.ZodNumber;
-        }, "strip", z.ZodTypeAny, {
-            page: number;
-            limit: number;
-            data: z.objectOutputType<{
-                token_id: z.ZodString;
-                bond_id: z.ZodString;
-                issuer_party_id: z.ZodString;
-                current_owner: z.ZodNullable<z.ZodString>;
-                status: z.ZodNativeEnum<{
-                    readonly EMITIDO: "emitido";
-                    readonly PENDIENTE: "pendiente";
-                    readonly APROBADO: "aprobado";
-                    readonly ACTIVO: "activo";
-                    readonly EN_VENTA: "en_venta";
-                    readonly EN_ESCROW: "en_escrow";
-                    readonly TRANSFERIDO: "transferido";
-                    readonly CANCELADO: "cancelado";
-                    readonly RECHAZADO: "rechazado";
-                    readonly CONGELADO: "congelado";
-                }>;
-                document_hash: z.ZodString;
-                metadata_uri: z.ZodNullable<z.ZodString>;
-                face_value: z.ZodNullable<z.ZodNumber>;
-                certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                currency: z.ZodOptional<z.ZodString>;
-                interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                country: z.ZodOptional<z.ZodString>;
-                payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-                stellar_status: z.ZodOptional<z.ZodString>;
-                stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">[];
-            total: number;
-        }, {
-            page: number;
-            limit: number;
-            data: z.objectInputType<{
-                token_id: z.ZodString;
-                bond_id: z.ZodString;
-                issuer_party_id: z.ZodString;
-                current_owner: z.ZodNullable<z.ZodString>;
-                status: z.ZodNativeEnum<{
-                    readonly EMITIDO: "emitido";
-                    readonly PENDIENTE: "pendiente";
-                    readonly APROBADO: "aprobado";
-                    readonly ACTIVO: "activo";
-                    readonly EN_VENTA: "en_venta";
-                    readonly EN_ESCROW: "en_escrow";
-                    readonly TRANSFERIDO: "transferido";
-                    readonly CANCELADO: "cancelado";
-                    readonly RECHAZADO: "rechazado";
-                    readonly CONGELADO: "congelado";
-                }>;
-                document_hash: z.ZodString;
-                metadata_uri: z.ZodNullable<z.ZodString>;
-                face_value: z.ZodNullable<z.ZodNumber>;
-                certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                currency: z.ZodOptional<z.ZodString>;
-                interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                country: z.ZodOptional<z.ZodString>;
-                payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-                stellar_status: z.ZodOptional<z.ZodString>;
-                stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">[];
-            total: number;
-        }>;
+        }, z.core.$strip>;
     };
     readonly 'bonds.requests.list': {
         method: HttpMethod;
@@ -371,148 +130,64 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodUndefined;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodArray<z.ZodObject<{
             id: z.ZodString;
             party_id: z.ZodString;
             requested_by: z.ZodString;
-            status: z.ZodEnum<["pendiente", "aprobado", "rechazado"]>;
-            face_value: z.ZodNumber;
+            status: z.ZodEnum<{
+                pendiente: "pendiente";
+                aprobado: "aprobado";
+                rechazado: "rechazado";
+            }>;
+            face_value: z.ZodCoercedNumber<unknown>;
             currency: z.ZodString;
-            interest_rate: z.ZodNullable<z.ZodNumber>;
+            interest_rate: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
             issue_date: z.ZodNullable<z.ZodString>;
             maturity_date: z.ZodNullable<z.ZodString>;
             bond_token_id: z.ZodNullable<z.ZodString>;
             rejection_reason: z.ZodNullable<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            requested_by: z.ZodString;
-            status: z.ZodEnum<["pendiente", "aprobado", "rechazado"]>;
-            face_value: z.ZodNumber;
-            currency: z.ZodString;
-            interest_rate: z.ZodNullable<z.ZodNumber>;
-            issue_date: z.ZodNullable<z.ZodString>;
-            maturity_date: z.ZodNullable<z.ZodString>;
-            bond_token_id: z.ZodNullable<z.ZodString>;
-            rejection_reason: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            requested_by: z.ZodString;
-            status: z.ZodEnum<["pendiente", "aprobado", "rechazado"]>;
-            face_value: z.ZodNumber;
-            currency: z.ZodString;
-            interest_rate: z.ZodNullable<z.ZodNumber>;
-            issue_date: z.ZodNullable<z.ZodString>;
-            maturity_date: z.ZodNullable<z.ZodString>;
-            bond_token_id: z.ZodNullable<z.ZodString>;
-            rejection_reason: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>, "many">;
+        }, z.core.$loose>>;
     };
     readonly 'bonds.requests.create': {
         method: HttpMethod;
         path: string;
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
-        body: z.ZodEffects<z.ZodObject<{
-            faceValue: z.ZodNumber;
+        body: z.ZodObject<{
+            faceValue: z.ZodCoercedNumber<unknown>;
             currency: z.ZodOptional<z.ZodString>;
-            interestRate: z.ZodOptional<z.ZodNumber>;
+            interestRate: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
             series: z.ZodOptional<z.ZodString>;
             issueDate: z.ZodOptional<z.ZodString>;
             maturityDate: z.ZodOptional<z.ZodString>;
             notes: z.ZodOptional<z.ZodString>;
             certificateNumber: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            faceValue: number;
-            certificateNumber?: string | undefined;
-            currency?: string | undefined;
-            interestRate?: number | undefined;
-            series?: string | undefined;
-            issueDate?: string | undefined;
-            maturityDate?: string | undefined;
-            notes?: string | undefined;
-        }, {
-            faceValue: number;
-            certificateNumber?: string | undefined;
-            currency?: string | undefined;
-            interestRate?: number | undefined;
-            series?: string | undefined;
-            issueDate?: string | undefined;
-            maturityDate?: string | undefined;
-            notes?: string | undefined;
-        }>, {
-            faceValue: number;
-            certificateNumber?: string | undefined;
-            currency?: string | undefined;
-            interestRate?: number | undefined;
-            series?: string | undefined;
-            issueDate?: string | undefined;
-            maturityDate?: string | undefined;
-            notes?: string | undefined;
-        }, {
-            faceValue: number;
-            certificateNumber?: string | undefined;
-            currency?: string | undefined;
-            interestRate?: number | undefined;
-            series?: string | undefined;
-            issueDate?: string | undefined;
-            maturityDate?: string | undefined;
-            notes?: string | undefined;
-        }>;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             party_id: z.ZodString;
             requested_by: z.ZodString;
-            status: z.ZodEnum<["pendiente", "aprobado", "rechazado"]>;
-            face_value: z.ZodNumber;
+            status: z.ZodEnum<{
+                pendiente: "pendiente";
+                aprobado: "aprobado";
+                rechazado: "rechazado";
+            }>;
+            face_value: z.ZodCoercedNumber<unknown>;
             currency: z.ZodString;
-            interest_rate: z.ZodNullable<z.ZodNumber>;
+            interest_rate: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
             issue_date: z.ZodNullable<z.ZodString>;
             maturity_date: z.ZodNullable<z.ZodString>;
             bond_token_id: z.ZodNullable<z.ZodString>;
             rejection_reason: z.ZodNullable<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            requested_by: z.ZodString;
-            status: z.ZodEnum<["pendiente", "aprobado", "rechazado"]>;
-            face_value: z.ZodNumber;
-            currency: z.ZodString;
-            interest_rate: z.ZodNullable<z.ZodNumber>;
-            issue_date: z.ZodNullable<z.ZodString>;
-            maturity_date: z.ZodNullable<z.ZodString>;
-            bond_token_id: z.ZodNullable<z.ZodString>;
-            rejection_reason: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            requested_by: z.ZodString;
-            status: z.ZodEnum<["pendiente", "aprobado", "rechazado"]>;
-            face_value: z.ZodNumber;
-            currency: z.ZodString;
-            interest_rate: z.ZodNullable<z.ZodNumber>;
-            issue_date: z.ZodNullable<z.ZodString>;
-            maturity_date: z.ZodNullable<z.ZodString>;
-            bond_token_id: z.ZodNullable<z.ZodString>;
-            rejection_reason: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.requests.approve': {
         method: HttpMethod;
@@ -522,18 +197,14 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             token_id: z.ZodString;
             bond_id: z.ZodString;
             issuer_party_id: z.ZodString;
             current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly EMITIDO: "emitido";
                 readonly PENDIENTE: "pendiente";
                 readonly APROBADO: "aprobado";
@@ -547,18 +218,22 @@ export declare const apiContracts: {
             }>;
             document_hash: z.ZodString;
             metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
+            face_value: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
             certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
+            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+                sinpe: "sinpe";
+                transferencia: "transferencia";
+                wallet: "wallet";
+            }>>>;
             stellar_status: z.ZodOptional<z.ZodString>;
             stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -566,83 +241,7 @@ export declare const apiContracts: {
             stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.requests.reject': {
         method: HttpMethod;
@@ -651,26 +250,14 @@ export declare const apiContracts: {
         auth: boolean;
         body: z.ZodObject<{
             reason: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            reason?: string | undefined;
-        }, {
-            reason?: string | undefined;
-        }>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             ok: z.ZodLiteral<true>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            ok: z.ZodLiteral<true>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            ok: z.ZodLiteral<true>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.available': {
         method: HttpMethod;
@@ -678,20 +265,16 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodUndefined;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        params: z.ZodObject<{}, z.core.$strict>;
         query: z.ZodObject<{
             country: z.ZodOptional<z.ZodString>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            country: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            country: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
         response: z.ZodArray<z.ZodObject<{
             token_id: z.ZodString;
             bond_id: z.ZodString;
             issuer_party_id: z.ZodString;
             current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly EMITIDO: "emitido";
                 readonly PENDIENTE: "pendiente";
                 readonly APROBADO: "aprobado";
@@ -705,18 +288,22 @@ export declare const apiContracts: {
             }>;
             document_hash: z.ZodString;
             metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
+            face_value: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
             certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
+            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+                sinpe: "sinpe";
+                transferencia: "transferencia";
+                wallet: "wallet";
+            }>>>;
             stellar_status: z.ZodOptional<z.ZodString>;
             stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -724,163 +311,35 @@ export declare const apiContracts: {
             stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>, "many">;
+        }, z.core.$loose>>;
     };
     readonly 'bonds.create': {
         method: HttpMethod;
         path: string;
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
-        body: z.ZodEffects<z.ZodObject<{
+        body: z.ZodObject<{
             bondId: z.ZodString;
             issuerPartyId: z.ZodString;
             documentHash: z.ZodString;
             metadataUri: z.ZodOptional<z.ZodString>;
-            faceValue: z.ZodOptional<z.ZodNumber>;
+            faceValue: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
             initialOwner: z.ZodOptional<z.ZodString>;
             certificateNumber: z.ZodOptional<z.ZodString>;
             currency: z.ZodOptional<z.ZodString>;
-            interestRate: z.ZodOptional<z.ZodNumber>;
+            interestRate: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
             series: z.ZodOptional<z.ZodString>;
             issueDate: z.ZodOptional<z.ZodString>;
             maturityDate: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            bondId: string;
-            issuerPartyId: string;
-            documentHash: string;
-            metadataUri?: string | undefined;
-            faceValue?: number | undefined;
-            initialOwner?: string | undefined;
-            certificateNumber?: string | undefined;
-            currency?: string | undefined;
-            interestRate?: number | undefined;
-            series?: string | undefined;
-            issueDate?: string | undefined;
-            maturityDate?: string | undefined;
-        }, {
-            bondId: string;
-            issuerPartyId: string;
-            documentHash: string;
-            metadataUri?: string | undefined;
-            faceValue?: number | undefined;
-            initialOwner?: string | undefined;
-            certificateNumber?: string | undefined;
-            currency?: string | undefined;
-            interestRate?: number | undefined;
-            series?: string | undefined;
-            issueDate?: string | undefined;
-            maturityDate?: string | undefined;
-        }>, {
-            bondId: string;
-            issuerPartyId: string;
-            documentHash: string;
-            metadataUri?: string | undefined;
-            faceValue?: number | undefined;
-            initialOwner?: string | undefined;
-            certificateNumber?: string | undefined;
-            currency?: string | undefined;
-            interestRate?: number | undefined;
-            series?: string | undefined;
-            issueDate?: string | undefined;
-            maturityDate?: string | undefined;
-        }, {
-            bondId: string;
-            issuerPartyId: string;
-            documentHash: string;
-            metadataUri?: string | undefined;
-            faceValue?: number | undefined;
-            initialOwner?: string | undefined;
-            certificateNumber?: string | undefined;
-            currency?: string | undefined;
-            interestRate?: number | undefined;
-            series?: string | undefined;
-            issueDate?: string | undefined;
-            maturityDate?: string | undefined;
-        }>;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             token_id: z.ZodString;
             bond_id: z.ZodString;
             issuer_party_id: z.ZodString;
             current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly EMITIDO: "emitido";
                 readonly PENDIENTE: "pendiente";
                 readonly APROBADO: "aprobado";
@@ -894,18 +353,22 @@ export declare const apiContracts: {
             }>;
             document_hash: z.ZodString;
             metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
+            face_value: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
             certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
+            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+                sinpe: "sinpe";
+                transferencia: "transferencia";
+                wallet: "wallet";
+            }>>>;
             stellar_status: z.ZodOptional<z.ZodString>;
             stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -913,83 +376,7 @@ export declare const apiContracts: {
             stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.get': {
         method: HttpMethod;
@@ -999,18 +386,14 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             tokenId: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            tokenId: string;
-        }, {
-            tokenId: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             token_id: z.ZodString;
             bond_id: z.ZodString;
             issuer_party_id: z.ZodString;
             current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly EMITIDO: "emitido";
                 readonly PENDIENTE: "pendiente";
                 readonly APROBADO: "aprobado";
@@ -1024,18 +407,22 @@ export declare const apiContracts: {
             }>;
             document_hash: z.ZodString;
             metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
+            face_value: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
             certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
+            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+                sinpe: "sinpe";
+                transferencia: "transferencia";
+                wallet: "wallet";
+            }>>>;
             stellar_status: z.ZodOptional<z.ZodString>;
             stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -1043,83 +430,7 @@ export declare const apiContracts: {
             stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.onchain': {
         method: HttpMethod;
@@ -1129,19 +440,11 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             tokenId: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            tokenId: string;
-        }, {
-            tokenId: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             enabled: z.ZodBoolean;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            enabled: z.ZodBoolean;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            enabled: z.ZodBoolean;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.issueOnchain': {
         method: HttpMethod;
@@ -1151,25 +454,13 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             tokenId: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            tokenId: string;
-        }, {
-            tokenId: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             ok: z.ZodLiteral<true>;
             txHash: z.ZodOptional<z.ZodString>;
             alreadyIssued: z.ZodOptional<z.ZodBoolean>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            ok: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-            alreadyIssued: z.ZodOptional<z.ZodBoolean>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            ok: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-            alreadyIssued: z.ZodOptional<z.ZodBoolean>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.publish': {
         method: HttpMethod;
@@ -1177,26 +468,22 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodObject<{
-            paymentMethods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-        }, "strict", z.ZodTypeAny, {
-            paymentMethods?: ("sinpe" | "transferencia" | "wallet")[] | undefined;
-        }, {
-            paymentMethods?: ("sinpe" | "transferencia" | "wallet")[] | undefined;
-        }>;
+            paymentMethods: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+                sinpe: "sinpe";
+                transferencia: "transferencia";
+                wallet: "wallet";
+            }>>>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             tokenId: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            tokenId: string;
-        }, {
-            tokenId: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             token_id: z.ZodString;
             bond_id: z.ZodString;
             issuer_party_id: z.ZodString;
             current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly EMITIDO: "emitido";
                 readonly PENDIENTE: "pendiente";
                 readonly APROBADO: "aprobado";
@@ -1210,18 +497,22 @@ export declare const apiContracts: {
             }>;
             document_hash: z.ZodString;
             metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
+            face_value: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
             certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
+            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+                sinpe: "sinpe";
+                transferencia: "transferencia";
+                wallet: "wallet";
+            }>>>;
             stellar_status: z.ZodOptional<z.ZodString>;
             stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -1229,83 +520,7 @@ export declare const apiContracts: {
             stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.sorobanDetails': {
         method: HttpMethod;
@@ -1315,22 +530,15 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             tokenId: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            tokenId: string;
-        }, {
-            tokenId: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
-            source: z.ZodEnum<["soroban", "database_snapshot"]>;
+            source: z.ZodEnum<{
+                soroban: "soroban";
+                database_snapshot: "database_snapshot";
+            }>;
             contract_id: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            source: z.ZodEnum<["soroban", "database_snapshot"]>;
-            contract_id: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            source: z.ZodEnum<["soroban", "database_snapshot"]>;
-            contract_id: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.freeze': {
         method: HttpMethod;
@@ -1340,18 +548,14 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             tokenId: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            tokenId: string;
-        }, {
-            tokenId: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             token_id: z.ZodString;
             bond_id: z.ZodString;
             issuer_party_id: z.ZodString;
             current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly EMITIDO: "emitido";
                 readonly PENDIENTE: "pendiente";
                 readonly APROBADO: "aprobado";
@@ -1365,18 +569,22 @@ export declare const apiContracts: {
             }>;
             document_hash: z.ZodString;
             metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
+            face_value: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
             certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
+            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+                sinpe: "sinpe";
+                transferencia: "transferencia";
+                wallet: "wallet";
+            }>>>;
             stellar_status: z.ZodOptional<z.ZodString>;
             stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -1384,83 +592,7 @@ export declare const apiContracts: {
             stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.unfreeze': {
         method: HttpMethod;
@@ -1470,18 +602,14 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             tokenId: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            tokenId: string;
-        }, {
-            tokenId: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             token_id: z.ZodString;
             bond_id: z.ZodString;
             issuer_party_id: z.ZodString;
             current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly EMITIDO: "emitido";
                 readonly PENDIENTE: "pendiente";
                 readonly APROBADO: "aprobado";
@@ -1495,18 +623,22 @@ export declare const apiContracts: {
             }>;
             document_hash: z.ZodString;
             metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
+            face_value: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
             certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
+            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+                sinpe: "sinpe";
+                transferencia: "transferencia";
+                wallet: "wallet";
+            }>>>;
             stellar_status: z.ZodOptional<z.ZodString>;
             stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -1514,83 +646,7 @@ export declare const apiContracts: {
             stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            token_id: z.ZodString;
-            bond_id: z.ZodString;
-            issuer_party_id: z.ZodString;
-            current_owner: z.ZodNullable<z.ZodString>;
-            status: z.ZodNativeEnum<{
-                readonly EMITIDO: "emitido";
-                readonly PENDIENTE: "pendiente";
-                readonly APROBADO: "aprobado";
-                readonly ACTIVO: "activo";
-                readonly EN_VENTA: "en_venta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly TRANSFERIDO: "transferido";
-                readonly CANCELADO: "cancelado";
-                readonly RECHAZADO: "rechazado";
-                readonly CONGELADO: "congelado";
-            }>;
-            document_hash: z.ZodString;
-            metadata_uri: z.ZodNullable<z.ZodString>;
-            face_value: z.ZodNullable<z.ZodNumber>;
-            certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            currency: z.ZodOptional<z.ZodString>;
-            interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-            stellar_status: z.ZodOptional<z.ZodString>;
-            stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.uploadDocument': {
         method: HttpMethod;
@@ -1600,22 +656,12 @@ export declare const apiContracts: {
         body: z.ZodUnknown;
         params: z.ZodObject<{
             tokenId: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            tokenId: string;
-        }, {
-            tokenId: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             documentHash: z.ZodString;
             sorobanTxHash: z.ZodOptional<z.ZodString>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            documentHash: z.ZodString;
-            sorobanTxHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            documentHash: z.ZodString;
-            sorobanTxHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'bonds.hash': {
         method: HttpMethod;
@@ -1624,20 +670,12 @@ export declare const apiContracts: {
         auth: boolean;
         body: z.ZodObject<{
             content: z.ZodString;
-        }, "strict", z.ZodTypeAny, {
-            content: string;
-        }, {
-            content: string;
-        }>;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             hash: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            hash: string;
-        }, {
-            hash: string;
-        }>;
+        }, z.core.$strip>;
     };
     readonly 'transfers.list': {
         method: HttpMethod;
@@ -1645,24 +683,18 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodUndefined;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        params: z.ZodObject<{}, z.core.$strict>;
         query: z.ZodObject<{
-            page: z.ZodOptional<z.ZodNumber>;
-            limit: z.ZodOptional<z.ZodNumber>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            page: z.ZodOptional<z.ZodNumber>;
-            limit: z.ZodOptional<z.ZodNumber>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            page: z.ZodOptional<z.ZodNumber>;
-            limit: z.ZodOptional<z.ZodNumber>;
-        }, z.ZodTypeAny, "passthrough">>;
+            page: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
+            limit: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
+        }, z.core.$loose>;
         response: z.ZodObject<{
             data: z.ZodArray<z.ZodObject<{
                 id: z.ZodString;
                 bond_token_id: z.ZodString;
                 from_owner: z.ZodString;
                 to_owner: z.ZodString;
-                status: z.ZodNativeEnum<{
+                status: z.ZodEnum<{
                     readonly SOLICITADA: "solicitada";
                     readonly ACEPTADA: "aceptada";
                     readonly CONTRAOFERTA: "contraoferta";
@@ -1676,8 +708,8 @@ export declare const apiContracts: {
                 escrow_contract_id: z.ZodNullable<z.ZodString>;
                 payment_evidence_hash: z.ZodNullable<z.ZodString>;
                 validated_by: z.ZodNullable<z.ZodString>;
-                amount: z.ZodNullable<z.ZodNumber>;
-                counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+                amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+                counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
                 seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
                 buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
                 return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -1690,153 +722,11 @@ export declare const apiContracts: {
                 return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
                 created_at: z.ZodString;
                 updated_at: z.ZodString;
-            }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-                id: z.ZodString;
-                bond_token_id: z.ZodString;
-                from_owner: z.ZodString;
-                to_owner: z.ZodString;
-                status: z.ZodNativeEnum<{
-                    readonly SOLICITADA: "solicitada";
-                    readonly ACEPTADA: "aceptada";
-                    readonly CONTRAOFERTA: "contraoferta";
-                    readonly EN_ESCROW: "en_escrow";
-                    readonly PAGO_REGISTRADO: "pago_registrado";
-                    readonly PAGO_VALIDADO: "pago_validado";
-                    readonly LIBERADA: "liberada";
-                    readonly RECHAZADA: "rechazada";
-                    readonly CANCELADA: "cancelada";
-                }>;
-                escrow_contract_id: z.ZodNullable<z.ZodString>;
-                payment_evidence_hash: z.ZodNullable<z.ZodString>;
-                validated_by: z.ZodNullable<z.ZodString>;
-                amount: z.ZodNullable<z.ZodNumber>;
-                counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-                id: z.ZodString;
-                bond_token_id: z.ZodString;
-                from_owner: z.ZodString;
-                to_owner: z.ZodString;
-                status: z.ZodNativeEnum<{
-                    readonly SOLICITADA: "solicitada";
-                    readonly ACEPTADA: "aceptada";
-                    readonly CONTRAOFERTA: "contraoferta";
-                    readonly EN_ESCROW: "en_escrow";
-                    readonly PAGO_REGISTRADO: "pago_registrado";
-                    readonly PAGO_VALIDADO: "pago_validado";
-                    readonly LIBERADA: "liberada";
-                    readonly RECHAZADA: "rechazada";
-                    readonly CANCELADA: "cancelada";
-                }>;
-                escrow_contract_id: z.ZodNullable<z.ZodString>;
-                payment_evidence_hash: z.ZodNullable<z.ZodString>;
-                validated_by: z.ZodNullable<z.ZodString>;
-                amount: z.ZodNullable<z.ZodNumber>;
-                counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">>, "many">;
+            }, z.core.$loose>>;
             total: z.ZodNumber;
             page: z.ZodNumber;
             limit: z.ZodNumber;
-        }, "strip", z.ZodTypeAny, {
-            page: number;
-            limit: number;
-            data: z.objectOutputType<{
-                id: z.ZodString;
-                bond_token_id: z.ZodString;
-                from_owner: z.ZodString;
-                to_owner: z.ZodString;
-                status: z.ZodNativeEnum<{
-                    readonly SOLICITADA: "solicitada";
-                    readonly ACEPTADA: "aceptada";
-                    readonly CONTRAOFERTA: "contraoferta";
-                    readonly EN_ESCROW: "en_escrow";
-                    readonly PAGO_REGISTRADO: "pago_registrado";
-                    readonly PAGO_VALIDADO: "pago_validado";
-                    readonly LIBERADA: "liberada";
-                    readonly RECHAZADA: "rechazada";
-                    readonly CANCELADA: "cancelada";
-                }>;
-                escrow_contract_id: z.ZodNullable<z.ZodString>;
-                payment_evidence_hash: z.ZodNullable<z.ZodString>;
-                validated_by: z.ZodNullable<z.ZodString>;
-                amount: z.ZodNullable<z.ZodNumber>;
-                counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">[];
-            total: number;
-        }, {
-            page: number;
-            limit: number;
-            data: z.objectInputType<{
-                id: z.ZodString;
-                bond_token_id: z.ZodString;
-                from_owner: z.ZodString;
-                to_owner: z.ZodString;
-                status: z.ZodNativeEnum<{
-                    readonly SOLICITADA: "solicitada";
-                    readonly ACEPTADA: "aceptada";
-                    readonly CONTRAOFERTA: "contraoferta";
-                    readonly EN_ESCROW: "en_escrow";
-                    readonly PAGO_REGISTRADO: "pago_registrado";
-                    readonly PAGO_VALIDADO: "pago_validado";
-                    readonly LIBERADA: "liberada";
-                    readonly RECHAZADA: "rechazada";
-                    readonly CANCELADA: "cancelada";
-                }>;
-                escrow_contract_id: z.ZodNullable<z.ZodString>;
-                payment_evidence_hash: z.ZodNullable<z.ZodString>;
-                validated_by: z.ZodNullable<z.ZodString>;
-                amount: z.ZodNullable<z.ZodNumber>;
-                counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-                seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-                created_at: z.ZodString;
-                updated_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">[];
-            total: number;
-        }>;
+        }, z.core.$strip>;
     };
     readonly 'transfers.create': {
         method: HttpMethod;
@@ -1846,33 +736,23 @@ export declare const apiContracts: {
         body: z.ZodObject<{
             bondTokenId: z.ZodString;
             toOwner: z.ZodOptional<z.ZodString>;
-            paymentMethod: z.ZodOptional<z.ZodEnum<["sinpe", "transferencia", "wallet"]>>;
-            amount: z.ZodOptional<z.ZodNumber>;
+            paymentMethod: z.ZodOptional<z.ZodEnum<{
+                sinpe: "sinpe";
+                transferencia: "transferencia";
+                wallet: "wallet";
+            }>>;
+            amount: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
             message: z.ZodOptional<z.ZodString>;
-            counterOfferAmount: z.ZodOptional<z.ZodNumber>;
-        }, "strict", z.ZodTypeAny, {
-            bondTokenId: string;
-            message?: string | undefined;
-            toOwner?: string | undefined;
-            paymentMethod?: "sinpe" | "transferencia" | "wallet" | undefined;
-            amount?: number | undefined;
-            counterOfferAmount?: number | undefined;
-        }, {
-            bondTokenId: string;
-            message?: string | undefined;
-            toOwner?: string | undefined;
-            paymentMethod?: "sinpe" | "transferencia" | "wallet" | undefined;
-            amount?: number | undefined;
-            counterOfferAmount?: number | undefined;
-        }>;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+            counterOfferAmount: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             bond_token_id: z.ZodString;
             from_owner: z.ZodString;
             to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly SOLICITADA: "solicitada";
                 readonly ACEPTADA: "aceptada";
                 readonly CONTRAOFERTA: "contraoferta";
@@ -1886,8 +766,8 @@ export declare const apiContracts: {
             escrow_contract_id: z.ZodNullable<z.ZodString>;
             payment_evidence_hash: z.ZodNullable<z.ZodString>;
             validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -1900,73 +780,7 @@ export declare const apiContracts: {
             return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.get': {
         method: HttpMethod;
@@ -1976,18 +790,14 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodNullable<z.ZodObject<{
             id: z.ZodString;
             bond_token_id: z.ZodString;
             from_owner: z.ZodString;
             to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly SOLICITADA: "solicitada";
                 readonly ACEPTADA: "aceptada";
                 readonly CONTRAOFERTA: "contraoferta";
@@ -2001,8 +811,8 @@ export declare const apiContracts: {
             escrow_contract_id: z.ZodNullable<z.ZodString>;
             payment_evidence_hash: z.ZodNullable<z.ZodString>;
             validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -2015,73 +825,7 @@ export declare const apiContracts: {
             return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>>;
+        }, z.core.$loose>>;
     };
     readonly 'transfers.accept': {
         method: HttpMethod;
@@ -2091,18 +835,14 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        response: z.ZodUnion<[z.ZodObject<{
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
+        response: z.ZodUnion<readonly [z.ZodObject<{
             id: z.ZodString;
             bond_token_id: z.ZodString;
             from_owner: z.ZodString;
             to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly SOLICITADA: "solicitada";
                 readonly ACEPTADA: "aceptada";
                 readonly CONTRAOFERTA: "contraoferta";
@@ -2116,8 +856,8 @@ export declare const apiContracts: {
             escrow_contract_id: z.ZodNullable<z.ZodString>;
             payment_evidence_hash: z.ZodNullable<z.ZodString>;
             validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -2130,82 +870,10 @@ export declare const apiContracts: {
             return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>, z.ZodObject<{
+        }, z.core.$loose>, z.ZodObject<{
             success: z.ZodLiteral<true>;
             txHash: z.ZodOptional<z.ZodString>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">>]>;
+        }, z.core.$loose>]>;
     };
     readonly 'transfers.reject': {
         method: HttpMethod;
@@ -2215,19 +883,11 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             success: z.ZodLiteral<true>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            success: z.ZodLiteral<true>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            success: z.ZodLiteral<true>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.counter': {
         method: HttpMethod;
@@ -2235,29 +895,19 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodObject<{
-            amount: z.ZodNumber;
+            amount: z.ZodCoercedNumber<unknown>;
             message: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            amount: number;
-            message?: string | undefined;
-        }, {
-            amount: number;
-            message?: string | undefined;
-        }>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             bond_token_id: z.ZodString;
             from_owner: z.ZodString;
             to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly SOLICITADA: "solicitada";
                 readonly ACEPTADA: "aceptada";
                 readonly CONTRAOFERTA: "contraoferta";
@@ -2271,8 +921,8 @@ export declare const apiContracts: {
             escrow_contract_id: z.ZodNullable<z.ZodString>;
             payment_evidence_hash: z.ZodNullable<z.ZodString>;
             validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -2285,73 +935,7 @@ export declare const apiContracts: {
             return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.acceptCounter': {
         method: HttpMethod;
@@ -2361,18 +945,14 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        response: z.ZodUnion<[z.ZodObject<{
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
+        response: z.ZodUnion<readonly [z.ZodObject<{
             id: z.ZodString;
             bond_token_id: z.ZodString;
             from_owner: z.ZodString;
             to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly SOLICITADA: "solicitada";
                 readonly ACEPTADA: "aceptada";
                 readonly CONTRAOFERTA: "contraoferta";
@@ -2386,8 +966,8 @@ export declare const apiContracts: {
             escrow_contract_id: z.ZodNullable<z.ZodString>;
             payment_evidence_hash: z.ZodNullable<z.ZodString>;
             validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -2400,118 +980,30 @@ export declare const apiContracts: {
             return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>, z.ZodObject<{
+        }, z.core.$loose>, z.ZodObject<{
             success: z.ZodLiteral<true>;
             txHash: z.ZodOptional<z.ZodString>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">>]>;
+        }, z.core.$loose>]>;
     };
     readonly 'transfers.payment': {
         method: HttpMethod;
         path: string;
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
-        body: z.ZodEffects<z.ZodObject<{
+        body: z.ZodObject<{
             evidence: z.ZodOptional<z.ZodString>;
             evidenceContent: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            evidence?: string | undefined;
-            evidenceContent?: string | undefined;
-        }, {
-            evidence?: string | undefined;
-            evidenceContent?: string | undefined;
-        }>, {
-            evidence?: string | undefined;
-            evidenceContent?: string | undefined;
-        }, {
-            evidence?: string | undefined;
-            evidenceContent?: string | undefined;
-        }>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             bond_token_id: z.ZodString;
             from_owner: z.ZodString;
             to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly SOLICITADA: "solicitada";
                 readonly ACEPTADA: "aceptada";
                 readonly CONTRAOFERTA: "contraoferta";
@@ -2525,8 +1017,8 @@ export declare const apiContracts: {
             escrow_contract_id: z.ZodNullable<z.ZodString>;
             payment_evidence_hash: z.ZodNullable<z.ZodString>;
             validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -2539,73 +1031,7 @@ export declare const apiContracts: {
             return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.validate': {
         method: HttpMethod;
@@ -2615,18 +1041,14 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             bond_token_id: z.ZodString;
             from_owner: z.ZodString;
             to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly SOLICITADA: "solicitada";
                 readonly ACEPTADA: "aceptada";
                 readonly CONTRAOFERTA: "contraoferta";
@@ -2640,8 +1062,8 @@ export declare const apiContracts: {
             escrow_contract_id: z.ZodNullable<z.ZodString>;
             payment_evidence_hash: z.ZodNullable<z.ZodString>;
             validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -2654,73 +1076,7 @@ export declare const apiContracts: {
             return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.release': {
         method: HttpMethod;
@@ -2730,22 +1086,12 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             success: z.ZodLiteral<true>;
             newOwner: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            success: z.ZodLiteral<true>;
-            newOwner: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            success: z.ZodLiteral<true>;
-            newOwner: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.cancel': {
         method: HttpMethod;
@@ -2755,19 +1101,11 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             success: z.ZodLiteral<true>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            success: z.ZodLiteral<true>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            success: z.ZodLiteral<true>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.buildXdr': {
         method: HttpMethod;
@@ -2777,22 +1115,12 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             xdr: z.ZodString;
             networkPassphrase: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            xdr: z.ZodString;
-            networkPassphrase: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            xdr: z.ZodString;
-            networkPassphrase: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.submitXdr': {
         method: HttpMethod;
@@ -2801,29 +1129,15 @@ export declare const apiContracts: {
         auth: boolean;
         body: z.ZodObject<{
             signedXdr: z.ZodString;
-        }, "strict", z.ZodTypeAny, {
-            signedXdr: string;
-        }, {
-            signedXdr: string;
-        }>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             success: z.ZodLiteral<true>;
             txHash: z.ZodOptional<z.ZodString>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.instantBuy.buildXdr': {
         method: HttpMethod;
@@ -2833,22 +1147,12 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             bondTokenId: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            bondTokenId: string;
-        }, {
-            bondTokenId: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             xdr: z.ZodString;
             networkPassphrase: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            xdr: z.ZodString;
-            networkPassphrase: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            xdr: z.ZodString;
-            networkPassphrase: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.instantBuy.submitXdr': {
         method: HttpMethod;
@@ -2857,29 +1161,15 @@ export declare const apiContracts: {
         auth: boolean;
         body: z.ZodObject<{
             signedXdr: z.ZodString;
-        }, "strict", z.ZodTypeAny, {
-            signedXdr: string;
-        }, {
-            signedXdr: string;
-        }>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             bondTokenId: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            bondTokenId: string;
-        }, {
-            bondTokenId: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             success: z.ZodLiteral<true>;
             txHash: z.ZodOptional<z.ZodString>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.walletPayment.buildXdr': {
         method: HttpMethod;
@@ -2889,22 +1179,12 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             xdr: z.ZodString;
             networkPassphrase: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            xdr: z.ZodString;
-            networkPassphrase: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            xdr: z.ZodString;
-            networkPassphrase: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.walletPayment.submitXdr': {
         method: HttpMethod;
@@ -2913,29 +1193,15 @@ export declare const apiContracts: {
         auth: boolean;
         body: z.ZodObject<{
             signedXdr: z.ZodString;
-        }, "strict", z.ZodTypeAny, {
-            signedXdr: string;
-        }, {
-            signedXdr: string;
-        }>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             success: z.ZodLiteral<true>;
             txHash: z.ZodOptional<z.ZodString>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.requestReturn': {
         method: HttpMethod;
@@ -2944,25 +1210,17 @@ export declare const apiContracts: {
         auth: boolean;
         body: z.ZodObject<{
             reason: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            reason?: string | undefined;
-        }, {
-            reason?: string | undefined;
-        }>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             bond_token_id: z.ZodString;
             from_owner: z.ZodString;
             to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly SOLICITADA: "solicitada";
                 readonly ACEPTADA: "aceptada";
                 readonly CONTRAOFERTA: "contraoferta";
@@ -2976,8 +1234,8 @@ export declare const apiContracts: {
             escrow_contract_id: z.ZodNullable<z.ZodString>;
             payment_evidence_hash: z.ZodNullable<z.ZodString>;
             validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -2990,73 +1248,7 @@ export declare const apiContracts: {
             return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.approveReturn': {
         method: HttpMethod;
@@ -3065,29 +1257,15 @@ export declare const apiContracts: {
         auth: boolean;
         body: z.ZodObject<{
             notes: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            notes?: string | undefined;
-        }, {
-            notes?: string | undefined;
-        }>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             success: z.ZodLiteral<true>;
             txHash: z.ZodOptional<z.ZodString>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            success: z.ZodLiteral<true>;
-            txHash: z.ZodOptional<z.ZodString>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'transfers.rejectReturn': {
         method: HttpMethod;
@@ -3096,25 +1274,17 @@ export declare const apiContracts: {
         auth: boolean;
         body: z.ZodObject<{
             notes: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            notes?: string | undefined;
-        }, {
-            notes?: string | undefined;
-        }>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             bond_token_id: z.ZodString;
             from_owner: z.ZodString;
             to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
+            status: z.ZodEnum<{
                 readonly SOLICITADA: "solicitada";
                 readonly ACEPTADA: "aceptada";
                 readonly CONTRAOFERTA: "contraoferta";
@@ -3128,8 +1298,8 @@ export declare const apiContracts: {
             escrow_contract_id: z.ZodNullable<z.ZodString>;
             payment_evidence_hash: z.ZodNullable<z.ZodString>;
             validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
             seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -3142,73 +1312,7 @@ export declare const apiContracts: {
             return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            bond_token_id: z.ZodString;
-            from_owner: z.ZodString;
-            to_owner: z.ZodString;
-            status: z.ZodNativeEnum<{
-                readonly SOLICITADA: "solicitada";
-                readonly ACEPTADA: "aceptada";
-                readonly CONTRAOFERTA: "contraoferta";
-                readonly EN_ESCROW: "en_escrow";
-                readonly PAGO_REGISTRADO: "pago_registrado";
-                readonly PAGO_VALIDADO: "pago_validado";
-                readonly LIBERADA: "liberada";
-                readonly RECHAZADA: "rechazada";
-                readonly CANCELADA: "cancelada";
-            }>;
-            escrow_contract_id: z.ZodNullable<z.ZodString>;
-            payment_evidence_hash: z.ZodNullable<z.ZodString>;
-            validated_by: z.ZodNullable<z.ZodString>;
-            amount: z.ZodNullable<z.ZodNumber>;
-            counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-            seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'reports.list': {
         method: HttpMethod;
@@ -3216,8 +1320,8 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodUndefined;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodArray<z.ZodObject<{
             id: z.ZodString;
             party_id: z.ZodString;
@@ -3226,91 +1330,36 @@ export declare const apiContracts: {
             description: z.ZodString;
             period_start: z.ZodNullable<z.ZodString>;
             period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
+            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString>>;
+            total_amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            status: z.ZodEnum<{
+                aprobado: "aprobado";
+                enviado: "enviado";
+                revisado: "revisado";
+                observado: "observado";
+            }>;
             reviewed_by: z.ZodNullable<z.ZodString>;
             reviewed_at: z.ZodNullable<z.ZodString>;
             tse_notes: z.ZodNullable<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            submitted_by: z.ZodString;
-            title: z.ZodString;
-            description: z.ZodString;
-            period_start: z.ZodNullable<z.ZodString>;
-            period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
-            reviewed_by: z.ZodNullable<z.ZodString>;
-            reviewed_at: z.ZodNullable<z.ZodString>;
-            tse_notes: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            submitted_by: z.ZodString;
-            title: z.ZodString;
-            description: z.ZodString;
-            period_start: z.ZodNullable<z.ZodString>;
-            period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
-            reviewed_by: z.ZodNullable<z.ZodString>;
-            reviewed_at: z.ZodNullable<z.ZodString>;
-            tse_notes: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>, "many">;
+        }, z.core.$loose>>;
     };
     readonly 'reports.create': {
         method: HttpMethod;
         path: string;
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
-        body: z.ZodEffects<z.ZodObject<{
+        body: z.ZodObject<{
             title: z.ZodString;
             description: z.ZodString;
             period_start: z.ZodOptional<z.ZodString>;
             period_end: z.ZodOptional<z.ZodString>;
-            bond_token_ids: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodOptional<z.ZodNumber>;
-        }, "strict", z.ZodTypeAny, {
-            title: string;
-            description: string;
-            period_start?: string | undefined;
-            period_end?: string | undefined;
-            bond_token_ids?: string[] | undefined;
-            total_amount?: number | undefined;
-        }, {
-            title: string;
-            description: string;
-            period_start?: string | undefined;
-            period_end?: string | undefined;
-            bond_token_ids?: string[] | undefined;
-            total_amount?: number | undefined;
-        }>, {
-            title: string;
-            description: string;
-            period_start?: string | undefined;
-            period_end?: string | undefined;
-            bond_token_ids?: string[] | undefined;
-            total_amount?: number | undefined;
-        }, {
-            title: string;
-            description: string;
-            period_start?: string | undefined;
-            period_end?: string | undefined;
-            bond_token_ids?: string[] | undefined;
-            total_amount?: number | undefined;
-        }>;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+            bond_token_ids: z.ZodOptional<z.ZodArray<z.ZodString>>;
+            total_amount: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             party_id: z.ZodString;
@@ -3319,47 +1368,20 @@ export declare const apiContracts: {
             description: z.ZodString;
             period_start: z.ZodNullable<z.ZodString>;
             period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
+            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString>>;
+            total_amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            status: z.ZodEnum<{
+                aprobado: "aprobado";
+                enviado: "enviado";
+                revisado: "revisado";
+                observado: "observado";
+            }>;
             reviewed_by: z.ZodNullable<z.ZodString>;
             reviewed_at: z.ZodNullable<z.ZodString>;
             tse_notes: z.ZodNullable<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            submitted_by: z.ZodString;
-            title: z.ZodString;
-            description: z.ZodString;
-            period_start: z.ZodNullable<z.ZodString>;
-            period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
-            reviewed_by: z.ZodNullable<z.ZodString>;
-            reviewed_at: z.ZodNullable<z.ZodString>;
-            tse_notes: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            submitted_by: z.ZodString;
-            title: z.ZodString;
-            description: z.ZodString;
-            period_start: z.ZodNullable<z.ZodString>;
-            period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
-            reviewed_by: z.ZodNullable<z.ZodString>;
-            reviewed_at: z.ZodNullable<z.ZodString>;
-            tse_notes: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'reports.get': {
         method: HttpMethod;
@@ -3369,12 +1391,8 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             party_id: z.ZodString;
@@ -3383,47 +1401,20 @@ export declare const apiContracts: {
             description: z.ZodString;
             period_start: z.ZodNullable<z.ZodString>;
             period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
+            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString>>;
+            total_amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            status: z.ZodEnum<{
+                aprobado: "aprobado";
+                enviado: "enviado";
+                revisado: "revisado";
+                observado: "observado";
+            }>;
             reviewed_by: z.ZodNullable<z.ZodString>;
             reviewed_at: z.ZodNullable<z.ZodString>;
             tse_notes: z.ZodNullable<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            submitted_by: z.ZodString;
-            title: z.ZodString;
-            description: z.ZodString;
-            period_start: z.ZodNullable<z.ZodString>;
-            period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
-            reviewed_by: z.ZodNullable<z.ZodString>;
-            reviewed_at: z.ZodNullable<z.ZodString>;
-            tse_notes: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            submitted_by: z.ZodString;
-            title: z.ZodString;
-            description: z.ZodString;
-            period_start: z.ZodNullable<z.ZodString>;
-            period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
-            reviewed_by: z.ZodNullable<z.ZodString>;
-            reviewed_at: z.ZodNullable<z.ZodString>;
-            tse_notes: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'reports.review': {
         method: HttpMethod;
@@ -3431,23 +1422,17 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodObject<{
-            status: z.ZodEnum<["revisado", "observado", "aprobado"]>;
+            status: z.ZodEnum<{
+                aprobado: "aprobado";
+                revisado: "revisado";
+                observado: "observado";
+            }>;
             notes: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            status: "aprobado" | "revisado" | "observado";
-            notes?: string | undefined;
-        }, {
-            status: "aprobado" | "revisado" | "observado";
-            notes?: string | undefined;
-        }>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             party_id: z.ZodString;
@@ -3456,47 +1441,20 @@ export declare const apiContracts: {
             description: z.ZodString;
             period_start: z.ZodNullable<z.ZodString>;
             period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
+            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString>>;
+            total_amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+            status: z.ZodEnum<{
+                aprobado: "aprobado";
+                enviado: "enviado";
+                revisado: "revisado";
+                observado: "observado";
+            }>;
             reviewed_by: z.ZodNullable<z.ZodString>;
             reviewed_at: z.ZodNullable<z.ZodString>;
             tse_notes: z.ZodNullable<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            submitted_by: z.ZodString;
-            title: z.ZodString;
-            description: z.ZodString;
-            period_start: z.ZodNullable<z.ZodString>;
-            period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
-            reviewed_by: z.ZodNullable<z.ZodString>;
-            reviewed_at: z.ZodNullable<z.ZodString>;
-            tse_notes: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            party_id: z.ZodString;
-            submitted_by: z.ZodString;
-            title: z.ZodString;
-            description: z.ZodString;
-            period_start: z.ZodNullable<z.ZodString>;
-            period_end: z.ZodNullable<z.ZodString>;
-            bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-            total_amount: z.ZodNullable<z.ZodNumber>;
-            status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
-            reviewed_by: z.ZodNullable<z.ZodString>;
-            reviewed_at: z.ZodNullable<z.ZodString>;
-            tse_notes: z.ZodNullable<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'notifications.list': {
         method: HttpMethod;
@@ -3504,13 +1462,13 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodUndefined;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             notifications: z.ZodArray<z.ZodObject<{
                 id: z.ZodString;
                 user_id: z.ZodString;
-                type: z.ZodNativeEnum<{
+                type: z.ZodEnum<{
                     readonly OFFER_RECEIVED: "offer_received";
                     readonly OFFER_ACCEPTED: "offer_accepted";
                     readonly OFFER_REJECTED: "offer_rejected";
@@ -3518,79 +1476,17 @@ export declare const apiContracts: {
                     readonly PAYMENT_CONFIRMED: "payment_confirmed";
                     readonly BOND_APPROVED: "bond_approved";
                     readonly BOND_REJECTED: "bond_rejected";
+                    readonly REPORT_SUBMITTED: "report_submitted";
+                    readonly REPORT_OBSERVED: "report_observed";
+                    readonly REPORT_APPROVED: "report_approved";
+                    readonly REPORT_RESUBMITTED: "report_resubmitted";
                 }>;
                 payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
                 read: z.ZodBoolean;
                 created_at: z.ZodString;
-            }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-                id: z.ZodString;
-                user_id: z.ZodString;
-                type: z.ZodNativeEnum<{
-                    readonly OFFER_RECEIVED: "offer_received";
-                    readonly OFFER_ACCEPTED: "offer_accepted";
-                    readonly OFFER_REJECTED: "offer_rejected";
-                    readonly COUNTER_OFFER_RECEIVED: "counter_offer_received";
-                    readonly PAYMENT_CONFIRMED: "payment_confirmed";
-                    readonly BOND_APPROVED: "bond_approved";
-                    readonly BOND_REJECTED: "bond_rejected";
-                }>;
-                payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-                read: z.ZodBoolean;
-                created_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-                id: z.ZodString;
-                user_id: z.ZodString;
-                type: z.ZodNativeEnum<{
-                    readonly OFFER_RECEIVED: "offer_received";
-                    readonly OFFER_ACCEPTED: "offer_accepted";
-                    readonly OFFER_REJECTED: "offer_rejected";
-                    readonly COUNTER_OFFER_RECEIVED: "counter_offer_received";
-                    readonly PAYMENT_CONFIRMED: "payment_confirmed";
-                    readonly BOND_APPROVED: "bond_approved";
-                    readonly BOND_REJECTED: "bond_rejected";
-                }>;
-                payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-                read: z.ZodBoolean;
-                created_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">>, "many">;
+            }, z.core.$loose>>;
             unreadCount: z.ZodNumber;
-        }, "strip", z.ZodTypeAny, {
-            notifications: z.objectOutputType<{
-                id: z.ZodString;
-                user_id: z.ZodString;
-                type: z.ZodNativeEnum<{
-                    readonly OFFER_RECEIVED: "offer_received";
-                    readonly OFFER_ACCEPTED: "offer_accepted";
-                    readonly OFFER_REJECTED: "offer_rejected";
-                    readonly COUNTER_OFFER_RECEIVED: "counter_offer_received";
-                    readonly PAYMENT_CONFIRMED: "payment_confirmed";
-                    readonly BOND_APPROVED: "bond_approved";
-                    readonly BOND_REJECTED: "bond_rejected";
-                }>;
-                payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-                read: z.ZodBoolean;
-                created_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">[];
-            unreadCount: number;
-        }, {
-            notifications: z.objectInputType<{
-                id: z.ZodString;
-                user_id: z.ZodString;
-                type: z.ZodNativeEnum<{
-                    readonly OFFER_RECEIVED: "offer_received";
-                    readonly OFFER_ACCEPTED: "offer_accepted";
-                    readonly OFFER_REJECTED: "offer_rejected";
-                    readonly COUNTER_OFFER_RECEIVED: "counter_offer_received";
-                    readonly PAYMENT_CONFIRMED: "payment_confirmed";
-                    readonly BOND_APPROVED: "bond_approved";
-                    readonly BOND_REJECTED: "bond_rejected";
-                }>;
-                payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-                read: z.ZodBoolean;
-                created_at: z.ZodString;
-            }, z.ZodTypeAny, "passthrough">[];
-            unreadCount: number;
-        }>;
+        }, z.core.$strip>;
     };
     readonly 'notifications.readAll': {
         method: HttpMethod;
@@ -3598,15 +1494,11 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodUndefined;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             ok: z.ZodLiteral<true>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            ok: z.ZodLiteral<true>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            ok: z.ZodLiteral<true>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'notifications.read': {
         method: HttpMethod;
@@ -3616,19 +1508,11 @@ export declare const apiContracts: {
         body: z.ZodUndefined;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             ok: z.ZodLiteral<true>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            ok: z.ZodLiteral<true>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            ok: z.ZodLiteral<true>;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'users.me': {
         method: HttpMethod;
@@ -3636,13 +1520,13 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodUndefined;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             email: z.ZodString;
             full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
+            role: z.ZodEnum<{
                 readonly TSE: "tse";
                 readonly EMISOR: "emisor";
                 readonly COMPRADOR: "comprador";
@@ -3656,67 +1540,23 @@ export declare const apiContracts: {
             country: z.ZodOptional<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            email: z.ZodString;
-            full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
-                readonly TSE: "tse";
-                readonly EMISOR: "emisor";
-                readonly COMPRADOR: "comprador";
-                readonly RECOMPRADOR: "recomprador";
-                readonly VALIDADOR: "validador";
-                readonly ADMIN: "admin";
-            }>;
-            party_id: z.ZodNullable<z.ZodString>;
-            stellar_wallet: z.ZodNullable<z.ZodString>;
-            stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            email: z.ZodString;
-            full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
-                readonly TSE: "tse";
-                readonly EMISOR: "emisor";
-                readonly COMPRADOR: "comprador";
-                readonly RECOMPRADOR: "recomprador";
-                readonly VALIDADOR: "validador";
-                readonly ADMIN: "admin";
-            }>;
-            party_id: z.ZodNullable<z.ZodString>;
-            stellar_wallet: z.ZodNullable<z.ZodString>;
-            stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'users.updateMe': {
         method: HttpMethod;
         path: string;
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
-        body: z.ZodEffects<z.ZodObject<{
+        body: z.ZodObject<{
             full_name: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            full_name?: string | undefined;
-        }, {
-            full_name?: string | undefined;
-        }>, {
-            full_name?: string | undefined;
-        }, {
-            full_name?: string | undefined;
-        }>;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             email: z.ZodString;
             full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
+            role: z.ZodEnum<{
                 readonly TSE: "tse";
                 readonly EMISOR: "emisor";
                 readonly COMPRADOR: "comprador";
@@ -3730,43 +1570,7 @@ export declare const apiContracts: {
             country: z.ZodOptional<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            email: z.ZodString;
-            full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
-                readonly TSE: "tse";
-                readonly EMISOR: "emisor";
-                readonly COMPRADOR: "comprador";
-                readonly RECOMPRADOR: "recomprador";
-                readonly VALIDADOR: "validador";
-                readonly ADMIN: "admin";
-            }>;
-            party_id: z.ZodNullable<z.ZodString>;
-            stellar_wallet: z.ZodNullable<z.ZodString>;
-            stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            email: z.ZodString;
-            full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
-                readonly TSE: "tse";
-                readonly EMISOR: "emisor";
-                readonly COMPRADOR: "comprador";
-                readonly RECOMPRADOR: "recomprador";
-                readonly VALIDADOR: "validador";
-                readonly ADMIN: "admin";
-            }>;
-            party_id: z.ZodNullable<z.ZodString>;
-            stellar_wallet: z.ZodNullable<z.ZodString>;
-            stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'users.updateWallet': {
         method: HttpMethod;
@@ -3775,23 +1579,13 @@ export declare const apiContracts: {
         auth: boolean;
         body: z.ZodObject<{
             publicKey: z.ZodString;
-        }, "strict", z.ZodTypeAny, {
-            publicKey: string;
-        }, {
-            publicKey: string;
-        }>;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             ok: z.ZodLiteral<true>;
             stellar_public_key: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            ok: z.ZodLiteral<true>;
-            stellar_public_key: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            ok: z.ZodLiteral<true>;
-            stellar_public_key: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
     readonly 'users.list': {
         method: HttpMethod;
@@ -3799,13 +1593,13 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodUndefined;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodArray<z.ZodObject<{
             id: z.ZodString;
             email: z.ZodString;
             full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
+            role: z.ZodEnum<{
                 readonly TSE: "tse";
                 readonly EMISOR: "emisor";
                 readonly COMPRADOR: "comprador";
@@ -3819,43 +1613,7 @@ export declare const apiContracts: {
             country: z.ZodOptional<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            email: z.ZodString;
-            full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
-                readonly TSE: "tse";
-                readonly EMISOR: "emisor";
-                readonly COMPRADOR: "comprador";
-                readonly RECOMPRADOR: "recomprador";
-                readonly VALIDADOR: "validador";
-                readonly ADMIN: "admin";
-            }>;
-            party_id: z.ZodNullable<z.ZodString>;
-            stellar_wallet: z.ZodNullable<z.ZodString>;
-            stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            email: z.ZodString;
-            full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
-                readonly TSE: "tse";
-                readonly EMISOR: "emisor";
-                readonly COMPRADOR: "comprador";
-                readonly RECOMPRADOR: "recomprador";
-                readonly VALIDADOR: "validador";
-                readonly ADMIN: "admin";
-            }>;
-            party_id: z.ZodNullable<z.ZodString>;
-            stellar_wallet: z.ZodNullable<z.ZodString>;
-            stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>, "many">;
+        }, z.core.$loose>>;
     };
     readonly 'users.recipients': {
         method: HttpMethod;
@@ -3863,13 +1621,13 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodUndefined;
-        params: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodArray<z.ZodObject<{
             id: z.ZodString;
             full_name: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             email: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            role: z.ZodNativeEnum<{
+            role: z.ZodEnum<{
                 readonly TSE: "tse";
                 readonly EMISOR: "emisor";
                 readonly COMPRADOR: "comprador";
@@ -3877,31 +1635,7 @@ export declare const apiContracts: {
                 readonly VALIDADOR: "validador";
                 readonly ADMIN: "admin";
             }>;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            full_name: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            email: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            role: z.ZodNativeEnum<{
-                readonly TSE: "tse";
-                readonly EMISOR: "emisor";
-                readonly COMPRADOR: "comprador";
-                readonly RECOMPRADOR: "recomprador";
-                readonly VALIDADOR: "validador";
-                readonly ADMIN: "admin";
-            }>;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            full_name: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            email: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            role: z.ZodNativeEnum<{
-                readonly TSE: "tse";
-                readonly EMISOR: "emisor";
-                readonly COMPRADOR: "comprador";
-                readonly RECOMPRADOR: "recomprador";
-                readonly VALIDADOR: "validador";
-                readonly ADMIN: "admin";
-            }>;
-        }, z.ZodTypeAny, "passthrough">>, "many">;
+        }, z.core.$loose>>;
     };
     readonly 'users.setRole': {
         method: HttpMethod;
@@ -3909,7 +1643,7 @@ export declare const apiContracts: {
         module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users";
         auth: boolean;
         body: z.ZodObject<{
-            role: z.ZodNativeEnum<{
+            role: z.ZodEnum<{
                 readonly TSE: "tse";
                 readonly EMISOR: "emisor";
                 readonly COMPRADOR: "comprador";
@@ -3917,24 +1651,16 @@ export declare const apiContracts: {
                 readonly VALIDADOR: "validador";
                 readonly ADMIN: "admin";
             }>;
-        }, "strict", z.ZodTypeAny, {
-            role: "tse" | "emisor" | "comprador" | "recomprador" | "validador" | "admin";
-        }, {
-            role: "tse" | "emisor" | "comprador" | "recomprador" | "validador" | "admin";
-        }>;
+        }, z.core.$strict>;
         params: z.ZodObject<{
             id: z.ZodString;
-        }, "strip", z.ZodTypeAny, {
-            id: string;
-        }, {
-            id: string;
-        }>;
-        query: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
         response: z.ZodObject<{
             id: z.ZodString;
             email: z.ZodString;
             full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
+            role: z.ZodEnum<{
                 readonly TSE: "tse";
                 readonly EMISOR: "emisor";
                 readonly COMPRADOR: "comprador";
@@ -3948,43 +1674,7 @@ export declare const apiContracts: {
             country: z.ZodOptional<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
-        }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-            id: z.ZodString;
-            email: z.ZodString;
-            full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
-                readonly TSE: "tse";
-                readonly EMISOR: "emisor";
-                readonly COMPRADOR: "comprador";
-                readonly RECOMPRADOR: "recomprador";
-                readonly VALIDADOR: "validador";
-                readonly ADMIN: "admin";
-            }>;
-            party_id: z.ZodNullable<z.ZodString>;
-            stellar_wallet: z.ZodNullable<z.ZodString>;
-            stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-            id: z.ZodString;
-            email: z.ZodString;
-            full_name: z.ZodNullable<z.ZodString>;
-            role: z.ZodNativeEnum<{
-                readonly TSE: "tse";
-                readonly EMISOR: "emisor";
-                readonly COMPRADOR: "comprador";
-                readonly RECOMPRADOR: "recomprador";
-                readonly VALIDADOR: "validador";
-                readonly ADMIN: "admin";
-            }>;
-            party_id: z.ZodNullable<z.ZodString>;
-            stellar_wallet: z.ZodNullable<z.ZodString>;
-            stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-            country: z.ZodOptional<z.ZodString>;
-            created_at: z.ZodString;
-            updated_at: z.ZodString;
-        }, z.ZodTypeAny, "passthrough">>;
+        }, z.core.$loose>;
     };
 };
 export type EndpointName = keyof typeof apiContracts;

--- a/packages/types/types/errors.d.ts
+++ b/packages/types/types/errors.d.ts
@@ -16,7 +16,7 @@ export declare const ErrorCode: {
     readonly INTERNAL_ERROR: "INTERNAL_ERROR";
 };
 export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
-export declare const errorCodeSchema: z.ZodNativeEnum<{
+export declare const errorCodeSchema: z.ZodEnum<{
     readonly VALIDATION_ERROR: "VALIDATION_ERROR";
     readonly RESPONSE_VALIDATION_ERROR: "RESPONSE_VALIDATION_ERROR";
     readonly UNAUTHORIZED: "UNAUTHORIZED";
@@ -37,7 +37,7 @@ export interface ValidationIssue {
     path: Array<string | number>;
 }
 export declare const contractErrorSchema: z.ZodObject<{
-    code: z.ZodNativeEnum<{
+    code: z.ZodEnum<{
         readonly VALIDATION_ERROR: "VALIDATION_ERROR";
         readonly RESPONSE_VALIDATION_ERROR: "RESPONSE_VALIDATION_ERROR";
         readonly UNAUTHORIZED: "UNAUTHORIZED";
@@ -51,26 +51,14 @@ export declare const contractErrorSchema: z.ZodObject<{
         readonly INTERNAL_ERROR: "INTERNAL_ERROR";
     }>;
     message: z.ZodString;
-    fields: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodArray<z.ZodString, "many">>>;
+    fields: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodArray<z.ZodString>>>;
     details: z.ZodOptional<z.ZodUnknown>;
     requestId: z.ZodOptional<z.ZodString>;
-}, "strip", z.ZodTypeAny, {
-    code: "VALIDATION_ERROR" | "RESPONSE_VALIDATION_ERROR" | "UNAUTHORIZED" | "FORBIDDEN" | "NOT_FOUND" | "CONFLICT" | "RATE_LIMITED" | "BUSINESS_RULE_VIOLATION" | "EXTERNAL_SERVICE_ERROR" | "NETWORK_ERROR" | "INTERNAL_ERROR";
-    message: string;
-    fields?: Record<string, string[]> | undefined;
-    details?: unknown;
-    requestId?: string | undefined;
-}, {
-    code: "VALIDATION_ERROR" | "RESPONSE_VALIDATION_ERROR" | "UNAUTHORIZED" | "FORBIDDEN" | "NOT_FOUND" | "CONFLICT" | "RATE_LIMITED" | "BUSINESS_RULE_VIOLATION" | "EXTERNAL_SERVICE_ERROR" | "NETWORK_ERROR" | "INTERNAL_ERROR";
-    message: string;
-    fields?: Record<string, string[]> | undefined;
-    details?: unknown;
-    requestId?: string | undefined;
-}>;
+}, z.core.$strip>;
 export declare const apiErrorResponseSchema: z.ZodObject<{
     success: z.ZodLiteral<false>;
     error: z.ZodObject<{
-        code: z.ZodNativeEnum<{
+        code: z.ZodEnum<{
             readonly VALIDATION_ERROR: "VALIDATION_ERROR";
             readonly RESPONSE_VALIDATION_ERROR: "RESPONSE_VALIDATION_ERROR";
             readonly UNAUTHORIZED: "UNAUTHORIZED";
@@ -84,41 +72,11 @@ export declare const apiErrorResponseSchema: z.ZodObject<{
             readonly INTERNAL_ERROR: "INTERNAL_ERROR";
         }>;
         message: z.ZodString;
-        fields: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodArray<z.ZodString, "many">>>;
+        fields: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodArray<z.ZodString>>>;
         details: z.ZodOptional<z.ZodUnknown>;
         requestId: z.ZodOptional<z.ZodString>;
-    }, "strip", z.ZodTypeAny, {
-        code: "VALIDATION_ERROR" | "RESPONSE_VALIDATION_ERROR" | "UNAUTHORIZED" | "FORBIDDEN" | "NOT_FOUND" | "CONFLICT" | "RATE_LIMITED" | "BUSINESS_RULE_VIOLATION" | "EXTERNAL_SERVICE_ERROR" | "NETWORK_ERROR" | "INTERNAL_ERROR";
-        message: string;
-        fields?: Record<string, string[]> | undefined;
-        details?: unknown;
-        requestId?: string | undefined;
-    }, {
-        code: "VALIDATION_ERROR" | "RESPONSE_VALIDATION_ERROR" | "UNAUTHORIZED" | "FORBIDDEN" | "NOT_FOUND" | "CONFLICT" | "RATE_LIMITED" | "BUSINESS_RULE_VIOLATION" | "EXTERNAL_SERVICE_ERROR" | "NETWORK_ERROR" | "INTERNAL_ERROR";
-        message: string;
-        fields?: Record<string, string[]> | undefined;
-        details?: unknown;
-        requestId?: string | undefined;
-    }>;
-}, "strip", z.ZodTypeAny, {
-    success: false;
-    error: {
-        code: "VALIDATION_ERROR" | "RESPONSE_VALIDATION_ERROR" | "UNAUTHORIZED" | "FORBIDDEN" | "NOT_FOUND" | "CONFLICT" | "RATE_LIMITED" | "BUSINESS_RULE_VIOLATION" | "EXTERNAL_SERVICE_ERROR" | "NETWORK_ERROR" | "INTERNAL_ERROR";
-        message: string;
-        fields?: Record<string, string[]> | undefined;
-        details?: unknown;
-        requestId?: string | undefined;
-    };
-}, {
-    success: false;
-    error: {
-        code: "VALIDATION_ERROR" | "RESPONSE_VALIDATION_ERROR" | "UNAUTHORIZED" | "FORBIDDEN" | "NOT_FOUND" | "CONFLICT" | "RATE_LIMITED" | "BUSINESS_RULE_VIOLATION" | "EXTERNAL_SERVICE_ERROR" | "NETWORK_ERROR" | "INTERNAL_ERROR";
-        message: string;
-        fields?: Record<string, string[]> | undefined;
-        details?: unknown;
-        requestId?: string | undefined;
-    };
-}>;
+    }, z.core.$strip>;
+}, z.core.$strip>;
 export type ContractError = z.infer<typeof contractErrorSchema>;
 export type ApiErrorResponse = z.infer<typeof apiErrorResponseSchema>;
 export declare function normalizeLocale(value?: string | null): Locale;

--- a/packages/types/types/errors.js
+++ b/packages/types/types/errors.js
@@ -84,7 +84,7 @@ const VALIDATION_MESSAGES = {
 exports.contractErrorSchema = zod_1.z.object({
     code: exports.errorCodeSchema,
     message: zod_1.z.string().min(1),
-    fields: zod_1.z.record(zod_1.z.array(zod_1.z.string())).optional(),
+    fields: zod_1.z.record(zod_1.z.string(), zod_1.z.array(zod_1.z.string())).optional(),
     details: zod_1.z.unknown().optional(),
     requestId: zod_1.z.string().optional(),
 });

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -3,6 +3,7 @@ export * from './country';
 export * from './bond';
 export * from './transfer';
 export * from './audit';
+export * from './report';
 export * from './escrow';
 export * from './api';
 export * from './notification';

--- a/packages/types/types/index.js
+++ b/packages/types/types/index.js
@@ -19,6 +19,7 @@ __exportStar(require("./country"), exports);
 __exportStar(require("./bond"), exports);
 __exportStar(require("./transfer"), exports);
 __exportStar(require("./audit"), exports);
+__exportStar(require("./report"), exports);
 __exportStar(require("./escrow"), exports);
 __exportStar(require("./api"), exports);
 __exportStar(require("./notification"), exports);

--- a/packages/types/types/notification.d.ts
+++ b/packages/types/types/notification.d.ts
@@ -10,6 +10,10 @@ export declare const NotificationType: {
     readonly PAYMENT_CONFIRMED: "payment_confirmed";
     readonly BOND_APPROVED: "bond_approved";
     readonly BOND_REJECTED: "bond_rejected";
+    readonly REPORT_SUBMITTED: "report_submitted";
+    readonly REPORT_OBSERVED: "report_observed";
+    readonly REPORT_APPROVED: "report_approved";
+    readonly REPORT_RESUBMITTED: "report_resubmitted";
 };
 export type NotificationType = (typeof NotificationType)[keyof typeof NotificationType];
 export interface Notification {

--- a/packages/types/types/notification.js
+++ b/packages/types/types/notification.js
@@ -13,4 +13,8 @@ exports.NotificationType = {
     PAYMENT_CONFIRMED: 'payment_confirmed',
     BOND_APPROVED: 'bond_approved',
     BOND_REJECTED: 'bond_rejected',
+    REPORT_SUBMITTED: 'report_submitted',
+    REPORT_OBSERVED: 'report_observed',
+    REPORT_APPROVED: 'report_approved',
+    REPORT_RESUBMITTED: 'report_resubmitted',
 };

--- a/packages/types/types/report.d.ts
+++ b/packages/types/types/report.d.ts
@@ -1,0 +1,189 @@
+/**
+ * Reporte mensual del partido al TSE — ciclo de vida completo, versionado y
+ * motor de conciliación contra los bonos que el partido realmente posee on-chain.
+ *
+ * Esta es la FUENTE DE VERDAD del dominio de reportes: la comparten `apps/api`
+ * (lógica y persistencia) y `apps/web` (builder multi-paso e historial). El
+ * módulo `reports` original solo guardaba metadata de texto libre; esto lo
+ * extiende a un reporte estructurado, con archivos, líneas y conciliación.
+ */
+/**
+ * Ciclo legal del reporte:
+ *   borrador → enviado → en_revision → observado → reenviado → (en_revision) → aprobado
+ *
+ * `aprobado` es terminal. `observado` es la vía de corrección: el partido
+ * reenvía (nueva versión) y vuelve a revisión.
+ */
+export declare const ReportStatus: {
+    readonly BORRADOR: "borrador";
+    readonly ENVIADO: "enviado";
+    readonly EN_REVISION: "en_revision";
+    readonly OBSERVADO: "observado";
+    readonly REENVIADO: "reenviado";
+    readonly APROBADO: "aprobado";
+};
+export type ReportStatus = (typeof ReportStatus)[keyof typeof ReportStatus];
+/** Estados en los que el partido todavía puede editar el borrador/corregir. */
+export declare const EDITABLE_REPORT_STATUSES: ReportStatus[];
+/** Categoría contable de una línea del reporte. */
+export declare const ReportLineCategory: {
+    readonly INGRESO: "ingreso";
+    readonly EGRESO: "egreso";
+    readonly DONACION: "donacion";
+    readonly BONO: "bono";
+    readonly OTRO: "otro";
+};
+export type ReportLineCategory = (typeof ReportLineCategory)[keyof typeof ReportLineCategory];
+export interface ReportLineItem {
+    id: string;
+    reportId: string;
+    concept: string;
+    amount: number;
+    category: ReportLineCategory;
+    /** Referencia al bono declarado (si la línea corresponde a un bono). */
+    bondTokenId: string | null;
+    createdAt: string;
+}
+/** Payload para crear/editar una línea (sin ids ni timestamps). */
+export interface ReportLineItemInput {
+    concept: string;
+    amount: number;
+    category: ReportLineCategory;
+    bondTokenId?: string | null;
+}
+/** Resultado del hook de antivirus (interfaz + stub, sin vendor real). */
+export declare const FileScanStatus: {
+    readonly PENDING: "pending";
+    readonly CLEAN: "clean";
+    readonly INFECTED: "infected";
+};
+export type FileScanStatus = (typeof FileScanStatus)[keyof typeof FileScanStatus];
+export interface ReportFile {
+    id: string;
+    reportId: string;
+    /** Ruta dentro del bucket privado de Storage. */
+    filePath: string;
+    fileName: string;
+    mimeType: string;
+    sizeBytes: number;
+    /** SHA-256 en hex del contenido, para integridad. */
+    checksum: string;
+    scanStatus: FileScanStatus;
+    createdAt: string;
+}
+/** Foto inmutable del reporte al momento de un envío. */
+export interface ReportSnapshot {
+    status: ReportStatus;
+    title: string;
+    periodYear: number;
+    periodMonth: number;
+    lineItems: Omit<ReportLineItem, 'reportId' | 'createdAt'>[];
+    files: Omit<ReportFile, 'reportId' | 'createdAt'>[];
+    declaredTotal: number;
+    reconciliation: ReconciliationResult;
+}
+export interface ReportVersion {
+    id: string;
+    reportId: string;
+    version: number;
+    status: ReportStatus;
+    snapshot: ReportSnapshot;
+    createdBy: string;
+    createdAt: string;
+}
+export interface MonthlyReport {
+    id: string;
+    partyId: string;
+    /** Año del período reportado. */
+    periodYear: number;
+    /** Mes del período reportado, 1-12. */
+    periodMonth: number;
+    status: ReportStatus;
+    /** Número de la versión vigente (empieza en 0 mientras es borrador). */
+    currentVersion: number;
+    title: string;
+    submittedBy: string | null;
+    submittedAt: string | null;
+    reviewedBy: string | null;
+    reviewedAt: string | null;
+    tseNotes: string | null;
+    createdAt: string;
+    updatedAt: string;
+}
+/** Reporte con sus relaciones cargadas, para el detalle/builder. */
+export interface MonthlyReportDetail extends MonthlyReport {
+    lineItems: ReportLineItem[];
+    files: ReportFile[];
+    versions: ReportVersion[];
+    reconciliation: ReconciliationResult;
+}
+/** Tipo de discrepancia detectada al conciliar el reporte con la cadena. */
+export declare const DiscrepancyType: {
+    /** El monto declarado no coincide con el valor del bono en poder del partido. */
+    readonly AMOUNT_MISMATCH: "amount_mismatch";
+    /** El partido posee un bono que no está declarado en el reporte. */
+    readonly MISSING_BOND: "missing_bond";
+    /** El reporte referencia un bono que el partido no posee. */
+    readonly UNKNOWN_REFERENCE: "unknown_reference";
+};
+export type DiscrepancyType = (typeof DiscrepancyType)[keyof typeof DiscrepancyType];
+export interface Discrepancy {
+    type: DiscrepancyType;
+    bondTokenId: string;
+    /** Monto declarado en el reporte (null si el bono no fue declarado). */
+    declaredAmount: number | null;
+    /** Monto real según la tenencia on-chain (null si no se posee). */
+    actualAmount: number | null;
+    message: string;
+}
+/** Un bono declarado en una línea del reporte. */
+export interface DeclaredBondRef {
+    bondTokenId: string;
+    amount: number;
+}
+/** Un bono efectivamente en poder del partido (alimentado por fixtures/DB). */
+export interface HeldBond {
+    bondTokenId: string;
+    amount: number;
+}
+export interface ReconciliationResult {
+    status: 'clean' | 'discrepancies';
+    discrepancies: Discrepancy[];
+    /** Suma de montos declarados en el reporte. */
+    declaredTotal: number;
+    /** Suma de montos reales de los bonos en poder del partido. */
+    actualTotal: number;
+    /** Cantidad de bonos que coincidieron exactamente. */
+    matchedCount: number;
+}
+/** Estado de cumplimiento de un período. */
+export declare const ComplianceStatus: {
+    /** Aún no vence. */
+    readonly NOT_DUE: "not_due";
+    /** Enviado antes del vencimiento. */
+    readonly ON_TIME: "on_time";
+    /** Enviado después del vencimiento pero dentro de la gracia. */
+    readonly LATE: "late";
+    /** Vencido y aún no enviado. */
+    readonly OVERDUE: "overdue";
+    /** Sin enviar y ya fuera de toda gracia. */
+    readonly MISSING: "missing";
+};
+export type ComplianceStatus = (typeof ComplianceStatus)[keyof typeof ComplianceStatus];
+/** Config del calendario de vencimientos mensuales. */
+export interface DeadlineConfig {
+    /** Día del mes SIGUIENTE en que vence el reporte de un período. Ej: 15. */
+    dueDayOfMonth: number;
+    /** Días de gracia tras el vencimiento antes de considerarlo "missing". */
+    graceDays: number;
+}
+export interface PeriodCompliance {
+    periodYear: number;
+    periodMonth: number;
+    /** Fecha de vencimiento calculada (ISO date, YYYY-MM-DD). */
+    dueDate: string;
+    status: ComplianceStatus;
+    /** Días hasta el vencimiento; negativo si ya pasó. null si ya se envió. */
+    daysRemaining: number | null;
+    submittedAt: string | null;
+}

--- a/packages/types/types/report.js
+++ b/packages/types/types/report.js
@@ -1,0 +1,83 @@
+"use strict";
+/**
+ * Reporte mensual del partido al TSE — ciclo de vida completo, versionado y
+ * motor de conciliación contra los bonos que el partido realmente posee on-chain.
+ *
+ * Esta es la FUENTE DE VERDAD del dominio de reportes: la comparten `apps/api`
+ * (lógica y persistencia) y `apps/web` (builder multi-paso e historial). El
+ * módulo `reports` original solo guardaba metadata de texto libre; esto lo
+ * extiende a un reporte estructurado, con archivos, líneas y conciliación.
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ComplianceStatus = exports.DiscrepancyType = exports.FileScanStatus = exports.ReportLineCategory = exports.EDITABLE_REPORT_STATUSES = exports.ReportStatus = void 0;
+// ---------------------------------------------------------------------------
+// Estados del workflow
+// ---------------------------------------------------------------------------
+/**
+ * Ciclo legal del reporte:
+ *   borrador → enviado → en_revision → observado → reenviado → (en_revision) → aprobado
+ *
+ * `aprobado` es terminal. `observado` es la vía de corrección: el partido
+ * reenvía (nueva versión) y vuelve a revisión.
+ */
+exports.ReportStatus = {
+    BORRADOR: 'borrador',
+    ENVIADO: 'enviado',
+    EN_REVISION: 'en_revision',
+    OBSERVADO: 'observado',
+    REENVIADO: 'reenviado',
+    APROBADO: 'aprobado',
+};
+/** Estados en los que el partido todavía puede editar el borrador/corregir. */
+exports.EDITABLE_REPORT_STATUSES = [
+    exports.ReportStatus.BORRADOR,
+    exports.ReportStatus.OBSERVADO,
+];
+// ---------------------------------------------------------------------------
+// Líneas del reporte
+// ---------------------------------------------------------------------------
+/** Categoría contable de una línea del reporte. */
+exports.ReportLineCategory = {
+    INGRESO: 'ingreso',
+    EGRESO: 'egreso',
+    DONACION: 'donacion',
+    BONO: 'bono',
+    OTRO: 'otro',
+};
+// ---------------------------------------------------------------------------
+// Archivos adjuntos
+// ---------------------------------------------------------------------------
+/** Resultado del hook de antivirus (interfaz + stub, sin vendor real). */
+exports.FileScanStatus = {
+    PENDING: 'pending',
+    CLEAN: 'clean',
+    INFECTED: 'infected',
+};
+// ---------------------------------------------------------------------------
+// Motor de conciliación (funciones puras)
+// ---------------------------------------------------------------------------
+/** Tipo de discrepancia detectada al conciliar el reporte con la cadena. */
+exports.DiscrepancyType = {
+    /** El monto declarado no coincide con el valor del bono en poder del partido. */
+    AMOUNT_MISMATCH: 'amount_mismatch',
+    /** El partido posee un bono que no está declarado en el reporte. */
+    MISSING_BOND: 'missing_bond',
+    /** El reporte referencia un bono que el partido no posee. */
+    UNKNOWN_REFERENCE: 'unknown_reference',
+};
+// ---------------------------------------------------------------------------
+// Deadlines y cumplimiento (funciones puras)
+// ---------------------------------------------------------------------------
+/** Estado de cumplimiento de un período. */
+exports.ComplianceStatus = {
+    /** Aún no vence. */
+    NOT_DUE: 'not_due',
+    /** Enviado antes del vencimiento. */
+    ON_TIME: 'on_time',
+    /** Enviado después del vencimiento pero dentro de la gracia. */
+    LATE: 'late',
+    /** Vencido y aún no enviado. */
+    OVERDUE: 'overdue',
+    /** Sin enviar y ya fuera de toda gracia. */
+    MISSING: 'missing',
+};

--- a/packages/types/types/schemas/auth.d.ts
+++ b/packages/types/types/schemas/auth.d.ts
@@ -1,19 +1,19 @@
 import { z } from 'zod';
-export declare const perspectiveSchema: z.ZodEnum<["usuario", "partido"]>;
+export declare const perspectiveSchema: z.ZodEnum<{
+    usuario: "usuario";
+    partido: "partido";
+}>;
 export declare const loginRequestSchema: z.ZodObject<{
     email: z.ZodString;
     password: z.ZodString;
-}, "strict", z.ZodTypeAny, {
-    email: string;
-    password: string;
-}, {
-    email: string;
-    password: string;
-}>;
-export declare const registerRequestSchema: z.ZodEffects<z.ZodObject<{
+}, z.core.$strict>;
+export declare const registerRequestSchema: z.ZodObject<{
     email: z.ZodString;
     password: z.ZodString;
-    perspectiva: z.ZodEnum<["usuario", "partido"]>;
+    perspectiva: z.ZodEnum<{
+        usuario: "usuario";
+        partido: "partido";
+    }>;
     nombres: z.ZodOptional<z.ZodString>;
     apellidos: z.ZodOptional<z.ZodString>;
     identificacion: z.ZodOptional<z.ZodString>;
@@ -23,100 +23,28 @@ export declare const registerRequestSchema: z.ZodEffects<z.ZodObject<{
     codigo: z.ZodOptional<z.ZodString>;
     representanteLegal: z.ZodOptional<z.ZodString>;
     cedulaJuridica: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    email: string;
-    password: string;
-    perspectiva: "usuario" | "partido";
-    nombres?: string | undefined;
-    apellidos?: string | undefined;
-    identificacion?: string | undefined;
-    telefono?: string | undefined;
-    direccion?: string | undefined;
-    nombrePartido?: string | undefined;
-    codigo?: string | undefined;
-    representanteLegal?: string | undefined;
-    cedulaJuridica?: string | undefined;
-}, {
-    email: string;
-    password: string;
-    perspectiva: "usuario" | "partido";
-    nombres?: string | undefined;
-    apellidos?: string | undefined;
-    identificacion?: string | undefined;
-    telefono?: string | undefined;
-    direccion?: string | undefined;
-    nombrePartido?: string | undefined;
-    codigo?: string | undefined;
-    representanteLegal?: string | undefined;
-    cedulaJuridica?: string | undefined;
-}>, {
-    email: string;
-    password: string;
-    perspectiva: "usuario" | "partido";
-    nombres?: string | undefined;
-    apellidos?: string | undefined;
-    identificacion?: string | undefined;
-    telefono?: string | undefined;
-    direccion?: string | undefined;
-    nombrePartido?: string | undefined;
-    codigo?: string | undefined;
-    representanteLegal?: string | undefined;
-    cedulaJuridica?: string | undefined;
-}, {
-    email: string;
-    password: string;
-    perspectiva: "usuario" | "partido";
-    nombres?: string | undefined;
-    apellidos?: string | undefined;
-    identificacion?: string | undefined;
-    telefono?: string | undefined;
-    direccion?: string | undefined;
-    nombrePartido?: string | undefined;
-    codigo?: string | undefined;
-    representanteLegal?: string | undefined;
-    cedulaJuridica?: string | undefined;
-}>;
+}, z.core.$strict>;
 export declare const registerResponseSchema: z.ZodObject<{
     id: z.ZodString;
     email: z.ZodString;
-    role: z.ZodEnum<["comprador", "emisor"]>;
-    perspectiva: z.ZodEnum<["usuario", "partido"]>;
+    role: z.ZodEnum<{
+        emisor: "emisor";
+        comprador: "comprador";
+    }>;
+    perspectiva: z.ZodEnum<{
+        usuario: "usuario";
+        partido: "partido";
+    }>;
     partyId: z.ZodNullable<z.ZodString>;
     wallet: z.ZodNullable<z.ZodString>;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    id: z.ZodString;
-    email: z.ZodString;
-    role: z.ZodEnum<["comprador", "emisor"]>;
-    perspectiva: z.ZodEnum<["usuario", "partido"]>;
-    partyId: z.ZodNullable<z.ZodString>;
-    wallet: z.ZodNullable<z.ZodString>;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    id: z.ZodString;
-    email: z.ZodString;
-    role: z.ZodEnum<["comprador", "emisor"]>;
-    perspectiva: z.ZodEnum<["usuario", "partido"]>;
-    partyId: z.ZodNullable<z.ZodString>;
-    wallet: z.ZodNullable<z.ZodString>;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const loginResponseSchema: z.ZodObject<{
     access_token: z.ZodString;
     refresh_token: z.ZodString;
     expires_in: z.ZodNumber;
     token_type: z.ZodString;
     user: z.ZodUnknown;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    access_token: z.ZodString;
-    refresh_token: z.ZodString;
-    expires_in: z.ZodNumber;
-    token_type: z.ZodString;
-    user: z.ZodUnknown;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    access_token: z.ZodString;
-    refresh_token: z.ZodString;
-    expires_in: z.ZodNumber;
-    token_type: z.ZodString;
-    user: z.ZodUnknown;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export type LoginRequest = z.input<typeof loginRequestSchema>;
 export type RegisterRequest = z.input<typeof registerRequestSchema>;
 export type RegisterResponse = z.output<typeof registerResponseSchema>;

--- a/packages/types/types/schemas/auth.js
+++ b/packages/types/types/schemas/auth.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.loginResponseSchema = exports.registerResponseSchema = exports.registerRequestSchema = exports.loginRequestSchema = exports.perspectiveSchema = void 0;
 const zod_1 = require("zod");
 const common_1 = require("./common");
-exports.perspectiveSchema = zod_1.z.enum(['usuario', 'partido'], { errorMap: () => ({ message: 'validation.enum' }) });
+exports.perspectiveSchema = zod_1.z.enum(['usuario', 'partido'], { error: 'validation.enum' });
 exports.loginRequestSchema = zod_1.z.object({
     email: common_1.requiredStringSchema.email('validation.email'),
     password: common_1.requiredStringSchema,

--- a/packages/types/types/schemas/bonds.d.ts
+++ b/packages/types/types/schemas/bonds.d.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export declare const bondStatusSchema: z.ZodNativeEnum<{
+export declare const bondStatusSchema: z.ZodEnum<{
     readonly EMITIDO: "emitido";
     readonly PENDIENTE: "pendiente";
     readonly APROBADO: "aprobado";
@@ -11,145 +11,49 @@ export declare const bondStatusSchema: z.ZodNativeEnum<{
     readonly RECHAZADO: "rechazado";
     readonly CONGELADO: "congelado";
 }>;
-export declare const createBondRequestSchema: z.ZodEffects<z.ZodObject<{
+export declare const createBondRequestSchema: z.ZodObject<{
     bondId: z.ZodString;
     issuerPartyId: z.ZodString;
     documentHash: z.ZodString;
     metadataUri: z.ZodOptional<z.ZodString>;
-    faceValue: z.ZodOptional<z.ZodNumber>;
+    faceValue: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
     initialOwner: z.ZodOptional<z.ZodString>;
     certificateNumber: z.ZodOptional<z.ZodString>;
     currency: z.ZodOptional<z.ZodString>;
-    interestRate: z.ZodOptional<z.ZodNumber>;
+    interestRate: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
     series: z.ZodOptional<z.ZodString>;
     issueDate: z.ZodOptional<z.ZodString>;
     maturityDate: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    bondId: string;
-    issuerPartyId: string;
-    documentHash: string;
-    metadataUri?: string | undefined;
-    faceValue?: number | undefined;
-    initialOwner?: string | undefined;
-    certificateNumber?: string | undefined;
-    currency?: string | undefined;
-    interestRate?: number | undefined;
-    series?: string | undefined;
-    issueDate?: string | undefined;
-    maturityDate?: string | undefined;
-}, {
-    bondId: string;
-    issuerPartyId: string;
-    documentHash: string;
-    metadataUri?: string | undefined;
-    faceValue?: number | undefined;
-    initialOwner?: string | undefined;
-    certificateNumber?: string | undefined;
-    currency?: string | undefined;
-    interestRate?: number | undefined;
-    series?: string | undefined;
-    issueDate?: string | undefined;
-    maturityDate?: string | undefined;
-}>, {
-    bondId: string;
-    issuerPartyId: string;
-    documentHash: string;
-    metadataUri?: string | undefined;
-    faceValue?: number | undefined;
-    initialOwner?: string | undefined;
-    certificateNumber?: string | undefined;
-    currency?: string | undefined;
-    interestRate?: number | undefined;
-    series?: string | undefined;
-    issueDate?: string | undefined;
-    maturityDate?: string | undefined;
-}, {
-    bondId: string;
-    issuerPartyId: string;
-    documentHash: string;
-    metadataUri?: string | undefined;
-    faceValue?: number | undefined;
-    initialOwner?: string | undefined;
-    certificateNumber?: string | undefined;
-    currency?: string | undefined;
-    interestRate?: number | undefined;
-    series?: string | undefined;
-    issueDate?: string | undefined;
-    maturityDate?: string | undefined;
-}>;
-export declare const createBondRequestRequestSchema: z.ZodEffects<z.ZodObject<{
-    faceValue: z.ZodNumber;
+}, z.core.$strict>;
+export declare const createBondRequestRequestSchema: z.ZodObject<{
+    faceValue: z.ZodCoercedNumber<unknown>;
     currency: z.ZodOptional<z.ZodString>;
-    interestRate: z.ZodOptional<z.ZodNumber>;
+    interestRate: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
     series: z.ZodOptional<z.ZodString>;
     issueDate: z.ZodOptional<z.ZodString>;
     maturityDate: z.ZodOptional<z.ZodString>;
     notes: z.ZodOptional<z.ZodString>;
     certificateNumber: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    faceValue: number;
-    certificateNumber?: string | undefined;
-    currency?: string | undefined;
-    interestRate?: number | undefined;
-    series?: string | undefined;
-    issueDate?: string | undefined;
-    maturityDate?: string | undefined;
-    notes?: string | undefined;
-}, {
-    faceValue: number;
-    certificateNumber?: string | undefined;
-    currency?: string | undefined;
-    interestRate?: number | undefined;
-    series?: string | undefined;
-    issueDate?: string | undefined;
-    maturityDate?: string | undefined;
-    notes?: string | undefined;
-}>, {
-    faceValue: number;
-    certificateNumber?: string | undefined;
-    currency?: string | undefined;
-    interestRate?: number | undefined;
-    series?: string | undefined;
-    issueDate?: string | undefined;
-    maturityDate?: string | undefined;
-    notes?: string | undefined;
-}, {
-    faceValue: number;
-    certificateNumber?: string | undefined;
-    currency?: string | undefined;
-    interestRate?: number | undefined;
-    series?: string | undefined;
-    issueDate?: string | undefined;
-    maturityDate?: string | undefined;
-    notes?: string | undefined;
-}>;
+}, z.core.$strict>;
 export declare const publishBondRequestSchema: z.ZodObject<{
-    paymentMethods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-}, "strict", z.ZodTypeAny, {
-    paymentMethods?: ("sinpe" | "transferencia" | "wallet")[] | undefined;
-}, {
-    paymentMethods?: ("sinpe" | "transferencia" | "wallet")[] | undefined;
-}>;
+    paymentMethods: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+        sinpe: "sinpe";
+        transferencia: "transferencia";
+        wallet: "wallet";
+    }>>>;
+}, z.core.$strict>;
 export declare const rejectBondRequestSchema: z.ZodObject<{
     reason: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    reason?: string | undefined;
-}, {
-    reason?: string | undefined;
-}>;
+}, z.core.$strict>;
 export declare const hashDocumentRequestSchema: z.ZodObject<{
     content: z.ZodString;
-}, "strict", z.ZodTypeAny, {
-    content: string;
-}, {
-    content: string;
-}>;
+}, z.core.$strict>;
 export declare const bondRowSchema: z.ZodObject<{
     token_id: z.ZodString;
     bond_id: z.ZodString;
     issuer_party_id: z.ZodString;
     current_owner: z.ZodNullable<z.ZodString>;
-    status: z.ZodNativeEnum<{
+    status: z.ZodEnum<{
         readonly EMITIDO: "emitido";
         readonly PENDIENTE: "pendiente";
         readonly APROBADO: "aprobado";
@@ -163,18 +67,22 @@ export declare const bondRowSchema: z.ZodObject<{
     }>;
     document_hash: z.ZodString;
     metadata_uri: z.ZodNullable<z.ZodString>;
-    face_value: z.ZodNullable<z.ZodNumber>;
+    face_value: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
     certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     currency: z.ZodOptional<z.ZodString>;
-    interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+    interest_rate: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
     series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     country: z.ZodOptional<z.ZodString>;
-    payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
+    payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<{
+        sinpe: "sinpe";
+        transferencia: "transferencia";
+        wallet: "wallet";
+    }>>>;
     stellar_status: z.ZodOptional<z.ZodString>;
     stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+    stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
     stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -182,193 +90,56 @@ export declare const bondRowSchema: z.ZodObject<{
     stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    token_id: z.ZodString;
-    bond_id: z.ZodString;
-    issuer_party_id: z.ZodString;
-    current_owner: z.ZodNullable<z.ZodString>;
-    status: z.ZodNativeEnum<{
-        readonly EMITIDO: "emitido";
-        readonly PENDIENTE: "pendiente";
-        readonly APROBADO: "aprobado";
-        readonly ACTIVO: "activo";
-        readonly EN_VENTA: "en_venta";
-        readonly EN_ESCROW: "en_escrow";
-        readonly TRANSFERIDO: "transferido";
-        readonly CANCELADO: "cancelado";
-        readonly RECHAZADO: "rechazado";
-        readonly CONGELADO: "congelado";
-    }>;
-    document_hash: z.ZodString;
-    metadata_uri: z.ZodNullable<z.ZodString>;
-    face_value: z.ZodNullable<z.ZodNumber>;
-    certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    currency: z.ZodOptional<z.ZodString>;
-    interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-    series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    country: z.ZodOptional<z.ZodString>;
-    payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-    stellar_status: z.ZodOptional<z.ZodString>;
-    stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-    stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    token_id: z.ZodString;
-    bond_id: z.ZodString;
-    issuer_party_id: z.ZodString;
-    current_owner: z.ZodNullable<z.ZodString>;
-    status: z.ZodNativeEnum<{
-        readonly EMITIDO: "emitido";
-        readonly PENDIENTE: "pendiente";
-        readonly APROBADO: "aprobado";
-        readonly ACTIVO: "activo";
-        readonly EN_VENTA: "en_venta";
-        readonly EN_ESCROW: "en_escrow";
-        readonly TRANSFERIDO: "transferido";
-        readonly CANCELADO: "cancelado";
-        readonly RECHAZADO: "rechazado";
-        readonly CONGELADO: "congelado";
-    }>;
-    document_hash: z.ZodString;
-    metadata_uri: z.ZodNullable<z.ZodString>;
-    face_value: z.ZodNullable<z.ZodNumber>;
-    certificate_number: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    currency: z.ZodOptional<z.ZodString>;
-    interest_rate: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-    series: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    issue_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    maturity_date: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    country: z.ZodOptional<z.ZodString>;
-    payment_methods: z.ZodOptional<z.ZodArray<z.ZodEnum<["sinpe", "transferencia", "wallet"]>, "many">>;
-    stellar_status: z.ZodOptional<z.ZodString>;
-    stellar_transaction_hash: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    stellar_ledger: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-    stellar_asset_code: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    stellar_issuer_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    stellar_owner_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    stellar_registered_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    stellar_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const bondRequestRowSchema: z.ZodObject<{
     id: z.ZodString;
     party_id: z.ZodString;
     requested_by: z.ZodString;
-    status: z.ZodEnum<["pendiente", "aprobado", "rechazado"]>;
-    face_value: z.ZodNumber;
+    status: z.ZodEnum<{
+        pendiente: "pendiente";
+        aprobado: "aprobado";
+        rechazado: "rechazado";
+    }>;
+    face_value: z.ZodCoercedNumber<unknown>;
     currency: z.ZodString;
-    interest_rate: z.ZodNullable<z.ZodNumber>;
+    interest_rate: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
     issue_date: z.ZodNullable<z.ZodString>;
     maturity_date: z.ZodNullable<z.ZodString>;
     bond_token_id: z.ZodNullable<z.ZodString>;
     rejection_reason: z.ZodNullable<z.ZodString>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    id: z.ZodString;
-    party_id: z.ZodString;
-    requested_by: z.ZodString;
-    status: z.ZodEnum<["pendiente", "aprobado", "rechazado"]>;
-    face_value: z.ZodNumber;
-    currency: z.ZodString;
-    interest_rate: z.ZodNullable<z.ZodNumber>;
-    issue_date: z.ZodNullable<z.ZodString>;
-    maturity_date: z.ZodNullable<z.ZodString>;
-    bond_token_id: z.ZodNullable<z.ZodString>;
-    rejection_reason: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    id: z.ZodString;
-    party_id: z.ZodString;
-    requested_by: z.ZodString;
-    status: z.ZodEnum<["pendiente", "aprobado", "rechazado"]>;
-    face_value: z.ZodNumber;
-    currency: z.ZodString;
-    interest_rate: z.ZodNullable<z.ZodNumber>;
-    issue_date: z.ZodNullable<z.ZodString>;
-    maturity_date: z.ZodNullable<z.ZodString>;
-    bond_token_id: z.ZodNullable<z.ZodString>;
-    rejection_reason: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const bondsQuerySchema: z.ZodObject<{
-    page: z.ZodOptional<z.ZodNumber>;
-    limit: z.ZodOptional<z.ZodNumber>;
+    page: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
+    limit: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
     country: z.ZodOptional<z.ZodString>;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    page: z.ZodOptional<z.ZodNumber>;
-    limit: z.ZodOptional<z.ZodNumber>;
-    country: z.ZodOptional<z.ZodString>;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    page: z.ZodOptional<z.ZodNumber>;
-    limit: z.ZodOptional<z.ZodNumber>;
-    country: z.ZodOptional<z.ZodString>;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const availableBondsQuerySchema: z.ZodObject<{
     country: z.ZodOptional<z.ZodString>;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    country: z.ZodOptional<z.ZodString>;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    country: z.ZodOptional<z.ZodString>;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const onchainBondResponseSchema: z.ZodObject<{
     enabled: z.ZodBoolean;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    enabled: z.ZodBoolean;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    enabled: z.ZodBoolean;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const sorobanBondResponseSchema: z.ZodObject<{
-    source: z.ZodEnum<["soroban", "database_snapshot"]>;
+    source: z.ZodEnum<{
+        soroban: "soroban";
+        database_snapshot: "database_snapshot";
+    }>;
     contract_id: z.ZodString;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    source: z.ZodEnum<["soroban", "database_snapshot"]>;
-    contract_id: z.ZodString;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    source: z.ZodEnum<["soroban", "database_snapshot"]>;
-    contract_id: z.ZodString;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const issueOnchainResponseSchema: z.ZodObject<{
     ok: z.ZodLiteral<true>;
     txHash: z.ZodOptional<z.ZodString>;
     alreadyIssued: z.ZodOptional<z.ZodBoolean>;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    ok: z.ZodLiteral<true>;
-    txHash: z.ZodOptional<z.ZodString>;
-    alreadyIssued: z.ZodOptional<z.ZodBoolean>;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    ok: z.ZodLiteral<true>;
-    txHash: z.ZodOptional<z.ZodString>;
-    alreadyIssued: z.ZodOptional<z.ZodBoolean>;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const documentUploadResponseSchema: z.ZodObject<{
     documentHash: z.ZodString;
     sorobanTxHash: z.ZodOptional<z.ZodString>;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    documentHash: z.ZodString;
-    sorobanTxHash: z.ZodOptional<z.ZodString>;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    documentHash: z.ZodString;
-    sorobanTxHash: z.ZodOptional<z.ZodString>;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const documentHashResponseSchema: z.ZodObject<{
     hash: z.ZodString;
-}, "strip", z.ZodTypeAny, {
-    hash: string;
-}, {
-    hash: string;
-}>;
+}, z.core.$strip>;
 export type CreateBondRequest = z.input<typeof createBondRequestSchema>;
 export type BondRequestRequest = z.input<typeof createBondRequestRequestSchema>;
 export type BondRow = z.output<typeof bondRowSchema>;

--- a/packages/types/types/schemas/common.d.ts
+++ b/packages/types/types/schemas/common.d.ts
@@ -3,9 +3,13 @@ export declare const requiredStringSchema: z.ZodString;
 export declare const idSchema: z.ZodString;
 export declare const isoDateSchema: z.ZodString;
 export declare const optionalIsoDateSchema: z.ZodOptional<z.ZodString>;
-export declare const positiveNumberSchema: z.ZodNumber;
-export declare const paymentMethodSchema: z.ZodEnum<["sinpe", "transferencia", "wallet"]>;
-export declare const roleSchema: z.ZodNativeEnum<{
+export declare const positiveNumberSchema: z.ZodCoercedNumber<unknown>;
+export declare const paymentMethodSchema: z.ZodEnum<{
+    sinpe: "sinpe";
+    transferencia: "transferencia";
+    wallet: "wallet";
+}>;
+export declare const roleSchema: z.ZodEnum<{
     readonly TSE: "tse";
     readonly EMISOR: "emisor";
     readonly COMPRADOR: "comprador";
@@ -15,63 +19,27 @@ export declare const roleSchema: z.ZodNativeEnum<{
 }>;
 export declare const paramsIdSchema: z.ZodObject<{
     id: z.ZodString;
-}, "strip", z.ZodTypeAny, {
-    id: string;
-}, {
-    id: string;
-}>;
+}, z.core.$strip>;
 export declare const paramsTokenIdSchema: z.ZodObject<{
     tokenId: z.ZodString;
-}, "strip", z.ZodTypeAny, {
-    tokenId: string;
-}, {
-    tokenId: string;
-}>;
+}, z.core.$strip>;
 export declare const paramsBondTokenIdSchema: z.ZodObject<{
     bondTokenId: z.ZodString;
-}, "strip", z.ZodTypeAny, {
-    bondTokenId: string;
-}, {
-    bondTokenId: string;
-}>;
-export declare const emptyObjectSchema: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+}, z.core.$strip>;
+export declare const emptyObjectSchema: z.ZodObject<{}, z.core.$strict>;
 export declare const okSchema: z.ZodObject<{
     ok: z.ZodLiteral<true>;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    ok: z.ZodLiteral<true>;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    ok: z.ZodLiteral<true>;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const successSchema: z.ZodObject<{
     success: z.ZodLiteral<true>;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    success: z.ZodLiteral<true>;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    success: z.ZodLiteral<true>;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const paginationQuerySchema: z.ZodObject<{
-    page: z.ZodOptional<z.ZodNumber>;
-    limit: z.ZodOptional<z.ZodNumber>;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    page: z.ZodOptional<z.ZodNumber>;
-    limit: z.ZodOptional<z.ZodNumber>;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    page: z.ZodOptional<z.ZodNumber>;
-    limit: z.ZodOptional<z.ZodNumber>;
-}, z.ZodTypeAny, "passthrough">>;
+    page: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
+    limit: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
+}, z.core.$loose>;
 export declare function paginatedSchema<T extends z.ZodTypeAny>(item: T): z.ZodObject<{
-    data: z.ZodArray<T, "many">;
+    data: z.ZodArray<T>;
     total: z.ZodNumber;
     page: z.ZodNumber;
     limit: z.ZodNumber;
-}, "strip", z.ZodTypeAny, {
-    page: number;
-    limit: number;
-    data: T["_output"][];
-    total: number;
-}, {
-    page: number;
-    limit: number;
-    data: T["_input"][];
-    total: number;
-}>;
+}, z.core.$strip>;

--- a/packages/types/types/schemas/common.js
+++ b/packages/types/types/schemas/common.js
@@ -4,13 +4,13 @@ exports.paginationQuerySchema = exports.successSchema = exports.okSchema = expor
 exports.paginatedSchema = paginatedSchema;
 const zod_1 = require("zod");
 const roles_1 = require("../roles");
-exports.requiredStringSchema = zod_1.z.string({ required_error: 'validation.required' }).trim().min(1, 'validation.required');
+exports.requiredStringSchema = zod_1.z.string({ error: 'validation.required' }).trim().min(1, 'validation.required');
 exports.idSchema = exports.requiredStringSchema;
 exports.isoDateSchema = zod_1.z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'validation.date');
 exports.optionalIsoDateSchema = exports.isoDateSchema.optional();
-exports.positiveNumberSchema = zod_1.z.coerce.number({ invalid_type_error: 'validation.positive' }).finite().positive('validation.positive');
-exports.paymentMethodSchema = zod_1.z.enum(['sinpe', 'transferencia', 'wallet'], { errorMap: () => ({ message: 'validation.enum' }) });
-exports.roleSchema = zod_1.z.nativeEnum(roles_1.Role, { errorMap: () => ({ message: 'validation.enum' }) });
+exports.positiveNumberSchema = zod_1.z.coerce.number({ error: 'validation.positive' }).finite().positive('validation.positive');
+exports.paymentMethodSchema = zod_1.z.enum(['sinpe', 'transferencia', 'wallet'], { error: 'validation.enum' });
+exports.roleSchema = zod_1.z.nativeEnum(roles_1.Role, { error: 'validation.enum' });
 exports.paramsIdSchema = zod_1.z.object({ id: exports.idSchema });
 exports.paramsTokenIdSchema = zod_1.z.object({ tokenId: exports.idSchema });
 exports.paramsBondTokenIdSchema = zod_1.z.object({ bondTokenId: exports.idSchema });

--- a/packages/types/types/schemas/escrow.d.ts
+++ b/packages/types/types/schemas/escrow.d.ts
@@ -5,32 +5,17 @@ export declare const escrowOperationSchema: z.ZodObject<{
     seller: z.ZodString;
     buyer: z.ZodString;
     approver: z.ZodString;
-    amount: z.ZodNumber;
+    amount: z.ZodCoercedNumber<unknown>;
     title: z.ZodString;
-}, "strict", z.ZodTypeAny, {
-    bondTokenId: string;
-    amount: number;
-    title: string;
-    transferId: string;
-    seller: string;
-    buyer: string;
-    approver: string;
-}, {
-    bondTokenId: string;
-    amount: number;
-    title: string;
-    transferId: string;
-    seller: string;
-    buyer: string;
-    approver: string;
-}>;
+}, z.core.$strict>;
 export declare const escrowStateSchema: z.ZodObject<{
     contractId: z.ZodOptional<z.ZodString>;
-    status: z.ZodOptional<z.ZodEnum<["initialized", "funded", "approved", "released", "refunded", "disputed"]>>;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    contractId: z.ZodOptional<z.ZodString>;
-    status: z.ZodOptional<z.ZodEnum<["initialized", "funded", "approved", "released", "refunded", "disputed"]>>;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    contractId: z.ZodOptional<z.ZodString>;
-    status: z.ZodOptional<z.ZodEnum<["initialized", "funded", "approved", "released", "refunded", "disputed"]>>;
-}, z.ZodTypeAny, "passthrough">>;
+    status: z.ZodOptional<z.ZodEnum<{
+        initialized: "initialized";
+        funded: "funded";
+        approved: "approved";
+        released: "released";
+        refunded: "refunded";
+        disputed: "disputed";
+    }>>;
+}, z.core.$loose>;

--- a/packages/types/types/schemas/notifications.d.ts
+++ b/packages/types/types/schemas/notifications.d.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 export declare const notificationRowSchema: z.ZodObject<{
     id: z.ZodString;
     user_id: z.ZodString;
-    type: z.ZodNativeEnum<{
+    type: z.ZodEnum<{
         readonly OFFER_RECEIVED: "offer_received";
         readonly OFFER_ACCEPTED: "offer_accepted";
         readonly OFFER_REJECTED: "offer_rejected";
@@ -10,46 +10,20 @@ export declare const notificationRowSchema: z.ZodObject<{
         readonly PAYMENT_CONFIRMED: "payment_confirmed";
         readonly BOND_APPROVED: "bond_approved";
         readonly BOND_REJECTED: "bond_rejected";
+        readonly REPORT_SUBMITTED: "report_submitted";
+        readonly REPORT_OBSERVED: "report_observed";
+        readonly REPORT_APPROVED: "report_approved";
+        readonly REPORT_RESUBMITTED: "report_resubmitted";
     }>;
     payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
     read: z.ZodBoolean;
     created_at: z.ZodString;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    id: z.ZodString;
-    user_id: z.ZodString;
-    type: z.ZodNativeEnum<{
-        readonly OFFER_RECEIVED: "offer_received";
-        readonly OFFER_ACCEPTED: "offer_accepted";
-        readonly OFFER_REJECTED: "offer_rejected";
-        readonly COUNTER_OFFER_RECEIVED: "counter_offer_received";
-        readonly PAYMENT_CONFIRMED: "payment_confirmed";
-        readonly BOND_APPROVED: "bond_approved";
-        readonly BOND_REJECTED: "bond_rejected";
-    }>;
-    payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-    read: z.ZodBoolean;
-    created_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    id: z.ZodString;
-    user_id: z.ZodString;
-    type: z.ZodNativeEnum<{
-        readonly OFFER_RECEIVED: "offer_received";
-        readonly OFFER_ACCEPTED: "offer_accepted";
-        readonly OFFER_REJECTED: "offer_rejected";
-        readonly COUNTER_OFFER_RECEIVED: "counter_offer_received";
-        readonly PAYMENT_CONFIRMED: "payment_confirmed";
-        readonly BOND_APPROVED: "bond_approved";
-        readonly BOND_REJECTED: "bond_rejected";
-    }>;
-    payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-    read: z.ZodBoolean;
-    created_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const notificationsResponseSchema: z.ZodObject<{
     notifications: z.ZodArray<z.ZodObject<{
         id: z.ZodString;
         user_id: z.ZodString;
-        type: z.ZodNativeEnum<{
+        type: z.ZodEnum<{
             readonly OFFER_RECEIVED: "offer_received";
             readonly OFFER_ACCEPTED: "offer_accepted";
             readonly OFFER_REJECTED: "offer_rejected";
@@ -57,76 +31,14 @@ export declare const notificationsResponseSchema: z.ZodObject<{
             readonly PAYMENT_CONFIRMED: "payment_confirmed";
             readonly BOND_APPROVED: "bond_approved";
             readonly BOND_REJECTED: "bond_rejected";
+            readonly REPORT_SUBMITTED: "report_submitted";
+            readonly REPORT_OBSERVED: "report_observed";
+            readonly REPORT_APPROVED: "report_approved";
+            readonly REPORT_RESUBMITTED: "report_resubmitted";
         }>;
         payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
         read: z.ZodBoolean;
         created_at: z.ZodString;
-    }, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-        id: z.ZodString;
-        user_id: z.ZodString;
-        type: z.ZodNativeEnum<{
-            readonly OFFER_RECEIVED: "offer_received";
-            readonly OFFER_ACCEPTED: "offer_accepted";
-            readonly OFFER_REJECTED: "offer_rejected";
-            readonly COUNTER_OFFER_RECEIVED: "counter_offer_received";
-            readonly PAYMENT_CONFIRMED: "payment_confirmed";
-            readonly BOND_APPROVED: "bond_approved";
-            readonly BOND_REJECTED: "bond_rejected";
-        }>;
-        payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        read: z.ZodBoolean;
-        created_at: z.ZodString;
-    }, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-        id: z.ZodString;
-        user_id: z.ZodString;
-        type: z.ZodNativeEnum<{
-            readonly OFFER_RECEIVED: "offer_received";
-            readonly OFFER_ACCEPTED: "offer_accepted";
-            readonly OFFER_REJECTED: "offer_rejected";
-            readonly COUNTER_OFFER_RECEIVED: "counter_offer_received";
-            readonly PAYMENT_CONFIRMED: "payment_confirmed";
-            readonly BOND_APPROVED: "bond_approved";
-            readonly BOND_REJECTED: "bond_rejected";
-        }>;
-        payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        read: z.ZodBoolean;
-        created_at: z.ZodString;
-    }, z.ZodTypeAny, "passthrough">>, "many">;
+    }, z.core.$loose>>;
     unreadCount: z.ZodNumber;
-}, "strip", z.ZodTypeAny, {
-    notifications: z.objectOutputType<{
-        id: z.ZodString;
-        user_id: z.ZodString;
-        type: z.ZodNativeEnum<{
-            readonly OFFER_RECEIVED: "offer_received";
-            readonly OFFER_ACCEPTED: "offer_accepted";
-            readonly OFFER_REJECTED: "offer_rejected";
-            readonly COUNTER_OFFER_RECEIVED: "counter_offer_received";
-            readonly PAYMENT_CONFIRMED: "payment_confirmed";
-            readonly BOND_APPROVED: "bond_approved";
-            readonly BOND_REJECTED: "bond_rejected";
-        }>;
-        payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        read: z.ZodBoolean;
-        created_at: z.ZodString;
-    }, z.ZodTypeAny, "passthrough">[];
-    unreadCount: number;
-}, {
-    notifications: z.objectInputType<{
-        id: z.ZodString;
-        user_id: z.ZodString;
-        type: z.ZodNativeEnum<{
-            readonly OFFER_RECEIVED: "offer_received";
-            readonly OFFER_ACCEPTED: "offer_accepted";
-            readonly OFFER_REJECTED: "offer_rejected";
-            readonly COUNTER_OFFER_RECEIVED: "counter_offer_received";
-            readonly PAYMENT_CONFIRMED: "payment_confirmed";
-            readonly BOND_APPROVED: "bond_approved";
-            readonly BOND_REJECTED: "bond_rejected";
-        }>;
-        payload: z.ZodRecord<z.ZodString, z.ZodUnknown>;
-        read: z.ZodBoolean;
-        created_at: z.ZodString;
-    }, z.ZodTypeAny, "passthrough">[];
-    unreadCount: number;
-}>;
+}, z.core.$strip>;

--- a/packages/types/types/schemas/notifications.js
+++ b/packages/types/types/schemas/notifications.js
@@ -8,7 +8,7 @@ exports.notificationRowSchema = zod_1.z.object({
     id: common_1.idSchema,
     user_id: common_1.idSchema,
     type: zod_1.z.nativeEnum(notification_1.NotificationType),
-    payload: zod_1.z.record(zod_1.z.unknown()),
+    payload: zod_1.z.record(zod_1.z.string(), zod_1.z.unknown()),
     read: zod_1.z.boolean(),
     created_at: zod_1.z.string(),
 }).passthrough();

--- a/packages/types/types/schemas/reports.d.ts
+++ b/packages/types/types/schemas/reports.d.ts
@@ -1,51 +1,26 @@
 import { z } from 'zod';
-export declare const reportStatusSchema: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
-export declare const createReportRequestSchema: z.ZodEffects<z.ZodObject<{
+export declare const reportStatusSchema: z.ZodEnum<{
+    aprobado: "aprobado";
+    enviado: "enviado";
+    revisado: "revisado";
+    observado: "observado";
+}>;
+export declare const createReportRequestSchema: z.ZodObject<{
     title: z.ZodString;
     description: z.ZodString;
     period_start: z.ZodOptional<z.ZodString>;
     period_end: z.ZodOptional<z.ZodString>;
-    bond_token_ids: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
-    total_amount: z.ZodOptional<z.ZodNumber>;
-}, "strict", z.ZodTypeAny, {
-    title: string;
-    description: string;
-    period_start?: string | undefined;
-    period_end?: string | undefined;
-    bond_token_ids?: string[] | undefined;
-    total_amount?: number | undefined;
-}, {
-    title: string;
-    description: string;
-    period_start?: string | undefined;
-    period_end?: string | undefined;
-    bond_token_ids?: string[] | undefined;
-    total_amount?: number | undefined;
-}>, {
-    title: string;
-    description: string;
-    period_start?: string | undefined;
-    period_end?: string | undefined;
-    bond_token_ids?: string[] | undefined;
-    total_amount?: number | undefined;
-}, {
-    title: string;
-    description: string;
-    period_start?: string | undefined;
-    period_end?: string | undefined;
-    bond_token_ids?: string[] | undefined;
-    total_amount?: number | undefined;
-}>;
+    bond_token_ids: z.ZodOptional<z.ZodArray<z.ZodString>>;
+    total_amount: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
+}, z.core.$strict>;
 export declare const reviewReportRequestSchema: z.ZodObject<{
-    status: z.ZodEnum<["revisado", "observado", "aprobado"]>;
+    status: z.ZodEnum<{
+        aprobado: "aprobado";
+        revisado: "revisado";
+        observado: "observado";
+    }>;
     notes: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    status: "aprobado" | "revisado" | "observado";
-    notes?: string | undefined;
-}, {
-    status: "aprobado" | "revisado" | "observado";
-    notes?: string | undefined;
-}>;
+}, z.core.$strict>;
 export declare const reportRowSchema: z.ZodObject<{
     id: z.ZodString;
     party_id: z.ZodString;
@@ -54,46 +29,19 @@ export declare const reportRowSchema: z.ZodObject<{
     description: z.ZodString;
     period_start: z.ZodNullable<z.ZodString>;
     period_end: z.ZodNullable<z.ZodString>;
-    bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-    total_amount: z.ZodNullable<z.ZodNumber>;
-    status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
+    bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString>>;
+    total_amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+    status: z.ZodEnum<{
+        aprobado: "aprobado";
+        enviado: "enviado";
+        revisado: "revisado";
+        observado: "observado";
+    }>;
     reviewed_by: z.ZodNullable<z.ZodString>;
     reviewed_at: z.ZodNullable<z.ZodString>;
     tse_notes: z.ZodNullable<z.ZodString>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    id: z.ZodString;
-    party_id: z.ZodString;
-    submitted_by: z.ZodString;
-    title: z.ZodString;
-    description: z.ZodString;
-    period_start: z.ZodNullable<z.ZodString>;
-    period_end: z.ZodNullable<z.ZodString>;
-    bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-    total_amount: z.ZodNullable<z.ZodNumber>;
-    status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
-    reviewed_by: z.ZodNullable<z.ZodString>;
-    reviewed_at: z.ZodNullable<z.ZodString>;
-    tse_notes: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    id: z.ZodString;
-    party_id: z.ZodString;
-    submitted_by: z.ZodString;
-    title: z.ZodString;
-    description: z.ZodString;
-    period_start: z.ZodNullable<z.ZodString>;
-    period_end: z.ZodNullable<z.ZodString>;
-    bond_token_ids: z.ZodNullable<z.ZodArray<z.ZodString, "many">>;
-    total_amount: z.ZodNullable<z.ZodNumber>;
-    status: z.ZodEnum<["enviado", "revisado", "observado", "aprobado"]>;
-    reviewed_by: z.ZodNullable<z.ZodString>;
-    reviewed_at: z.ZodNullable<z.ZodString>;
-    tse_notes: z.ZodNullable<z.ZodString>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export type CreateReportRequest = z.input<typeof createReportRequestSchema>;
 export type ReportRow = z.output<typeof reportRowSchema>;

--- a/packages/types/types/schemas/reports.js
+++ b/packages/types/types/schemas/reports.js
@@ -13,7 +13,7 @@ exports.createReportRequestSchema = zod_1.z.object({
     total_amount: common_1.positiveNumberSchema.optional(),
 }).strict().refine((value) => !value.period_start || !value.period_end || value.period_end >= value.period_start, { path: ['period_end'], message: 'validation.date' });
 exports.reviewReportRequestSchema = zod_1.z.object({
-    status: zod_1.z.enum(['revisado', 'observado', 'aprobado'], { errorMap: () => ({ message: 'validation.enum' }) }),
+    status: zod_1.z.enum(['revisado', 'observado', 'aprobado'], { error: 'validation.enum' }),
     notes: zod_1.z.string().trim().max(2000).optional(),
 }).strict();
 exports.reportRowSchema = zod_1.z.object({

--- a/packages/types/types/schemas/transfers.d.ts
+++ b/packages/types/types/schemas/transfers.d.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-export declare const transferStatusSchema: z.ZodNativeEnum<{
+export declare const transferStatusSchema: z.ZodEnum<{
     readonly SOLICITADA: "solicitada";
     readonly ACEPTADA: "aceptada";
     readonly CONTRAOFERTA: "contraoferta";
@@ -13,78 +13,38 @@ export declare const transferStatusSchema: z.ZodNativeEnum<{
 export declare const createTransferRequestSchema: z.ZodObject<{
     bondTokenId: z.ZodString;
     toOwner: z.ZodOptional<z.ZodString>;
-    paymentMethod: z.ZodOptional<z.ZodEnum<["sinpe", "transferencia", "wallet"]>>;
-    amount: z.ZodOptional<z.ZodNumber>;
+    paymentMethod: z.ZodOptional<z.ZodEnum<{
+        sinpe: "sinpe";
+        transferencia: "transferencia";
+        wallet: "wallet";
+    }>>;
+    amount: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
     message: z.ZodOptional<z.ZodString>;
-    counterOfferAmount: z.ZodOptional<z.ZodNumber>;
-}, "strict", z.ZodTypeAny, {
-    bondTokenId: string;
-    message?: string | undefined;
-    toOwner?: string | undefined;
-    paymentMethod?: "sinpe" | "transferencia" | "wallet" | undefined;
-    amount?: number | undefined;
-    counterOfferAmount?: number | undefined;
-}, {
-    bondTokenId: string;
-    message?: string | undefined;
-    toOwner?: string | undefined;
-    paymentMethod?: "sinpe" | "transferencia" | "wallet" | undefined;
-    amount?: number | undefined;
-    counterOfferAmount?: number | undefined;
-}>;
+    counterOfferAmount: z.ZodOptional<z.ZodCoercedNumber<unknown>>;
+}, z.core.$strict>;
 export declare const counterOfferRequestSchema: z.ZodObject<{
-    amount: z.ZodNumber;
+    amount: z.ZodCoercedNumber<unknown>;
     message: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    amount: number;
-    message?: string | undefined;
-}, {
-    amount: number;
-    message?: string | undefined;
-}>;
-export declare const registerPaymentRequestSchema: z.ZodEffects<z.ZodObject<{
+}, z.core.$strict>;
+export declare const registerPaymentRequestSchema: z.ZodObject<{
     evidence: z.ZodOptional<z.ZodString>;
     evidenceContent: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    evidence?: string | undefined;
-    evidenceContent?: string | undefined;
-}, {
-    evidence?: string | undefined;
-    evidenceContent?: string | undefined;
-}>, {
-    evidence?: string | undefined;
-    evidenceContent?: string | undefined;
-}, {
-    evidence?: string | undefined;
-    evidenceContent?: string | undefined;
-}>;
+}, z.core.$strict>;
 export declare const submitXdrRequestSchema: z.ZodObject<{
     signedXdr: z.ZodString;
-}, "strict", z.ZodTypeAny, {
-    signedXdr: string;
-}, {
-    signedXdr: string;
-}>;
+}, z.core.$strict>;
 export declare const requestReturnRequestSchema: z.ZodObject<{
     reason: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    reason?: string | undefined;
-}, {
-    reason?: string | undefined;
-}>;
+}, z.core.$strict>;
 export declare const returnDecisionRequestSchema: z.ZodObject<{
     notes: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    notes?: string | undefined;
-}, {
-    notes?: string | undefined;
-}>;
+}, z.core.$strict>;
 export declare const transferRowSchema: z.ZodObject<{
     id: z.ZodString;
     bond_token_id: z.ZodString;
     from_owner: z.ZodString;
     to_owner: z.ZodString;
-    status: z.ZodNativeEnum<{
+    status: z.ZodEnum<{
         readonly SOLICITADA: "solicitada";
         readonly ACEPTADA: "aceptada";
         readonly CONTRAOFERTA: "contraoferta";
@@ -98,8 +58,8 @@ export declare const transferRowSchema: z.ZodObject<{
     escrow_contract_id: z.ZodNullable<z.ZodString>;
     payment_evidence_hash: z.ZodNullable<z.ZodString>;
     validated_by: z.ZodNullable<z.ZodString>;
-    amount: z.ZodNullable<z.ZodNumber>;
-    counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+    amount: z.ZodNullable<z.ZodCoercedNumber<unknown>>;
+    counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodCoercedNumber<unknown>>>;
     seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
@@ -112,102 +72,18 @@ export declare const transferRowSchema: z.ZodObject<{
     return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    id: z.ZodString;
-    bond_token_id: z.ZodString;
-    from_owner: z.ZodString;
-    to_owner: z.ZodString;
-    status: z.ZodNativeEnum<{
-        readonly SOLICITADA: "solicitada";
-        readonly ACEPTADA: "aceptada";
-        readonly CONTRAOFERTA: "contraoferta";
-        readonly EN_ESCROW: "en_escrow";
-        readonly PAGO_REGISTRADO: "pago_registrado";
-        readonly PAGO_VALIDADO: "pago_validado";
-        readonly LIBERADA: "liberada";
-        readonly RECHAZADA: "rechazada";
-        readonly CANCELADA: "cancelada";
-    }>;
-    escrow_contract_id: z.ZodNullable<z.ZodString>;
-    payment_evidence_hash: z.ZodNullable<z.ZodString>;
-    validated_by: z.ZodNullable<z.ZodString>;
-    amount: z.ZodNullable<z.ZodNumber>;
-    counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-    seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    id: z.ZodString;
-    bond_token_id: z.ZodString;
-    from_owner: z.ZodString;
-    to_owner: z.ZodString;
-    status: z.ZodNativeEnum<{
-        readonly SOLICITADA: "solicitada";
-        readonly ACEPTADA: "aceptada";
-        readonly CONTRAOFERTA: "contraoferta";
-        readonly EN_ESCROW: "en_escrow";
-        readonly PAGO_REGISTRADO: "pago_registrado";
-        readonly PAGO_VALIDADO: "pago_validado";
-        readonly LIBERADA: "liberada";
-        readonly RECHAZADA: "rechazada";
-        readonly CANCELADA: "cancelada";
-    }>;
-    escrow_contract_id: z.ZodNullable<z.ZodString>;
-    payment_evidence_hash: z.ZodNullable<z.ZodString>;
-    validated_by: z.ZodNullable<z.ZodString>;
-    amount: z.ZodNullable<z.ZodNumber>;
-    counter_offer_amount: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
-    seller_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    buyer_message: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_requested_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_requested_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_reason: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_approved_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_approved_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_rejected_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_rejected_by: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    return_tse_notes: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const xdrResponseSchema: z.ZodObject<{
     xdr: z.ZodString;
     networkPassphrase: z.ZodString;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    xdr: z.ZodString;
-    networkPassphrase: z.ZodString;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    xdr: z.ZodString;
-    networkPassphrase: z.ZodString;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const transactionResponseSchema: z.ZodObject<{
     success: z.ZodLiteral<true>;
     txHash: z.ZodOptional<z.ZodString>;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    success: z.ZodLiteral<true>;
-    txHash: z.ZodOptional<z.ZodString>;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    success: z.ZodLiteral<true>;
-    txHash: z.ZodOptional<z.ZodString>;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const releaseResponseSchema: z.ZodObject<{
     success: z.ZodLiteral<true>;
     newOwner: z.ZodString;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    success: z.ZodLiteral<true>;
-    newOwner: z.ZodString;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    success: z.ZodLiteral<true>;
-    newOwner: z.ZodString;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export type CreateTransferRequest = z.input<typeof createTransferRequestSchema>;
 export type TransferRow = z.output<typeof transferRowSchema>;

--- a/packages/types/types/schemas/users.d.ts
+++ b/packages/types/types/schemas/users.d.ts
@@ -1,24 +1,12 @@
 import { z } from 'zod';
-export declare const updateProfileRequestSchema: z.ZodEffects<z.ZodObject<{
+export declare const updateProfileRequestSchema: z.ZodObject<{
     full_name: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    full_name?: string | undefined;
-}, {
-    full_name?: string | undefined;
-}>, {
-    full_name?: string | undefined;
-}, {
-    full_name?: string | undefined;
-}>;
+}, z.core.$strict>;
 export declare const updateWalletRequestSchema: z.ZodObject<{
     publicKey: z.ZodString;
-}, "strict", z.ZodTypeAny, {
-    publicKey: string;
-}, {
-    publicKey: string;
-}>;
+}, z.core.$strict>;
 export declare const setRoleRequestSchema: z.ZodObject<{
-    role: z.ZodNativeEnum<{
+    role: z.ZodEnum<{
         readonly TSE: "tse";
         readonly EMISOR: "emisor";
         readonly COMPRADOR: "comprador";
@@ -26,16 +14,12 @@ export declare const setRoleRequestSchema: z.ZodObject<{
         readonly VALIDADOR: "validador";
         readonly ADMIN: "admin";
     }>;
-}, "strict", z.ZodTypeAny, {
-    role: "tse" | "emisor" | "comprador" | "recomprador" | "validador" | "admin";
-}, {
-    role: "tse" | "emisor" | "comprador" | "recomprador" | "validador" | "admin";
-}>;
+}, z.core.$strict>;
 export declare const profileRowSchema: z.ZodObject<{
     id: z.ZodString;
     email: z.ZodString;
     full_name: z.ZodNullable<z.ZodString>;
-    role: z.ZodNativeEnum<{
+    role: z.ZodEnum<{
         readonly TSE: "tse";
         readonly EMISOR: "emisor";
         readonly COMPRADOR: "comprador";
@@ -49,48 +33,12 @@ export declare const profileRowSchema: z.ZodObject<{
     country: z.ZodOptional<z.ZodString>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    id: z.ZodString;
-    email: z.ZodString;
-    full_name: z.ZodNullable<z.ZodString>;
-    role: z.ZodNativeEnum<{
-        readonly TSE: "tse";
-        readonly EMISOR: "emisor";
-        readonly COMPRADOR: "comprador";
-        readonly RECOMPRADOR: "recomprador";
-        readonly VALIDADOR: "validador";
-        readonly ADMIN: "admin";
-    }>;
-    party_id: z.ZodNullable<z.ZodString>;
-    stellar_wallet: z.ZodNullable<z.ZodString>;
-    stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    country: z.ZodOptional<z.ZodString>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    id: z.ZodString;
-    email: z.ZodString;
-    full_name: z.ZodNullable<z.ZodString>;
-    role: z.ZodNativeEnum<{
-        readonly TSE: "tse";
-        readonly EMISOR: "emisor";
-        readonly COMPRADOR: "comprador";
-        readonly RECOMPRADOR: "recomprador";
-        readonly VALIDADOR: "validador";
-        readonly ADMIN: "admin";
-    }>;
-    party_id: z.ZodNullable<z.ZodString>;
-    stellar_wallet: z.ZodNullable<z.ZodString>;
-    stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    country: z.ZodOptional<z.ZodString>;
-    created_at: z.ZodString;
-    updated_at: z.ZodString;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const recipientRowSchema: z.ZodObject<{
     id: z.ZodString;
     full_name: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     email: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    role: z.ZodNativeEnum<{
+    role: z.ZodEnum<{
         readonly TSE: "tse";
         readonly EMISOR: "emisor";
         readonly COMPRADOR: "comprador";
@@ -98,38 +46,8 @@ export declare const recipientRowSchema: z.ZodObject<{
         readonly VALIDADOR: "validador";
         readonly ADMIN: "admin";
     }>;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    id: z.ZodString;
-    full_name: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    email: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    role: z.ZodNativeEnum<{
-        readonly TSE: "tse";
-        readonly EMISOR: "emisor";
-        readonly COMPRADOR: "comprador";
-        readonly RECOMPRADOR: "recomprador";
-        readonly VALIDADOR: "validador";
-        readonly ADMIN: "admin";
-    }>;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    id: z.ZodString;
-    full_name: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    email: z.ZodOptional<z.ZodNullable<z.ZodString>>;
-    role: z.ZodNativeEnum<{
-        readonly TSE: "tse";
-        readonly EMISOR: "emisor";
-        readonly COMPRADOR: "comprador";
-        readonly RECOMPRADOR: "recomprador";
-        readonly VALIDADOR: "validador";
-        readonly ADMIN: "admin";
-    }>;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;
 export declare const walletResponseSchema: z.ZodObject<{
     ok: z.ZodLiteral<true>;
     stellar_public_key: z.ZodString;
-}, "passthrough", z.ZodTypeAny, z.objectOutputType<{
-    ok: z.ZodLiteral<true>;
-    stellar_public_key: z.ZodString;
-}, z.ZodTypeAny, "passthrough">, z.objectInputType<{
-    ok: z.ZodLiteral<true>;
-    stellar_public_key: z.ZodString;
-}, z.ZodTypeAny, "passthrough">>;
+}, z.core.$loose>;

--- a/supabase/migrations/20260701000000_report_lifecycle_compliance.sql
+++ b/supabase/migrations/20260701000000_report_lifecycle_compliance.sql
@@ -1,0 +1,196 @@
+-- VELAR: ciclo de vida completo del reporte mensual del partido al TSE.
+-- EXTIENDE `reports` (que solo guardaba metadata de texto libre) a un reporte
+-- estructurado, versionado, con archivos y conciliación contra los bonos que el
+-- partido posee on-chain. Append-only en las versiones. NO reescribe lógica
+-- existente (docs/AGENTS.md §3).
+
+-- ── 1. Estados del workflow + campos de período/versión ────────────────────
+-- reports.status es un CHECK de texto: lo ampliamos conservando los estados ya
+-- usados ('enviado','revisado','observado','aprobado').
+ALTER TABLE reports DROP CONSTRAINT IF EXISTS reports_status_check;
+ALTER TABLE reports
+  ADD CONSTRAINT reports_status_check
+  CHECK (status IN (
+    'borrador', 'enviado', 'en_revision', 'revisado',
+    'observado', 'reenviado', 'aprobado'
+  ));
+
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS period_year     int;
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS period_month    int
+  CHECK (period_month IS NULL OR period_month BETWEEN 1 AND 12);
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS current_version int NOT NULL DEFAULT 0;
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS submitted_at    timestamptz;
+
+-- Un partido tiene a lo sumo un reporte por período.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_reports_party_period
+  ON reports(party_id, period_year, period_month)
+  WHERE period_year IS NOT NULL AND period_month IS NOT NULL;
+
+-- ── 2. Líneas del reporte ──────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS report_line_items (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_id     uuid NOT NULL REFERENCES reports(id) ON DELETE CASCADE,
+  concept       text NOT NULL,
+  amount        numeric NOT NULL DEFAULT 0,
+  category      text NOT NULL DEFAULT 'otro'
+                  CHECK (category IN ('ingreso', 'egreso', 'donacion', 'bono', 'otro')),
+  bond_token_id uuid,   -- referencia declarada a un bono (opcional)
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_report_line_items_report ON report_line_items(report_id);
+
+-- ── 3. Archivos adjuntos (metadata; el binario vive en Storage) ────────────
+CREATE TABLE IF NOT EXISTS report_files (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_id   uuid NOT NULL REFERENCES reports(id) ON DELETE CASCADE,
+  file_path   text NOT NULL,          -- ruta dentro del bucket privado
+  file_name   text NOT NULL,
+  mime_type   text NOT NULL,
+  size_bytes  bigint NOT NULL DEFAULT 0,
+  checksum    text NOT NULL,          -- sha-256 en hex
+  scan_status text NOT NULL DEFAULT 'pending'
+                CHECK (scan_status IN ('pending', 'clean', 'infected')),
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_report_files_report ON report_files(report_id);
+
+-- ── 4. Versiones inmutables (snapshot por envío) ───────────────────────────
+CREATE TABLE IF NOT EXISTS report_versions (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  report_id  uuid NOT NULL REFERENCES reports(id) ON DELETE CASCADE,
+  version    int NOT NULL,
+  status     text NOT NULL,
+  snapshot   jsonb NOT NULL,          -- foto completa del reporte al enviar
+  created_by uuid NOT NULL REFERENCES profiles(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (report_id, version)
+);
+CREATE INDEX IF NOT EXISTS idx_report_versions_report ON report_versions(report_id);
+
+-- Append-only: una versión enviada nunca se edita ni borra (igual que audit_events).
+CREATE OR REPLACE FUNCTION deny_report_version_mutation()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'report_versions is append-only: % not allowed', TG_OP;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_report_versions_immutable ON report_versions;
+CREATE TRIGGER trg_report_versions_immutable
+  BEFORE UPDATE OR DELETE ON report_versions
+  FOR EACH ROW EXECUTE FUNCTION deny_report_version_mutation();
+
+-- ── 5. Config de vencimientos mensuales ────────────────────────────────────
+CREATE TABLE IF NOT EXISTS report_deadlines (
+  id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  country_code     text NOT NULL DEFAULT 'GLOBAL',  -- 'GLOBAL' = default; o CR/CO/BR/AR
+  due_day_of_month int  NOT NULL DEFAULT 15 CHECK (due_day_of_month BETWEEN 1 AND 28),
+  grace_days       int  NOT NULL DEFAULT 5  CHECK (grace_days >= 0),
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (country_code)
+);
+INSERT INTO report_deadlines (country_code, due_day_of_month, grace_days)
+VALUES ('GLOBAL', 15, 5)
+ON CONFLICT (country_code) DO NOTHING;
+
+-- ── 6. RLS: el partido ve solo lo suyo; TSE/admin ven todo ─────────────────
+ALTER TABLE report_line_items ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS report_line_items_access ON report_line_items;
+CREATE POLICY report_line_items_access ON report_line_items
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM reports r
+      WHERE r.id = report_line_items.report_id
+        AND (
+          r.party_id = (SELECT party_id FROM profiles WHERE id = auth.uid())
+          OR public.auth_role() IN ('tse', 'admin')
+        )
+    )
+  );
+
+ALTER TABLE report_files ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS report_files_access ON report_files;
+CREATE POLICY report_files_access ON report_files
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM reports r
+      WHERE r.id = report_files.report_id
+        AND (
+          r.party_id = (SELECT party_id FROM profiles WHERE id = auth.uid())
+          OR public.auth_role() IN ('tse', 'admin')
+        )
+    )
+  );
+
+ALTER TABLE report_versions ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS report_versions_read ON report_versions;
+CREATE POLICY report_versions_read ON report_versions
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM reports r
+      WHERE r.id = report_versions.report_id
+        AND (
+          r.party_id = (SELECT party_id FROM profiles WHERE id = auth.uid())
+          OR public.auth_role() IN ('tse', 'admin')
+        )
+    )
+  );
+
+ALTER TABLE report_deadlines ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS report_deadlines_read ON report_deadlines;
+CREATE POLICY report_deadlines_read ON report_deadlines
+  FOR SELECT TO authenticated USING (true);
+DROP POLICY IF EXISTS report_deadlines_admin ON report_deadlines;
+CREATE POLICY report_deadlines_admin ON report_deadlines
+  FOR ALL TO authenticated
+  USING (public.auth_role() IN ('tse', 'admin'));
+
+-- ── 7. Bucket privado para archivos de reporte ─────────────────────────────
+-- Convención de ruta: <party_id>/<report_id>/<file_name>
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'report-files',
+  'report-files',
+  false,
+  10485760,  -- 10 MB
+  ARRAY[
+    'application/pdf',
+    'text/csv',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'image/png',
+    'image/jpeg'
+  ]
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Solo el partido dueño (rol emisor) puede subir a su carpeta.
+DROP POLICY IF EXISTS "party_can_upload_report_file" ON storage.objects;
+CREATE POLICY "party_can_upload_report_file"
+  ON storage.objects FOR INSERT
+  WITH CHECK (
+    bucket_id = 'report-files'
+    AND public.auth_role() = 'emisor'
+    AND split_part(name, '/', 1) = (SELECT party_id::text FROM profiles WHERE id = auth.uid())
+  );
+
+-- El partido dueño o el TSE/admin pueden descargar.
+DROP POLICY IF EXISTS "party_or_tse_can_download_report_file" ON storage.objects;
+CREATE POLICY "party_or_tse_can_download_report_file"
+  ON storage.objects FOR SELECT
+  USING (
+    bucket_id = 'report-files'
+    AND (
+      public.auth_role() IN ('tse', 'admin')
+      OR split_part(name, '/', 1) = (SELECT party_id::text FROM profiles WHERE id = auth.uid())
+    )
+  );
+
+-- ── 8. Nuevos eventos de auditoría ─────────────────────────────────────────
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'report_submitted';
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'report_resubmitted';
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'report_version_created';
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'report_observed';
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'report_approved';
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'report_file_uploaded';


### PR DESCRIPTION
Closes Velar-Bonds/Velar#40

Extiende el módulo `reports` (que solo guardaba metadata de texto libre) a un **ciclo de vida completo del reporte mensual del partido**: estructurado, versionado, con archivos, conciliación contra los bonos que el partido posee on-chain, deadlines y workflow de envío/corrección. Todo verificable localmente con mocks/stubs/fixtures — **sin credenciales de VELAR**.

Sigue `docs/AGENTS.md`: **extiende**, no reescribe la lógica existente. El lado TSE (revisión/command-center) es un epic aparte; esta PR cubre el lado del partido + el dominio compartido de reporte/conciliación.

## Qué incluye

**Dominio compartido** (`@velar/types`): estados del workflow, líneas, archivos, versiones/snapshots, tipos de conciliación y de cumplimiento; nuevos `AuditEventType` y `NotificationType`.

**Base de datos** (`20260701000000_report_lifecycle_compliance.sql`, append-only): extiende `reports` (período, versión, estados); tablas `report_line_items`, `report_files` (checksum + scan_status), `report_versions` (inmutable vía trigger), `report_deadlines`; RLS por partido; bucket privado `report-files`.

**Backend** (`apps/api/src/reports/`):
- Motor de **conciliación** puro con discrepancias tipadas (`amount_mismatch`, `missing_bond`, `unknown_reference`).
- Lógica pura de **deadlines/cumplimiento** (`not_due|on_time|late|overdue|missing`).
- **Máquina de estados** con transiciones legales (`borrador→enviado→en_revision→observado→reenviado→…→aprobado`).
- Hook de **antivirus** (interfaz + `StubFileScanner`, sin vendor real) + validación/checksum de archivos.
- **Servicio** del ciclo de vida: builder, versionado inmutable, submit/reenvío, audit + notificaciones. Solo el `emisor` dueño puede enviar.
- Endpoints REST `reports/lifecycle/*` (draft, líneas, upload multipart, conciliación, submit, detalle).

**Frontend** (`apps/web/app/partido/reportes/`): builder multi-paso (período → líneas → archivos → conciliación → revisar), detalle con **timeline de versiones**, corrección/reenvío guiado ante observación, badges de cumplimiento. Localizado (es), responsive, con estados de carga/vacío/error.

**Docs**: `BACKEND.md` §7 y `FRONTEND_GUIDE.md` §11.

## Definición de "terminado"
- `apps/api`: build ✅ · lint 0 errores ✅ · **112 tests** ✅
- `apps/web`: build ✅ · lint 0 errores ✅ · **8 tests** ✅
- Sin secretos ni `service_role` en el repo/cliente.

## Nota (fix incidental)
Dos commits `fix(...): ... (unblock build)` corrigen un **breakage pre-existente de #48** (migración a zod v4 en los schemas del contract-layer y normalización de issue paths). Eran necesarios para dejar `npm run build` en verde; se pueden revisar/aislar por separado.

## Requisitos de campaña (FWC26)
- Follow en X: https://x.com/VelarApp
- Star al repo y follow a la org Velar-Bonds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
