### PR TITLE
feat(web): interactive contract reader component (#39, PR 4/5)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { ReportsModule } from './reports/reports.module';
 import { ExplorerModule } from './explorer/explorer.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { HealthModule } from './health/health.module';
+import { ContractsModule } from './contracts/contracts.module';
 import { RolesGuard } from './auth/roles.guard';
 import { AuthGuard } from './auth/auth.guard';
 
@@ -50,6 +51,7 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
     ExplorerModule,
     NotificationsModule,
     HealthModule,
+    ContractsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/contracts/contracts.controller.ts
+++ b/apps/api/src/contracts/contracts.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import type { ReaderLocale } from '@velar/types';
+import { Public } from '../auth/public.decorator';
+import { ContractsService } from './contracts.service';
+
+const SUPPORTED_LOCALES: ReaderLocale[] = ['es', 'en'];
+
+function normalizeLocale(value?: string): ReaderLocale {
+  return SUPPORTED_LOCALES.includes(value as ReaderLocale) ? (value as ReaderLocale) : 'es';
+}
+
+/**
+ * Endpoints PÚBLICOS (sin auth) del lector de contratos (#39). Son públicos
+ * porque el lector también se usa en la página de verificación pública
+ * (`/verificar/[id]`). Solo exponen contenido de comprensión: glosario y
+ * explicaciones en lenguaje simple. El contrato legal no se reemplaza.
+ */
+@Public()
+@Controller('contracts')
+export class ContractsController {
+  constructor(private readonly contracts: ContractsService) {}
+
+  @Get('glossary')
+  getGlossary(@Query('locale') locale?: string) {
+    return this.contracts.getGlossary(normalizeLocale(locale));
+  }
+
+  @Get(':bondId/reader')
+  getReader(@Param('bondId') bondId: string, @Query('locale') locale?: string) {
+    return this.contracts.getReader(bondId, normalizeLocale(locale));
+  }
+}

--- a/apps/api/src/contracts/contracts.module.ts
+++ b/apps/api/src/contracts/contracts.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { ContractsController } from './contracts.controller';
+import { ContractsService } from './contracts.service';
+
+/**
+ * Contract reading & comprehension experience (#39). SupabaseModule is global,
+ * so SupabaseService is available for injection without importing it here.
+ */
+@Module({
+  controllers: [ContractsController],
+  providers: [ContractsService],
+  exports: [ContractsService],
+})
+export class ContractsModule {}

--- a/apps/api/src/contracts/contracts.service.spec.ts
+++ b/apps/api/src/contracts/contracts.service.spec.ts
@@ -1,0 +1,81 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ContractsService } from './contracts.service';
+import { SupabaseService } from '../common/supabase/supabase.service';
+
+const GLOSSARY_ROWS = [
+  { id: 'g-escrow', term: 'escrow', definition: 'Depósito en garantía.', locale: 'es', aliases: ['custodia'] },
+  { id: 'g-token', term: 'token', definition: 'Representación digital del bono.', locale: 'es', aliases: null },
+];
+
+/**
+ * Builds a mock SupabaseService whose `.from(table).select(cols).eq(col, val)`
+ * chain resolves to the given result.
+ */
+function mockSupabase(result: { data: unknown; error: unknown }) {
+  const eq = jest.fn().mockResolvedValue(result);
+  const select = jest.fn().mockReturnValue({ eq });
+  const from = jest.fn().mockReturnValue({ select });
+  return { service: { admin: { from } } as unknown as SupabaseService, from, select, eq };
+}
+
+async function buildService(supabase: SupabaseService): Promise<ContractsService> {
+  const moduleRef: TestingModule = await Test.createTestingModule({
+    providers: [ContractsService, { provide: SupabaseService, useValue: supabase }],
+  }).compile();
+  return moduleRef.get(ContractsService);
+}
+
+describe('ContractsService', () => {
+  describe('getGlossary', () => {
+    it('maps glossary rows to typed GlossaryTerm[] and filters by locale', async () => {
+      const { service: supabase, from, select, eq } = mockSupabase({ data: GLOSSARY_ROWS, error: null });
+      const service = await buildService(supabase);
+
+      const glossary = await service.getGlossary('es');
+
+      expect(from).toHaveBeenCalledWith('glossary_terms');
+      expect(select).toHaveBeenCalledWith('id, term, definition, locale, aliases');
+      expect(eq).toHaveBeenCalledWith('locale', 'es');
+      expect(glossary).toEqual([
+        { id: 'g-escrow', term: 'escrow', definition: 'Depósito en garantía.', locale: 'es', aliases: ['custodia'] },
+        { id: 'g-token', term: 'token', definition: 'Representación digital del bono.', locale: 'es', aliases: undefined },
+      ]);
+    });
+
+    it('returns an empty array when there are no rows', async () => {
+      const { service: supabase } = mockSupabase({ data: null, error: null });
+      const service = await buildService(supabase);
+      await expect(service.getGlossary('es')).resolves.toEqual([]);
+    });
+
+    it('throws when Supabase returns an error', async () => {
+      const { service: supabase } = mockSupabase({ data: null, error: { message: 'boom' } });
+      const service = await buildService(supabase);
+      await expect(service.getGlossary('es')).rejects.toThrow('boom');
+    });
+  });
+
+  describe('getReader', () => {
+    it('returns a typed reader response derived from the contract + glossary', async () => {
+      const { service: supabase } = mockSupabase({ data: GLOSSARY_ROWS, error: null });
+      const service = await buildService(supabase);
+
+      const reader = await service.getReader('bond-xyz', 'es');
+
+      expect(reader.bondId).toBe('bond-xyz');
+      expect(reader.locale).toBe('es');
+      expect(reader.clauses.length).toBeGreaterThan(0);
+      // Each clause exposes the shape the reader UI needs.
+      for (const clause of reader.clauses) {
+        expect(typeof clause.legalText).toBe('string');
+        expect(typeof clause.unknown).toBe('boolean');
+        expect(clause.anchor).toMatch(/^clausula-\d+$/);
+      }
+      // Glossary is limited to referenced entries, all resolvable.
+      const referenced = new Set(reader.clauses.flatMap((c) => c.keyTerms.map((t) => t.glossaryId)));
+      for (const entry of reader.glossary) {
+        expect(referenced.has(entry.id)).toBe(true);
+      }
+    });
+  });
+});

