### PR TITLE
feat(api): glossary service + reader endpoints + RLS migration (#39, PR 3/5)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { ReportsModule } from './reports/reports.module';
 import { ExplorerModule } from './explorer/explorer.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { HealthModule } from './health/health.module';
+import { ContractsModule } from './contracts/contracts.module';
 import { RolesGuard } from './auth/roles.guard';
 import { AuthGuard } from './auth/auth.guard';
 
@@ -50,6 +51,7 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
     ExplorerModule,
     NotificationsModule,
     HealthModule,
+    ContractsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/contracts/contracts.controller.ts
+++ b/apps/api/src/contracts/contracts.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import type { ReaderLocale } from '@velar/types';
+import { Public } from '../auth/public.decorator';
+import { ContractsService } from './contracts.service';
+
+const SUPPORTED_LOCALES: ReaderLocale[] = ['es', 'en'];
+
+function normalizeLocale(value?: string): ReaderLocale {
+  return SUPPORTED_LOCALES.includes(value as ReaderLocale) ? (value as ReaderLocale) : 'es';
+}
+
+/**
+ * Endpoints PÚBLICOS (sin auth) del lector de contratos (#39). Son públicos
+ * porque el lector también se usa en la página de verificación pública
+ * (`/verificar/[id]`). Solo exponen contenido de comprensión: glosario y
+ * explicaciones en lenguaje simple. El contrato legal no se reemplaza.
+ */
+@Public()
+@Controller('contracts')
+export class ContractsController {
+  constructor(private readonly contracts: ContractsService) {}
+
+  @Get('glossary')
+  getGlossary(@Query('locale') locale?: string) {
+    return this.contracts.getGlossary(normalizeLocale(locale));
+  }
+
+  @Get(':bondId/reader')
+  getReader(@Param('bondId') bondId: string, @Query('locale') locale?: string) {
+    return this.contracts.getReader(bondId, normalizeLocale(locale));
+  }
+}

--- a/apps/api/src/contracts/contracts.module.ts
+++ b/apps/api/src/contracts/contracts.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ContractsController } from './contracts.controller';
+import { ContractsService } from './contracts.service';
+
+/**
+ * Contract reading & comprehension experience (#39). SupabaseModule is global,
+ * so SupabaseService is available for injection without importing it here.
+ */
+@Module({
+  controllers: [ContractsController],
+  providers: [ContractsService],
+  exports: [ContractsService],
+})
+export class ContractsModule {}

