### PR TITLE
feat(api): plain-language contract derivation (pure functions) (#39, PR 2/5)

### DIFF
--- a/apps/api/src/contracts/plain-language.spec.ts
+++ b/apps/api/src/contracts/plain-language.spec.ts
@@ -1,0 +1,123 @@
+import {
+  contractSummaryFixture,
+  glossaryFixture,
+  type ContractClause,
+} from '@velar/types';
+import {
+  buildContractReaderResponse,
+  clauseAnchor,
+  deriveContractSummaryText,
+  derivePlainLanguageClause,
+  extractKeyTerms,
+} from './plain-language';
+
+describe('plain-language derivation', () => {
+  describe('extractKeyTerms', () => {
+    it('finds glossary terms present in a clause and links them by id', () => {
+      const escrowClause = contractSummaryFixture.clauses.find((c) => c.category === 'garantia')!;
+      const terms = extractKeyTerms(escrowClause.legalText, glossaryFixture);
+      const ids = terms.map((t) => t.glossaryId);
+      expect(ids).toContain('g-escrow');
+      expect(ids).toContain('g-token');
+    });
+
+    it('matches aliases (e.g. "custodia" → escrow)', () => {
+      const terms = extractKeyTerms('El token queda en custodia hasta el pago.', glossaryFixture);
+      expect(terms.map((t) => t.glossaryId)).toEqual(expect.arrayContaining(['g-escrow', 'g-token']));
+    });
+
+    it('is case-insensitive and matches whole words only', () => {
+      expect(extractKeyTerms('SINPE o transferencia', glossaryFixture).map((t) => t.glossaryId)).toContain(
+        'g-sinpe',
+      );
+      // "tokenizado" must NOT match the term "token" (whole-word only)
+      expect(extractKeyTerms('bono tokenizado', glossaryFixture).map((t) => t.glossaryId)).not.toContain(
+        'g-token',
+      );
+    });
+
+    it('returns at most one reference per glossary entry', () => {
+      const terms = extractKeyTerms('token, token, token', glossaryFixture);
+      expect(terms.filter((t) => t.glossaryId === 'g-token')).toHaveLength(1);
+    });
+
+    it('returns nothing for text with no glossary terms', () => {
+      expect(extractKeyTerms('texto sin términos técnicos', glossaryFixture)).toEqual([]);
+    });
+  });
+
+  describe('derivePlainLanguageClause', () => {
+    it('maps a known category to its maintained template (nothing invented)', () => {
+      const pagoClause = contractSummaryFixture.clauses.find((c) => c.category === 'pago')!;
+      const result = derivePlainLanguageClause(pagoClause, glossaryFixture);
+      expect(result.unknown).toBe(false);
+      expect(result.plainLanguage.length).toBeGreaterThan(0);
+      // The legal text is preserved verbatim (never rewritten).
+      expect(result.legalText).toBe(pagoClause.legalText);
+      expect(result.anchor).toBe(clauseAnchor(pagoClause));
+    });
+
+    it('flags clauses with no template as unknown and leaves plain language empty', () => {
+      const otroClause: ContractClause = {
+        id: 'cl-x',
+        order: 9,
+        title: 'Cláusula 9 — Anexo',
+        category: 'otro',
+        legalText: 'Disposición sin plantilla de lenguaje simple.',
+      };
+      const result = derivePlainLanguageClause(otroClause, glossaryFixture);
+      expect(result.unknown).toBe(true);
+      expect(result.plainLanguage).toBe('');
+    });
+
+    it('flags an unsupported locale as unknown rather than inventing content', () => {
+      const pagoClause = contractSummaryFixture.clauses.find((c) => c.category === 'pago')!;
+      const result = derivePlainLanguageClause(pagoClause, glossaryFixture, 'en');
+      expect(result.unknown).toBe(true);
+      expect(result.plainLanguage).toBe('');
+    });
+  });
+
+  describe('deriveContractSummaryText', () => {
+    it('summarizes the categories present without asserting contract-specific facts', () => {
+      const summary = deriveContractSummaryText(contractSummaryFixture.clauses);
+      expect(summary).toContain('las partes');
+      expect(summary).toContain('la custodia en escrow');
+      expect(summary).toContain('no lo reemplaza');
+    });
+
+    it('returns empty string when there are no clauses', () => {
+      expect(deriveContractSummaryText([])).toBe('');
+    });
+  });
+
+  describe('buildContractReaderResponse', () => {
+    it('derives one plain-language clause per source clause and preserves identifiers', () => {
+      const res = buildContractReaderResponse(contractSummaryFixture, glossaryFixture);
+      expect(res.clauses).toHaveLength(contractSummaryFixture.clauses.length);
+      expect(res.bondId).toBe(contractSummaryFixture.bondId);
+      expect(res.contractId).toBe(contractSummaryFixture.contractId);
+      expect(res.version).toBe(contractSummaryFixture.version);
+      expect(res.locale).toBe('es');
+    });
+
+    it('includes only glossary entries referenced by the clauses', () => {
+      const res = buildContractReaderResponse(contractSummaryFixture, glossaryFixture);
+      const referenced = new Set(res.clauses.flatMap((c) => c.keyTerms.map((t) => t.glossaryId)));
+      for (const entry of res.glossary) {
+        expect(referenced.has(entry.id)).toBe(true);
+      }
+      // Every referenced id resolves to an included glossary entry.
+      const includedIds = new Set(res.glossary.map((g) => g.id));
+      for (const id of referenced) {
+        expect(includedIds.has(id)).toBe(true);
+      }
+    });
+
+    it('produces unique, order-based anchors for deep-linking', () => {
+      const res = buildContractReaderResponse(contractSummaryFixture, glossaryFixture);
+      const anchors = res.clauses.map((c) => c.anchor);
+      expect(new Set(anchors).size).toBe(anchors.length);
+    });
+  });
+});

--- a/apps/api/src/contracts/plain-language.ts
+++ b/apps/api/src/contracts/plain-language.ts
@@ -1,0 +1,177 @@
+import type {
+  ClauseCategory,
+  ClauseKeyTerm,
+  ContractClause,
+  ContractReaderResponse,
+  ContractSummary,
+  GlossaryTerm,
+  PlainLanguageClause,
+  ReaderLocale,
+} from '@velar/types';
+
+/**
+ * Plain-language derivation for the contract reading & comprehension experience
+ * (issue #39). These are PURE functions: given a structured contract + a
+ * maintained glossary, they produce per-clause plain-language explanations and a
+ * highlighted key-terms set.
+ *
+ * Key rule: legal meaning is NEVER invented. Plain-language content comes from a
+ * maintained, category-based template set describing what a clause of that kind
+ * means in general terms; the contract-specific wording stays in `legalText`.
+ * When there is no template for a clause's category, the clause is flagged as
+ * `unknown` and its `plainLanguage` is left empty (the reader shows a neutral
+ * "no simplified explanation available" state).
+ */
+
+/** Maintained plain-language templates per clause category, per locale. */
+const PLAIN_LANGUAGE_TEMPLATES: Record<ReaderLocale, Partial<Record<ClauseCategory, string>>> = {
+  es: {
+    partes:
+      'Identifica quiénes firman el contrato: quién vende y quién compra el bono.',
+    objeto:
+      'Explica qué se está transfiriendo: la propiedad del bono, representado por un token único en la blockchain.',
+    pago: 'Describe cuánto se paga y por qué medio, y que el pago queda registrado como evidencia.',
+    transferencia:
+      'Explica cómo cambia de dueño el bono una vez que se cumplen las condiciones acordadas.',
+    garantia:
+      'Explica que el token queda retenido en un escrow (una garantía) hasta que se confirme el pago, para proteger a ambas partes.',
+    plazo: 'Indica los tiempos o las fechas límite que aplican a la operación.',
+    incumplimiento:
+      'Describe qué sucede si alguna de las partes no cumple con lo acordado.',
+    jurisdiccion: 'Indica bajo qué leyes y qué autoridad se rige el contrato.',
+    firmas: 'Confirma que las partes aceptan el contrato.',
+    // `otro` is intentionally omitted → such clauses are flagged as `unknown`.
+  },
+  en: {
+    // English templates can be added later; until then EN clauses are flagged unknown.
+  },
+};
+
+/** Short label per category, used to build the top-level summary (no invented facts). */
+const CATEGORY_LABELS: Record<ReaderLocale, Partial<Record<ClauseCategory, string>>> = {
+  es: {
+    partes: 'las partes',
+    objeto: 'el objeto de la transferencia',
+    pago: 'el precio y la forma de pago',
+    transferencia: 'la transferencia de propiedad',
+    garantia: 'la custodia en escrow',
+    plazo: 'los plazos',
+    incumplimiento: 'el incumplimiento',
+    jurisdiccion: 'la jurisdicción',
+    firmas: 'las firmas',
+    otro: 'otras disposiciones',
+  },
+  en: {},
+};
+
+/** Stable deep-link anchor for a clause. */
+export function clauseAnchor(clause: Pick<ContractClause, 'order'>): string {
+  return `clausula-${clause.order}`;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Extracts the glossary key terms that actually appear in `text`, matching each
+ * term and its aliases as whole words (Unicode-aware, case-insensitive). Returns
+ * at most one reference per glossary entry, in glossary order.
+ */
+export function extractKeyTerms(text: string, glossary: GlossaryTerm[]): ClauseKeyTerm[] {
+  const haystack = text.toLowerCase();
+  const found: ClauseKeyTerm[] = [];
+
+  for (const entry of glossary) {
+    const forms = [entry.term, ...(entry.aliases ?? [])];
+    const matched = forms.some((form) => {
+      const needle = form.toLowerCase().trim();
+      if (!needle) return false;
+      // Whole-word match with Unicode-aware boundaries (handles accents).
+      const re = new RegExp(`(^|[^\\p{L}\\p{N}])${escapeRegExp(needle)}([^\\p{L}\\p{N}]|$)`, 'u');
+      return re.test(haystack);
+    });
+    if (matched) {
+      found.push({ term: entry.term, glossaryId: entry.id });
+    }
+  }
+
+  return found;
+}
+
+/** Derives the plain-language view of a single clause. */
+export function derivePlainLanguageClause(
+  clause: ContractClause,
+  glossary: GlossaryTerm[],
+  locale: ReaderLocale = 'es',
+): PlainLanguageClause {
+  const template = PLAIN_LANGUAGE_TEMPLATES[locale]?.[clause.category];
+  return {
+    clauseId: clause.id,
+    order: clause.order,
+    title: clause.title,
+    category: clause.category,
+    legalText: clause.legalText,
+    plainLanguage: template ?? '',
+    keyTerms: extractKeyTerms(clause.legalText, glossary),
+    unknown: template === undefined,
+    anchor: clauseAnchor(clause),
+  };
+}
+
+/**
+ * Builds the top-level plain-language summary from the categories present in the
+ * contract. Purely structural — it lists what the contract covers, never asserts
+ * contract-specific facts.
+ */
+export function deriveContractSummaryText(
+  clauses: ContractClause[],
+  locale: ReaderLocale = 'es',
+): string {
+  const labels = CATEGORY_LABELS[locale] ?? {};
+  const seen: string[] = [];
+  for (const clause of clauses) {
+    const label = labels[clause.category];
+    if (label && !seen.includes(label)) seen.push(label);
+  }
+  if (seen.length === 0) return '';
+
+  if (locale === 'es') {
+    const list =
+      seen.length === 1
+        ? seen[0]
+        : `${seen.slice(0, -1).join(', ')} y ${seen[seen.length - 1]}`;
+    return `Este contrato cubre ${list}. A continuación se explica cada cláusula en lenguaje simple. Esta guía complementa el contrato legal; no lo reemplaza.`;
+  }
+  return '';
+}
+
+/**
+ * Builds the full typed reader response for a structured contract. The returned
+ * glossary is limited to the entries actually referenced by the clauses.
+ */
+export function buildContractReaderResponse(
+  summary: ContractSummary,
+  glossary: GlossaryTerm[],
+  locale: ReaderLocale = 'es',
+): ContractReaderResponse {
+  const clauses = summary.clauses.map((clause) =>
+    derivePlainLanguageClause(clause, glossary, locale),
+  );
+  const referencedIds = new Set(
+    clauses.flatMap((clause) => clause.keyTerms.map((term) => term.glossaryId)),
+  );
+  const usedGlossary = glossary.filter((entry) => referencedIds.has(entry.id));
+
+  return {
+    bondId: summary.bondId,
+    contractId: summary.contractId,
+    title: summary.title,
+    version: summary.version,
+    summary: deriveContractSummaryText(summary.clauses, locale),
+    clauses,
+    glossary: usedGlossary,
+    locale,
+    generatedAt: summary.generatedAt,
+  };
+}


### PR DESCRIPTION
Part of epic #39 (Contract reading & comprehension). **PR 2/5** — the backend plain-language derivation as PURE functions, with unit tests.

> ⚠️ **Stacked on #50** (types + fixture). Until #50 merges, this PR's diff also shows #50's commit; review the `feat(api): plain-language …` commit for this PR's changes. GitHub will reduce the diff automatically once #50 is merged.

## What this adds (`apps/api/src/contracts/`)
- **`plain-language.ts`** — pure functions:
  - `extractKeyTerms(text, glossary)` — whole-word, Unicode-aware, case-insensitive matching of glossary terms + aliases; one reference per entry, linked by id.
  - `derivePlainLanguageClause(clause, glossary, locale)` — maps a clause to a maintained, category-based plain-language template; **flags `unknown` (empty plain language) when no template exists** — legal meaning is never invented; `legalText` is preserved verbatim.
  - `deriveContractSummaryText(...)` — structural top-level summary of the categories covered (no contract-specific facts).
  - `buildContractReaderResponse(...)` — full typed `ContractReaderResponse`, with the glossary limited to referenced entries and unique order-based anchors for deep-linking.
- **`plain-language.spec.ts`** — 13 tests over the `@velar/types` fixture asserting the acceptance criteria: plain-language maps to real clause data, unknowns flagged (unknown category **and** unsupported locale), key terms correctly extracted/linked (aliases, whole-word, case-insensitive), referenced-glossary subset, unique anchors.

## Testing (no VELAR credentials)
- `npm test --workspace apps/api` → 13/13 pass.
- `npm run typecheck --workspace apps/api` and `eslint` on the new files pass.

Next: PR 3 wires these into a glossary service + reader endpoint (mocked `SupabaseService`) with a timestamped RLS migration.

Refs #39.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