--- a/apps/api/src/contracts/contracts.service.ts
+++ b/apps/api/src/contracts/contracts.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import {
+  contractSummaryFixture,
+  type ContractReaderResponse,
+  type ContractSummary,
+  type GlossaryTerm,
+  type ReaderLocale,
+} from '@velar/types';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import { buildContractReaderResponse } from './plain-language';
+
+interface GlossaryRow {
+  id: string;
+  term: string;
+  definition: string;
+  locale: string;
+  aliases: string[] | null;
+}
+
+/**
+ * Backend service for the contract reading & comprehension experience (#39).
+ * Reads the glossary via Supabase (mocked in tests) and derives the typed reader
+ * response using the pure functions in `plain-language.ts`.
+ */
+@Injectable()
+export class ContractsService {
+  constructor(private readonly supabase: SupabaseService) {}
+
+  /** Returns the glossary terms for a locale (`GET /contracts/glossary`). */
+  async getGlossary(locale: ReaderLocale = 'es'): Promise<GlossaryTerm[]> {
+    const { data, error } = await this.supabase.admin
+      .from('glossary_terms')
+      .select('id, term, definition, locale, aliases')
+      .eq('locale', locale);
+
+    if (error) throw new Error(error.message);
+
+    return (data ?? []).map((row: GlossaryRow) => ({
+      id: row.id,
+      term: row.term,
+      definition: row.definition,
+      locale: (row.locale as ReaderLocale) ?? 'es',
+      aliases: row.aliases ?? undefined,
+    }));
+  }
+
+  /** Returns the typed reader response for a bond (`GET /contracts/:bondId/reader`). */
+  async getReader(bondId: string, locale: ReaderLocale = 'es'): Promise<ContractReaderResponse> {
+    const [summary, glossary] = await Promise.all([
+      this.getContractSummary(bondId),
+      this.getGlossary(locale),
+    ]);
+    return buildContractReaderResponse(summary, glossary, locale);
+  }
+
+  /**
+   * Source of the structured contract for a bond.
+   *
+   * The canonical structured-contract model + storage is owned by the "Contract
+   * intelligence & document assembly" epic (#38), which is not merged yet. Until
+   * then this returns the shared fixture shape with the requested `bondId`, so
+   * the reader endpoint is exercisable end-to-end with no VELAR database, secrets
+   * or external APIs.
+   *
+   * @todo Replace with the real structured-contract source when #38 lands.
+   */
+  private async getContractSummary(bondId: string): Promise<ContractSummary> {
+    return { ...contractSummaryFixture, bondId };
+  }
+}