--- a/apps/api/src/contracts/contracts.service.spec.ts
+++ b/apps/api/src/contracts/contracts.service.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ContractsService } from './contracts.service';
+import { SupabaseService } from '../common/supabase/supabase.service';
+
+const GLOSSARY_ROWS = [
+  { id: 'g-escrow', term: 'escrow', definition: 'Depósito en garantía.', locale: 'es', aliases: ['custodia'] },
+  { id: 'g-token', term: 'token', definition: 'Representación digital del bono.', locale: 'es', aliases: null },
+];
+
+/**
+ * Builds a mock SupabaseService whose `.from(table).select(cols).eq(col, val)`
+ * chain resolves to the given result.
+ */
+function mockSupabase(result: { data: unknown; error: unknown }) {
+  const eq = jest.fn().mockResolvedValue(result);
+  const select = jest.fn().mockReturnValue({ eq });
+  const from = jest.fn().mockReturnValue({ select });
+  return { service: { admin: { from } } as unknown as SupabaseService, from, select, eq };
+}
+
+async function buildService(supabase: SupabaseService): Promise<ContractsService> {
+  const moduleRef: TestingModule = await Test.createTestingModule({
+    providers: [ContractsService, { provide: SupabaseService, useValue: supabase }],
+  }).compile();
+  return moduleRef.get(ContractsService);
+}
+
+describe('ContractsService', () => {
+  describe('getGlossary', () => {
+    it('maps glossary rows to typed GlossaryTerm[] and filters by locale', async () => {
+      const { service: supabase, from, select, eq } = mockSupabase({ data: GLOSSARY_ROWS, error: null });
+      const service = await buildService(supabase);
+
+      const glossary = await service.getGlossary('es');
+
+      expect(from).toHaveBeenCalledWith('glossary_terms');
+      expect(select).toHaveBeenCalledWith('id, term, definition, locale, aliases');
+      expect(eq).toHaveBeenCalledWith('locale', 'es');
+      expect(glossary).toEqual([
+        { id: 'g-escrow', term: 'escrow', definition: 'Depósito en garantía.', locale: 'es', aliases: ['custodia'] },
+        { id: 'g-token', term: 'token', definition: 'Representación digital del bono.', locale: 'es', aliases: undefined },
+      ]);
+    });
+
+    it('returns an empty array when there are no rows', async () => {
+      const { service: supabase } = mockSupabase({ data: null, error: null });
+      const service = await buildService(supabase);
+      await expect(service.getGlossary('es')).resolves.toEqual([]);
+    });
+
+    it('throws when Supabase returns an error', async () => {
+      const { service: supabase } = mockSupabase({ data: null, error: { message: 'boom' } });
+      const service = await buildService(supabase);
+      await expect(service.getGlossary('es')).rejects.toThrow('boom');
+    });
+  });
+
+  describe('getReader', () => {
+    it('returns a typed reader response derived from the contract + glossary', async () => {
+      const { service: supabase } = mockSupabase({ data: GLOSSARY_ROWS, error: null });
+      const service = await buildService(supabase);
+
+      const reader = await service.getReader('bond-xyz', 'es');
+
+      expect(reader.bondId).toBe('bond-xyz');
+      expect(reader.locale).toBe('es');
+      expect(reader.clauses.length).toBeGreaterThan(0);
+      // Each clause exposes the shape the reader UI needs.
+      for (const clause of reader.clauses) {
+        expect(typeof clause.legalText).toBe('string');
+        expect(typeof clause.unknown).toBe('boolean');
+        expect(clause.anchor).toMatch(/^clausula-\d+$/);
+      }
+      // Glossary is limited to referenced entries, all resolvable.
+      const referenced = new Set(reader.clauses.flatMap((c) => c.keyTerms.map((t) => t.glossaryId)));
+      for (const entry of reader.glossary) {
+        expect(referenced.has(entry.id)).toBe(true);
+      }
+    });
+  });
+});

--- a/apps/api/src/contracts/contracts.service.ts
+++ b/apps/api/src/contracts/contracts.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import {
+  contractSummaryFixture,
+  type ContractReaderResponse,
+  type ContractSummary,
+  type GlossaryTerm,
+  type ReaderLocale,
+} from '@velar/types';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import { buildContractReaderResponse } from './plain-language';
+
+interface GlossaryRow {
+  id: string;
+  term: string;
+  definition: string;
+  locale: string;
+  aliases: string[] | null;
+}
+
+/**
+ * Backend service for the contract reading & comprehension experience (#39).
+ * Reads the glossary via Supabase (mocked in tests) and derives the typed reader
+ * response using the pure functions in `plain-language.ts`.
+ */
+@Injectable()
+export class ContractsService {
+  constructor(private readonly supabase: SupabaseService) {}
+
+  /** Returns the glossary terms for a locale (`GET /contracts/glossary`). */
+  async getGlossary(locale: ReaderLocale = 'es'): Promise<GlossaryTerm[]> {
+    const { data, error } = await this.supabase.admin
+      .from('glossary_terms')
+      .select('id, term, definition, locale, aliases')
+      .eq('locale', locale);
+
+    if (error) throw new Error(error.message);
+
+    return (data ?? []).map((row: GlossaryRow) => ({
+      id: row.id,
+      term: row.term,
+      definition: row.definition,
+      locale: (row.locale as ReaderLocale) ?? 'es',
+      aliases: row.aliases ?? undefined,
+    }));
+  }
+
+  /** Returns the typed reader response for a bond (`GET /contracts/:bondId/reader`). */
+  async getReader(bondId: string, locale: ReaderLocale = 'es'): Promise<ContractReaderResponse> {
+    const [summary, glossary] = await Promise.all([
+      this.getContractSummary(bondId),
+      this.getGlossary(locale),
+    ]);
+    return buildContractReaderResponse(summary, glossary, locale);
+  }
+
+  /**
+   * Source of the structured contract for a bond.
+   *
+   * The canonical structured-contract model + storage is owned by the "Contract
+   * intelligence & document assembly" epic (#38), which is not merged yet. Until
+   * then this returns the shared fixture shape with the requested `bondId`, so
+   * the reader endpoint is exercisable end-to-end with no VELAR database, secrets
+   * or external APIs.
+   *
+   * @todo Replace with the real structured-contract source when #38 lands.
+   */
+  private async getContractSummary(bondId: string): Promise<ContractSummary> {
+    return { ...contractSummaryFixture, bondId };
+  }
+}

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -259,3 +259,53 @@ npm run test --workspace apps/api -- --runInBand
 
 Las pruebas `common/contracts/*.spec.ts` validan payloads válidos/inválidos por cada módulo,
 localización, drift de responses y que toda ruta JSON de los controladores cubiertos tenga contrato.
