### PR TITLE
fix(types): pin zod v4 across workspaces to unblock CI build

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -46,7 +46,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "ws": "^8.21.0",
-    "zod": "^3.24.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,7 @@
     "ogl": "^1.0.11",
     "react": "19.2.4",
     "react-dom": "19.2.4",
-    "zod": "^3.24.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "ws": "^8.21.0",
-        "zod": "^3.24.2"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -75,15 +75,6 @@
         "typescript-eslint": "^8.20.0"
       }
     },
-    "apps/api/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "apps/web": {
       "version": "0.1.0",
       "dependencies": {
@@ -97,7 +88,7 @@
         "ogl": "^1.0.11",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "zod": "^3.24.2"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -121,15 +112,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "apps/web/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -29278,16 +29260,7 @@
       "name": "@velar/types",
       "version": "1.0.0",
       "dependencies": {
-        "zod": "^3.24.2"
-      }
-    },
-    "packages/types/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "zod": "^4.4.3"
       }
     }
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,7 @@
   "main": "./types/index.js",
   "types": "./types/index.d.ts",
   "dependencies": {
-    "zod": "^3.24.2"
+    "zod": "^4.4.3"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Problema

El build de `@velar/types` falla en CI (`npm run build --workspace @velar/types`) con errores tipo:

```
error TS2769: No overload matches this call ... 'error' does not exist in type '{ errorMap?, invalid_type_error?, required_error?, message?, description? }'
```

## Causa

Los schemas del contract layer ya usan sintaxis **Zod v4** (`z.enum([...], { error })`, `z.string({ error })`, etc.), pero `package.json` seguía declarando `"zod": "^3.24.2"`. En local compilaba porque un zod 4.x quedaba hoisteado en la raíz; en una instalación limpia de CI se resuelve **zod v3**, donde `error` no es un parámetro válido.

## Fix

- Alinea `packages/types`, `apps/api` y `apps/web` a `zod@^4.4.3`.
- Refresca `package-lock.json` (se eliminan las copias anidadas de v3; los 3 workspaces resuelven a 4.4.3).

## Verificación

`npm run build --workspace @velar/types` → compila limpio. No hay APIs exclusivas de v3 en uso (`z.nativeEnum` / `z.string().email()` están deprecadas pero funcionan en v4).