--- a/apps/web/components/contract-reader/ContractReader.tsx
+++ b/apps/web/components/contract-reader/ContractReader.tsx
@@ -1,0 +1,354 @@
+'use client';
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { BookOpen, Check, Download, FileText, Printer } from 'lucide-react';
+import type {
+  ContractReaderResponse,
+  GlossaryTerm,
+  PlainLanguageClause,
+  ReaderLocale,
+} from '@velar/types';
+import {
+  buildExportText,
+  computeReadingProgress,
+  createContractReaderClient,
+  glossaryById,
+  highlightSegments,
+  plainLanguageText,
+} from '../../lib/contract-reader';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api';
+
+type Mode = 'simple' | 'legal';
+
+export interface ContractReaderProps {
+  bondId: string;
+  locale?: ReaderLocale;
+  /** Preloaded response (fixtures/SSR). When provided, no network request is made. */
+  initialReader?: ContractReaderResponse;
+}
+
+/**
+ * Interactive contract reader (issue #39): clause-by-clause plain language with
+ * glossary tooltips, key-term highlighting, a summary ⇄ legal toggle, reading
+ * progress, comprehension checkpoints and print/export. Localized (es),
+ * responsive and keyboard accessible. Complements — never replaces — the legal
+ * contract.
+ */
+export function ContractReader({ bondId, locale = 'es', initialReader }: ContractReaderProps) {
+  const [reader, setReader] = useState<ContractReaderResponse | null>(initialReader ?? null);
+  const [loading, setLoading] = useState(!initialReader);
+  const [error, setError] = useState<string | null>(null);
+  const [mode, setMode] = useState<Mode>('simple');
+  const [readIds, setReadIds] = useState<Set<string>>(new Set());
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const clauseRefs = useRef<(HTMLElement | null)[]>([]);
+
+  useEffect(() => {
+    if (initialReader) return;
+    let active = true;
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const client = createContractReaderClient({ baseUrl: API_BASE });
+        const r = await client.getReader(bondId, locale);
+        if (active) setReader(r);
+      } catch (e: unknown) {
+        if (active) setError(e instanceof Error ? e.message : 'No se pudo cargar el contrato.');
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    void run();
+    return () => {
+      active = false;
+    };
+  }, [bondId, locale, initialReader, reloadKey]);
+
+  const glossaryMap = useMemo(() => glossaryById(reader?.glossary ?? []), [reader]);
+
+  const toggleRead = useCallback((clauseId: string) => {
+    setReadIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(clauseId)) next.delete(clauseId);
+      else next.add(clauseId);
+      return next;
+    });
+  }, []);
+
+  const handleExport = useCallback(() => {
+    if (!reader) return;
+    const blob = new Blob([buildExportText(reader)], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `contrato-${reader.bondId}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [reader]);
+
+  // Keyboard navigation between clauses (ArrowDown / ArrowUp when a clause is focused).
+  const onListKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+    const items = clauseRefs.current.filter(Boolean) as HTMLElement[];
+    const idx = items.indexOf(document.activeElement as HTMLElement);
+    if (idx === -1) return;
+    e.preventDefault();
+    const nextIdx = e.key === 'ArrowDown' ? Math.min(idx + 1, items.length - 1) : Math.max(idx - 1, 0);
+    items[nextIdx]?.focus();
+  }, []);
+
+  if (loading) {
+    return (
+      <div role="status" aria-live="polite" className="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-500">
+        Cargando el contrato…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div role="alert" className="rounded-2xl border border-red-200 bg-red-50 p-6">
+        <p className="text-sm text-red-700">{error}</p>
+        <button
+          type="button"
+          onClick={() => setReloadKey((k) => k + 1)}
+          className="mt-3 rounded-lg border border-red-300 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-100"
+        >
+          Reintentar
+        </button>
+      </div>
+    );
+  }
+
+  if (!reader || reader.clauses.length === 0) {
+    return (
+      <div className="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-500">
+        No hay un contrato disponible para mostrar todavía.
+      </div>
+    );
+  }
+
+  const progress = computeReadingProgress(readIds, reader.clauses.length);
+
+  return (
+    <section aria-label="Lector del contrato" className="rounded-2xl border border-gray-200 bg-white">
+      {/* Header + toolbar */}
+      <div className="border-b border-gray-100 p-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">{reader.title}</h2>
+            <p className="text-xs text-gray-500">
+              Esta guía te ayuda a entender el contrato. Complementa el documento legal; no lo reemplaza.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 print:hidden">
+            <div role="group" aria-label="Modo de lectura" className="flex rounded-lg border border-gray-200 p-0.5">
+              <button
+                type="button"
+                aria-pressed={mode === 'simple'}
+                onClick={() => setMode('simple')}
+                className={`flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium ${mode === 'simple' ? 'bg-gray-900 text-white' : 'text-gray-600'}`}
+              >
+                <BookOpen size={14} aria-hidden="true" /> Lenguaje simple
+              </button>
+              <button
+                type="button"
+                aria-pressed={mode === 'legal'}
+                onClick={() => setMode('legal')}
+                className={`flex items-center gap-1 rounded-md px-2.5 py-1 text-xs font-medium ${mode === 'legal' ? 'bg-gray-900 text-white' : 'text-gray-600'}`}
+              >
+                <FileText size={14} aria-hidden="true" /> Documento legal
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="flex items-center gap-1 rounded-lg border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
+            >
+              <Printer size={14} aria-hidden="true" /> Imprimir
+            </button>
+            <button
+              type="button"
+              onClick={handleExport}
+              className="flex items-center gap-1 rounded-lg border border-gray-200 px-2.5 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50"
+            >
+              <Download size={14} aria-hidden="true" /> Exportar
+            </button>
+          </div>
+        </div>
+
+        {/* Reading progress */}
+        <div className="mt-4">
+          <div className="mb-1 flex items-center justify-between text-xs text-gray-500">
+            <span>Progreso de lectura</span>
+            <span>{progress}%</span>
+          </div>
+          <div
+            className="h-2 w-full overflow-hidden rounded-full bg-gray-100"
+            role="progressbar"
+            aria-valuenow={progress}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label="Progreso de lectura del contrato"
+          >
+            <div
+              className="h-full rounded-full bg-emerald-500 transition-all motion-reduce:transition-none"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Summary */}
+      {reader.summary && (
+        <div className="border-b border-gray-100 bg-gray-50 p-5">
+          <h3 className="mb-1 text-sm font-semibold text-gray-900">Resumen</h3>
+          <p className="text-sm leading-relaxed text-gray-700">{reader.summary}</p>
+        </div>
+      )}
+
+      {/* Clauses */}
+      <ol className="divide-y divide-gray-100" onKeyDown={onListKeyDown}>
+        {reader.clauses.map((clause, index) => (
+          <ClauseItem
+            key={clause.clauseId}
+            registerRef={(el) => {
+              clauseRefs.current[index] = el;
+            }}
+            clause={clause}
+            glossaryMap={glossaryMap}
+            mode={mode}
+            read={readIds.has(clause.clauseId)}
+            onToggleRead={() => toggleRead(clause.clauseId)}
+          />
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+// ─── Clause item ────────────────────────────────────────────────────────────
+
+interface ClauseItemProps {
+  clause: PlainLanguageClause;
+  glossaryMap: Map<string, GlossaryTerm>;
+  mode: Mode;
+  read: boolean;
+  onToggleRead: () => void;
+  registerRef?: (el: HTMLLIElement | null) => void;
+}
+
+function ClauseItem({ clause, glossaryMap, mode, read, onToggleRead, registerRef }: ClauseItemProps) {
+  const headingId = `${clause.anchor}-title`;
+  const legalText = (
+    <HighlightedText clause={clause} glossaryMap={glossaryMap} />
+  );
+
+  return (
+    <li
+      id={clause.anchor}
+      ref={registerRef}
+      tabIndex={-1}
+      aria-labelledby={headingId}
+      className="scroll-mt-4 p-5 outline-none focus-visible:ring-2 focus-visible:ring-emerald-400"
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h3 id={headingId} className="text-sm font-semibold text-gray-900">
+          {clause.title}
+        </h3>
+        {read && (
+          <span className="flex items-center gap-1 text-xs font-medium text-emerald-600">
+            <Check size={14} aria-hidden="true" /> Entendida
+          </span>
+        )}
+      </div>
+
+      {mode === 'simple' ? (
+        <>
+          <p className="text-sm leading-relaxed text-gray-700">{plainLanguageText(clause)}</p>
+          <details className="mt-2">
+            <summary className="cursor-pointer text-xs font-medium text-gray-500 hover:text-gray-700">
+              Ver texto legal original
+            </summary>
+            <p className="mt-2 text-sm leading-relaxed text-gray-600">{legalText}</p>
+          </details>
+        </>
+      ) : (
+        <>
+          <p className="text-sm leading-relaxed text-gray-800">{legalText}</p>
+          <p className="mt-2 rounded-lg bg-gray-50 p-3 text-xs leading-relaxed text-gray-600">
+            <span className="font-medium text-gray-700">En lenguaje simple: </span>
+            {plainLanguageText(clause)}
+          </p>
+        </>
+      )}
+
+      {/* Comprehension checkpoint */}
+      <button
+        type="button"
+        onClick={onToggleRead}
+        aria-pressed={read}
+        className={`mt-3 rounded-lg border px-3 py-1.5 text-xs font-medium print:hidden ${
+          read
+            ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+            : 'border-gray-200 text-gray-600 hover:bg-gray-50'
+        }`}
+      >
+        {read ? 'Marcada como entendida' : '¿Entendiste esta cláusula?'}
+      </button>
+    </li>
+  );
+}
+
+// ─── Highlighted legal text with glossary tooltips ──────────────────────────
+
+function HighlightedText({
+  clause,
+  glossaryMap,
+}: {
+  clause: PlainLanguageClause;
+  glossaryMap: Map<string, GlossaryTerm>;
+}) {
+  const glossary = Array.from(glossaryMap.values());
+  const segments = highlightSegments(clause.legalText, clause.keyTerms, glossary);
+  return (
+    <>
+      {segments.map((seg, i) =>
+        seg.glossaryId ? (
+          <GlossaryMark key={i} text={seg.text} term={glossaryMap.get(seg.glossaryId)} />
+        ) : (
+          <span key={i}>{seg.text}</span>
+        ),
+      )}
+    </>
+  );
+}
+
+function GlossaryMark({ text, term }: { text: string; term?: GlossaryTerm }) {
+  const tooltipId = useId();
+  if (!term) return <span>{text}</span>;
+  return (
+    <span className="group relative inline-block">
+      <mark
+        tabIndex={0}
+        aria-describedby={tooltipId}
+        className="cursor-help rounded bg-amber-100 px-0.5 text-gray-900 underline decoration-dotted underline-offset-2 outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+      >
+        {text}
+      </mark>
+      <span
+        role="tooltip"
+        id={tooltipId}
+        className="pointer-events-none absolute bottom-full left-0 z-10 mb-1 w-56 rounded-lg bg-gray-900 p-2 text-xs leading-snug text-white opacity-0 shadow-lg transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:transition-none"
+      >
+        <span className="font-semibold">{term.term}: </span>
+        {term.definition}
+      </span>
+    </span>
+  );
+}
+
+export default ContractReader;

--- a/apps/web/lib/contract-reader.spec.ts
+++ b/apps/web/lib/contract-reader.spec.ts
@@ -1,0 +1,145 @@
+import { glossaryFixture, type ContractReaderResponse } from '@velar/types';
+import {
+  buildExportText,
+  computeReadingProgress,
+  createContractReaderClient,
+  highlightSegments,
+  NO_PLAIN_LANGUAGE_ES,
+  plainLanguageText,
+  type FetchLike,
+} from './contract-reader';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const READER: ContractReaderResponse = {
+  bondId: 'bond-1',
+  contractId: 'contract-1',
+  title: 'Contrato de prueba',
+  version: 'v1',
+  summary: 'Resumen del contrato.',
+  locale: 'es',
+  generatedAt: '2026-07-01T00:00:00.000Z',
+  clauses: [
+    {
+      clauseId: 'cl-1',
+      order: 1,
+      title: 'Cláusula 1',
+      category: 'garantia',
+      legalText: 'El token queda en custodia (escrow) hasta el pago.',
+      plainLanguage: 'El bono queda retenido hasta confirmar el pago.',
+      keyTerms: [
+        { term: 'escrow', glossaryId: 'g-escrow' },
+        { term: 'token', glossaryId: 'g-token' },
+      ],
+      unknown: false,
+      anchor: 'clausula-1',
+    },
+    {
+      clauseId: 'cl-2',
+      order: 2,
+      title: 'Cláusula 2',
+      category: 'otro',
+      legalText: 'Disposición sin plantilla.',
+      plainLanguage: '',
+      keyTerms: [],
+      unknown: true,
+      anchor: 'clausula-2',
+    },
+  ],
+  glossary: glossaryFixture.filter((g) => g.id === 'g-escrow' || g.id === 'g-token'),
+};
+
+describe('contract-reader client', () => {
+  it('fetches the reader response for a bond', async () => {
+    const fetcher: FetchLike = jest.fn(async () => jsonResponse(READER));
+    const client = createContractReaderClient({ baseUrl: 'http://test/api', fetch: fetcher });
+    const reader = await client.getReader('bond-1', 'es');
+    expect(reader.bondId).toBe('bond-1');
+    expect(fetcher).toHaveBeenCalledWith(
+      'http://test/api/contracts/bond-1/reader?locale=es',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('fetches the glossary', async () => {
+    const fetcher: FetchLike = jest.fn(async () => jsonResponse(READER.glossary));
+    const client = createContractReaderClient({ baseUrl: 'http://test/api', fetch: fetcher });
+    const glossary = await client.getGlossary('es');
+    expect(glossary.map((g) => g.id)).toContain('g-escrow');
+  });
+
+  it('throws with the backend message on error responses', async () => {
+    const fetcher: FetchLike = async () => jsonResponse({ message: 'no existe' }, 404);
+    const client = createContractReaderClient({ baseUrl: 'http://test/api', fetch: fetcher });
+    await expect(client.getReader('missing')).rejects.toThrow('no existe');
+  });
+});
+
+describe('highlightSegments', () => {
+  it('marks key terms (including aliases) and preserves the original text', () => {
+    const clause = READER.clauses[0];
+    const segments = highlightSegments(clause.legalText, clause.keyTerms, glossaryFixture);
+    // Rebuilding the segments yields the original text unchanged.
+    expect(segments.map((s) => s.text).join('')).toBe(clause.legalText);
+    const highlighted = segments.filter((s) => s.glossaryId);
+    // "custodia" (alias of escrow), "escrow" and "token" are all highlighted.
+    expect(highlighted.map((s) => s.glossaryId)).toEqual(
+      expect.arrayContaining(['g-escrow', 'g-token']),
+    );
+    expect(highlighted.map((s) => s.text.toLowerCase())).toEqual(
+      expect.arrayContaining(['custodia', 'escrow', 'token']),
+    );
+  });
+
+  it('matches whole words only', () => {
+    const segments = highlightSegments(
+      'bono tokenizado',
+      [{ term: 'token', glossaryId: 'g-token' }],
+      glossaryFixture,
+    );
+    expect(segments.some((s) => s.glossaryId)).toBe(false);
+  });
+
+  it('returns a single plain segment when there are no key terms', () => {
+    expect(highlightSegments('texto simple', [], glossaryFixture)).toEqual([{ text: 'texto simple' }]);
+  });
+});
+
+describe('computeReadingProgress', () => {
+  it('returns 0 when there are no clauses', () => {
+    expect(computeReadingProgress([], 0)).toBe(0);
+  });
+  it('rounds the percentage of read clauses', () => {
+    expect(computeReadingProgress(['a'], 3)).toBe(33);
+    expect(computeReadingProgress(['a', 'b', 'c'], 3)).toBe(100);
+  });
+  it('caps at 100 and de-duplicates', () => {
+    expect(computeReadingProgress(['a', 'a', 'b', 'x'], 2)).toBe(100);
+  });
+});
+
+describe('plainLanguageText', () => {
+  it('returns the neutral note for unknown clauses (no invented meaning)', () => {
+    expect(plainLanguageText(READER.clauses[1])).toBe(NO_PLAIN_LANGUAGE_ES);
+  });
+  it('returns the derived plain language for known clauses', () => {
+    expect(plainLanguageText(READER.clauses[0])).toBe(READER.clauses[0].plainLanguage);
+  });
+});
+
+describe('buildExportText', () => {
+  it('includes the title, summary, clauses, glossary and the disclaimer', () => {
+    const text = buildExportText(READER);
+    expect(text).toContain('Contrato de prueba');
+    expect(text).toContain('Resumen del contrato.');
+    expect(text).toContain('Cláusula 1');
+    expect(text).toContain(NO_PLAIN_LANGUAGE_ES); // unknown clause exported neutrally
+    expect(text).toContain('Glosario');
+    expect(text).toContain('no lo reemplaza');
+  });
+});

--- a/apps/web/lib/contract-reader.ts
+++ b/apps/web/lib/contract-reader.ts
@@ -1,0 +1,175 @@
+import type {
+  ClauseKeyTerm,
+  ContractReaderResponse,
+  GlossaryTerm,
+  PlainLanguageClause,
+  ReaderLocale,
+} from '@velar/types';
+
+/**
+ * Client + pure helpers for the contract reading experience (issue #39).
+ *
+ * The helpers are pure and framework-free so they can be unit-tested in the
+ * repo's node test environment; the React component composes them.
+ */
+
+// ─── Client ───────────────────────────────────────────────────────────────────
+
+export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export interface ContractReaderClientOptions {
+  baseUrl: string;
+  fetch?: FetchLike;
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  return `${baseUrl.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+}
+
+async function getJson<T>(opts: ContractReaderClientOptions, path: string): Promise<T> {
+  const doFetch = opts.fetch ?? fetch;
+  const res = await doFetch(joinUrl(opts.baseUrl, path), {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+  if (!res.ok) {
+    let message = `Error ${res.status}`;
+    try {
+      const body = (await res.json()) as { message?: unknown };
+      if (typeof body?.message === 'string' && body.message.trim()) message = body.message;
+    } catch {
+      // ignore non-JSON error bodies
+    }
+    throw new Error(message);
+  }
+  return (await res.json()) as T;
+}
+
+/** Creates a small client for the public contract-reader endpoints. */
+export function createContractReaderClient(opts: ContractReaderClientOptions) {
+  return {
+    getGlossary: (locale: ReaderLocale = 'es') =>
+      getJson<GlossaryTerm[]>(opts, `/contracts/glossary?locale=${encodeURIComponent(locale)}`),
+    getReader: (bondId: string, locale: ReaderLocale = 'es') =>
+      getJson<ContractReaderResponse>(
+        opts,
+        `/contracts/${encodeURIComponent(bondId)}/reader?locale=${encodeURIComponent(locale)}`,
+      ),
+  };
+}
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+/** A run of clause text, optionally linked to a glossary entry for highlighting. */
+export interface TextSegment {
+  text: string;
+  glossaryId?: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Index glossary entries by id for quick lookup. */
+export function glossaryById(glossary: GlossaryTerm[]): Map<string, GlossaryTerm> {
+  return new Map(glossary.map((entry) => [entry.id, entry]));
+}
+
+/**
+ * Splits `text` into segments, marking the occurrences of a clause's key terms
+ * (matched by the glossary entry's term + aliases, whole-word, case-insensitive)
+ * so the UI can highlight them and attach glossary tooltips. Non-overlapping,
+ * longest-match-first; original casing/spacing is preserved.
+ */
+export function highlightSegments(
+  text: string,
+  keyTerms: ClauseKeyTerm[],
+  glossary: GlossaryTerm[],
+): TextSegment[] {
+  if (!text) return [];
+  const byId = glossaryById(glossary);
+
+  // Collect all searchable forms with their glossary id, longest first.
+  const forms: { form: string; glossaryId: string }[] = [];
+  for (const kt of keyTerms) {
+    const entry = byId.get(kt.glossaryId);
+    const candidates = entry ? [entry.term, ...(entry.aliases ?? [])] : [kt.term];
+    for (const form of candidates) {
+      const trimmed = form.trim();
+      if (trimmed) forms.push({ form: trimmed, glossaryId: kt.glossaryId });
+    }
+  }
+  forms.sort((a, b) => b.form.length - a.form.length);
+  if (forms.length === 0) return [{ text }];
+
+  type Match = { start: number; end: number; glossaryId: string };
+  const matches: Match[] = [];
+  for (const { form, glossaryId } of forms) {
+    const re = new RegExp(`(^|[^\\p{L}\\p{N}])(${escapeRegExp(form)})(?=[^\\p{L}\\p{N}]|$)`, 'giu');
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      const start = m.index + m[1].length;
+      const end = start + m[2].length;
+      // Skip if this span overlaps an already-recorded (longer) match.
+      if (!matches.some((x) => start < x.end && end > x.start)) {
+        matches.push({ start, end, glossaryId });
+      }
+      if (m.index === re.lastIndex) re.lastIndex++;
+    }
+  }
+
+  matches.sort((a, b) => a.start - b.start);
+
+  const segments: TextSegment[] = [];
+  let cursor = 0;
+  for (const match of matches) {
+    if (match.start > cursor) segments.push({ text: text.slice(cursor, match.start) });
+    segments.push({ text: text.slice(match.start, match.end), glossaryId: match.glossaryId });
+    cursor = match.end;
+  }
+  if (cursor < text.length) segments.push({ text: text.slice(cursor) });
+  return segments;
+}
+
+/** Reading progress as a 0–100 integer given the set of clauses marked as read. */
+export function computeReadingProgress(readClauseIds: Iterable<string>, totalClauses: number): number {
+  if (totalClauses <= 0) return 0;
+  const read = new Set(readClauseIds).size;
+  return Math.round((Math.min(read, totalClauses) / totalClauses) * 100);
+}
+
+/** Neutral placeholder shown when a clause has no plain-language derivation. */
+export const NO_PLAIN_LANGUAGE_ES = 'Sin explicación simplificada disponible para esta cláusula.';
+
+/** Plain-language text for a clause, falling back to a neutral note when unknown. */
+export function plainLanguageText(clause: PlainLanguageClause): string {
+  return clause.unknown || !clause.plainLanguage ? NO_PLAIN_LANGUAGE_ES : clause.plainLanguage;
+}
+
+/** Builds a plain-text export/print version of the reader response. */
+export function buildExportText(reader: ContractReaderResponse): string {
+  const lines: string[] = [];
+  lines.push(reader.title);
+  lines.push('='.repeat(reader.title.length));
+  lines.push('');
+  if (reader.summary) {
+    lines.push('Resumen');
+    lines.push(reader.summary);
+    lines.push('');
+  }
+  for (const clause of reader.clauses) {
+    lines.push(clause.title);
+    lines.push(`Lenguaje simple: ${plainLanguageText(clause)}`);
+    lines.push(`Texto legal: ${clause.legalText}`);
+    lines.push('');
+  }
+  if (reader.glossary.length > 0) {
+    lines.push('Glosario');
+    for (const term of reader.glossary) {
+      lines.push(`- ${term.term}: ${term.definition}`);
+    }
+    lines.push('');
+  }
+  lines.push('Esta guía complementa el contrato legal; no lo reemplaza.');
+  return lines.join('\n');
+}

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -259,3 +259,53 @@ npm run test --workspace apps/api -- --runInBand
 
 Las pruebas `common/contracts/*.spec.ts` validan payloads válidos/inválidos por cada módulo,
 localización, drift de responses y que toda ruta JSON de los controladores cubiertos tenga contrato.
+
+## 7. Lector de contratos y glosario (issue #39)
+
+Módulo `apps/api/src/contracts/` — experiencia de lectura y comprensión del contrato de un bono.
+Complementa el contrato legal en lenguaje simple; **nunca lo reemplaza**.
+
+### Derivación a lenguaje simple (funciones puras)
+
+`contracts/plain-language.ts` transforma un contrato estructurado + un glosario en explicaciones
+por cláusula y un set de términos clave resaltados. Reglas:
+
+- El significado legal **no se inventa**: el lenguaje simple viene de plantillas mantenidas por
+  categoría de cláusula (`ClauseCategory`); el texto legal específico se preserva en `legalText`.
+- Cláusulas sin plantilla (categoría o idioma sin cobertura) se marcan con `unknown: true` y
+  `plainLanguage: ''` (la UI muestra un estado neutral, sin inventar).
+- `extractKeyTerms` hace match de términos + alias como palabra completa (Unicode, sin distinguir
+  mayúsculas), una referencia por término.
+- `buildContractReaderResponse` arma el `ContractReaderResponse` tipado, con el glosario limitado a
+  los términos referenciados y anchors por cláusula (`clausula-<order>`) para deep-link.
+
+### Glosario (Supabase)
+
+- Tabla `glossary_terms` (migración `20260701000000_glossary_terms.sql`): `id, term, definition,
+  locale, aliases[], created_at`. **RLS: lectura pública** (`USING (true)`); escritura solo por
+  `service_role` (backend). Semilla idempotente con los términos base en español.
+- `ContractsService` lee el glosario vía `SupabaseService` (mockeable en tests) y deriva el lector
+  con las funciones puras. El origen del contrato estructurado es un fixture hasta que aterrice el
+  epic #38 (Contract intelligence & assembly).
+
+### Endpoints (públicos — también los usa `/verificar/[id]`)
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| GET | `/contracts/glossary?locale=es` | Términos del glosario para un idioma |
+| GET | `/contracts/:bondId/reader?locale=es` | `ContractReaderResponse` tipado del bono |
+
+### Tipos
+
+En `@velar/types`: `ContractReaderResponse`, `PlainLanguageClause`, `GlossaryTerm`, `ClauseKeyTerm`,
+`ReaderLocale` (reader), y el modelo provisional `ContractSummary`/`ContractClause`/`ClauseCategory`
+(fixture de #38, a reemplazar cuando ese epic aterrice).
+
+### Comprobación local sin credenciales
+
+```bash
+npm run test --workspace apps/api -- --testPathPatterns contracts
+```
+
+Tests puros sobre el fixture (mapeo, `unknown` flagged, alias/palabra completa, subset de glosario,
+anchors) y tests del servicio con `SupabaseService` mockeado (glosario tipado + reader response).

--- a/supabase/migrations/20260701000000_glossary_terms.sql
+++ b/supabase/migrations/20260701000000_glossary_terms.sql
@@ -1,0 +1,63 @@
+-- ============================================================
+-- VELAR — Glosario de términos (contract reader) — issue #39
+-- ============================================================
+-- Tabla de términos + definiciones en lenguaje simple (i18n) que alimenta el
+-- glosario del lector de contratos. Los términos NO son datos sensibles: son
+-- definiciones públicas que ayudan a cualquiera a entender el contrato.
+--
+-- Principios de esta migración:
+--   • ADITIVA: solo crea una tabla nueva y la siembra. No toca nada existente.
+--   • APPEND-ONLY: no modifica migraciones ya aplicadas.
+--   • SEGURA: lectura pública (RLS `USING (true)`), escritura solo backend
+--     (service_role, que hace bypass de RLS). Sin secretos.
+--
+-- Rollback (si te arrepentís):
+--   DROP TABLE IF EXISTS public.glossary_terms;
+-- ============================================================
+
+-- ── 1. Tabla ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.glossary_terms (
+  id          text PRIMARY KEY,
+  term        text NOT NULL,
+  definition  text NOT NULL,
+  locale      text NOT NULL DEFAULT 'es',
+  aliases     text[] NOT NULL DEFAULT '{}',
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_glossary_terms_locale ON public.glossary_terms(locale);
+
+-- ── 2. RLS: lectura pública, escritura solo service_role ────
+ALTER TABLE public.glossary_terms ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'glossary_terms'
+      AND policyname = 'glossary_terms_public_read'
+  ) THEN
+    CREATE POLICY "glossary_terms_public_read" ON public.glossary_terms
+      FOR SELECT USING (true);
+  END IF;
+END $$;
+
+-- ── 3. Semilla (idempotente) ────────────────────────────────
+-- Definiciones base en español. Ampliables con futuras migraciones append-only.
+INSERT INTO public.glossary_terms (id, term, definition, locale, aliases) VALUES
+  ('g-escrow', 'escrow',
+   'Un depósito en garantía: el token queda retenido por un tercero neutral (un contrato en la blockchain) hasta que se cumplan las condiciones acordadas, como la confirmación del pago.',
+   'es', ARRAY['custodia','depósito en garantía']),
+  ('g-token', 'token',
+   'La representación digital única del bono en la red Stellar.',
+   'es', ARRAY['token del bono']),
+  ('g-sinpe', 'SINPE',
+   'Sistema Nacional de Pagos Electrónicos de Costa Rica, usado para transferencias de dinero entre cuentas.',
+   'es', ARRAY[]::text[]),
+  ('g-titularidad', 'titularidad',
+   'La condición de ser el dueño legal del bono.',
+   'es', ARRAY['titular']),
+  ('g-tse', 'TSE',
+   'Tribunal Supremo de Elecciones: la institución que emite los bonos, supervisa las transferencias y audita el historial.',
+   'es', ARRAY[]::text[])
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
Part of epic #39. **PR 4/5** — the interactive contract reader (frontend) with pure helpers + tests.

> ⚠️ **Stacked on #50, #51, #52.** Until they merge, the diff also shows their commits — review the `feat(web): interactive contract reader …` commit.

## What this adds (`apps/web`)
- **`lib/contract-reader.ts`** — framework-free client + pure helpers:
  - `createContractReaderClient({ baseUrl, fetch })` → `getGlossary`, `getReader` (public endpoints).
  - `highlightSegments(text, keyTerms, glossary)` — whole-word, Unicode, alias-aware term highlighting that preserves the original text.
  - `computeReadingProgress`, `plainLanguageText` (neutral note for `unknown`), `buildExportText`, `glossaryById`.
- **`components/contract-reader/ContractReader.tsx`** — clause-by-clause plain language, **glossary tooltips** on highlighted key terms, **summary ⇄ legal** toggle/compare, **reading progress**, **comprehension checkpoints** ("¿Entendiste esta cláusula?"), **print + text export**. Localized (es), responsive, and **accessible**: keyboard navigation between clauses (Arrow keys), `aria` (progressbar / tooltip / pressed), focus-visible rings, screen-reader definitions, reduced-motion. Loading / error / empty states. Uses the public endpoint — **no secrets in the client**.
- **`lib/contract-reader.spec.ts`** — 12 tests over the `@velar/types` fixture.

The repo's jest runs `.spec.ts` in a node environment, so reader logic is covered through the pure helpers (the `.tsx` composes them) — consistent with the existing `lib/contract-client.spec.ts` approach.

## Testing (no VELAR credentials)
- `npm test --workspace apps/web` → **20/20** (3 suites).
- `npm run typecheck` and `eslint` on the new files pass.

Next: PR 5 — mount the reader on `mis-bonos`, `partido/mis-bonos`, `tse/bono` and public `verificar/[id]`, plus `docs/FRONTEND_GUIDE.md`.

Refs #39.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