+
+## 7. Lector de contratos y glosario (issue #39)
+
+Módulo `apps/api/src/contracts/` — experiencia de lectura y comprensión del contrato de un bono.
+Complementa el contrato legal en lenguaje simple; **nunca lo reemplaza**.
+
+### Derivación a lenguaje simple (funciones puras)
+
+`contracts/plain-language.ts` transforma un contrato estructurado + un glosario en explicaciones
+por cláusula y un set de términos clave resaltados. Reglas:
+
+- El significado legal **no se inventa**: el lenguaje simple viene de plantillas mantenidas por
+  categoría de cláusula (`ClauseCategory`); el texto legal específico se preserva en `legalText`.
+- Cláusulas sin plantilla (categoría o idioma sin cobertura) se marcan con `unknown: true` y
+  `plainLanguage: ''` (la UI muestra un estado neutral, sin inventar).
+- `extractKeyTerms` hace match de términos + alias como palabra completa (Unicode, sin distinguir
+  mayúsculas), una referencia por término.
+- `buildContractReaderResponse` arma el `ContractReaderResponse` tipado, con el glosario limitado a
+  los términos referenciados y anchors por cláusula (`clausula-<order>`) para deep-link.
+
+### Glosario (Supabase)
+
+- Tabla `glossary_terms` (migración `20260701000000_glossary_terms.sql`): `id, term, definition,
+  locale, aliases[], created_at`. **RLS: lectura pública** (`USING (true)`); escritura solo por
+  `service_role` (backend). Semilla idempotente con los términos base en español.
+- `ContractsService` lee el glosario vía `SupabaseService` (mockeable en tests) y deriva el lector
+  con las funciones puras. El origen del contrato estructurado es un fixture hasta que aterrice el
+  epic #38 (Contract intelligence & assembly).
+
+### Endpoints (públicos — también los usa `/verificar/[id]`)
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| GET | `/contracts/glossary?locale=es` | Términos del glosario para un idioma |
+| GET | `/contracts/:bondId/reader?locale=es` | `ContractReaderResponse` tipado del bono |
+
+### Tipos
+
+En `@velar/types`: `ContractReaderResponse`, `PlainLanguageClause`, `GlossaryTerm`, `ClauseKeyTerm`,
+`ReaderLocale` (reader), y el modelo provisional `ContractSummary`/`ContractClause`/`ClauseCategory`
+(fixture de #38, a reemplazar cuando ese epic aterrice).
+
+### Comprobación local sin credenciales
+
+```bash
+npm run test --workspace apps/api -- --testPathPatterns contracts
+```
+
+Tests puros sobre el fixture (mapeo, `unknown` flagged, alias/palabra completa, subset de glosario,
+anchors) y tests del servicio con `SupabaseService` mockeado (glosario tipado + reader response).

--- a/supabase/migrations/20260701000000_glossary_terms.sql
+++ b/supabase/migrations/20260701000000_glossary_terms.sql
@@ -1,0 +1,63 @@
+-- ============================================================
+-- VELAR — Glosario de términos (contract reader) — issue #39
+-- ============================================================
+-- Tabla de términos + definiciones en lenguaje simple (i18n) que alimenta el
+-- glosario del lector de contratos. Los términos NO son datos sensibles: son
+-- definiciones públicas que ayudan a cualquiera a entender el contrato.
+--
+-- Principios de esta migración:
+--   • ADITIVA: solo crea una tabla nueva y la siembra. No toca nada existente.
+--   • APPEND-ONLY: no modifica migraciones ya aplicadas.
+--   • SEGURA: lectura pública (RLS `USING (true)`), escritura solo backend
+--     (service_role, que hace bypass de RLS). Sin secretos.
+--
+-- Rollback (si te arrepentís):
+--   DROP TABLE IF EXISTS public.glossary_terms;
+-- ============================================================
+
+-- ── 1. Tabla ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.glossary_terms (
+  id          text PRIMARY KEY,
+  term        text NOT NULL,
+  definition  text NOT NULL,
+  locale      text NOT NULL DEFAULT 'es',
+  aliases     text[] NOT NULL DEFAULT '{}',
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_glossary_terms_locale ON public.glossary_terms(locale);
+
+-- ── 2. RLS: lectura pública, escritura solo service_role ────
+ALTER TABLE public.glossary_terms ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'glossary_terms'
+      AND policyname = 'glossary_terms_public_read'
+  ) THEN
+    CREATE POLICY "glossary_terms_public_read" ON public.glossary_terms
+      FOR SELECT USING (true);
+  END IF;
+END $$;
+
+-- ── 3. Semilla (idempotente) ────────────────────────────────
+-- Definiciones base en español. Ampliables con futuras migraciones append-only.
+INSERT INTO public.glossary_terms (id, term, definition, locale, aliases) VALUES
+  ('g-escrow', 'escrow',
+   'Un depósito en garantía: el token queda retenido por un tercero neutral (un contrato en la blockchain) hasta que se cumplan las condiciones acordadas, como la confirmación del pago.',
+   'es', ARRAY['custodia','depósito en garantía']),
+  ('g-token', 'token',
+   'La representación digital única del bono en la red Stellar.',
+   'es', ARRAY['token del bono']),
+  ('g-sinpe', 'SINPE',
+   'Sistema Nacional de Pagos Electrónicos de Costa Rica, usado para transferencias de dinero entre cuentas.',
+   'es', ARRAY[]::text[]),
+  ('g-titularidad', 'titularidad',
+   'La condición de ser el dueño legal del bono.',
+   'es', ARRAY['titular']),
+  ('g-tse', 'TSE',
+   'Tribunal Supremo de Elecciones: la institución que emite los bonos, supervisa las transferencias y audita el historial.',
+   'es', ARRAY[]::text[])
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
Part of epic #39. **PR 3/5** — backend glossary service, reader endpoints, and the RLS migration; wires the pure derivation from #51 to data.

> ⚠️ **Stacked on #50 and #51.** Until they merge, this PR's diff also shows their commits — review the `feat(api): glossary service …` commit for this PR's changes.

## What this adds
- **`contracts.controller.ts` / `contracts.service.ts` / `contracts.module.ts`** (registered in `app.module`) — public endpoints:
  - `GET /contracts/glossary?locale=es` → `GlossaryTerm[]`
  - `GET /contracts/:bondId/reader?locale=es` → typed `ContractReaderResponse`
  - Public (`@Public()`) because the reader is also used on the public `/verificar/[id]` surface.
- **`supabase/migrations/20260701000000_glossary_terms.sql`** — new `glossary_terms` table; **public-read RLS** (`USING (true)`), writes only via `service_role`; idempotent seed of the base Spanish terms. Additive + append-only, with a documented rollback.
- Glossary is read via **`SupabaseService`**; the structured-contract source is the shared fixture until epic **#38** lands (documented `@todo`).
- **`contracts.service.spec.ts`** — mocked `SupabaseService` proving the typed glossary (mapping, empty rows, error propagation) and the reader response (typed shape, referenced-glossary subset, anchors).
- **`docs/BACKEND.md` §7** — derivation, glossary, endpoints and types.

## Testing (no VELAR credentials)
- `npm test --workspace apps/api` → **76/76** across 14 suites.
- `npm run build`, `typecheck`, `eslint` on `apps/api` pass.
- Migration is additive/append-only; no secrets; `audit_events` untouched.

Next: PR 4 — the frontend reader component (tooltips, highlighting, summary⇄full, progress, checkpoints, export) with a11y/i18n + fixtures tests.

Refs #39.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
