### PR TITLE
feat(types): BondProvenance model + fixture (#36, PR 1/5)

### DIFF
--- a/packages/types/src/fixtures/provenance.ts
+++ b/packages/types/src/fixtures/provenance.ts
@@ -1,0 +1,130 @@
+import type { ProvenanceInput } from '../provenance';
+
+/**
+ * Development/testing fixture for the provenance engine (issue #36).
+ *
+ * A clean, gap-free history of one bond: emitted to a party, then transferred
+ * to a buyer through the full escrow lifecycle. Reconstructs with NO anomalies.
+ * Anomaly variants (gap, illegal transition, on-chain/off-chain mismatch) are
+ * derived from this base in the engine's tests.
+ *
+ * NOT production data — exists so the engine, API and UI can be built and tested
+ * locally with no VELAR database, secrets or external APIs.
+ */
+
+const PARTY = 'party-libertad';
+const BUYER = 'buyer-juan';
+const TSE = 'tse-authority';
+const TOKEN = 'bond-token-001';
+const TRANSFER = 'transfer-001';
+const TX_ESCROW = 'stellar-tx-escrow-aaaa';
+const TX_RELEASE = 'stellar-tx-release-bbbb';
+
+export const provenanceFixture: ProvenanceInput = {
+  bond: {
+    tokenId: TOKEN,
+    bondId: 'BOND-2026-001',
+    issuerPartyId: PARTY,
+    country: 'CR',
+    currentOwner: BUYER,
+    status: 'transferido',
+    documentHash: 'sha256-bonddoc-0001',
+    faceValue: 1000,
+    currency: 'CRC',
+    createdAt: '2026-01-10T09:00:00.000Z',
+    updatedAt: '2026-03-01T12:00:00.000Z',
+  },
+  transfers: [
+    {
+      id: TRANSFER,
+      bondTokenId: TOKEN,
+      fromOwner: PARTY,
+      toOwner: BUYER,
+      status: 'liberada',
+      escrowContractId: 'CESCROW0001',
+      paymentEvidenceHash: 'sha256-payment-0001',
+      validatedBy: TSE,
+      amount: 1000,
+      createdAt: '2026-02-01T10:00:00.000Z',
+      updatedAt: '2026-03-01T12:00:00.000Z',
+    },
+  ],
+  events: [
+    {
+      id: 'evt-1',
+      bondTokenId: TOKEN,
+      transferId: null,
+      type: 'bond_emitido',
+      actorId: TSE,
+      payload: { owner: PARTY },
+      createdAt: '2026-01-10T09:00:00.000Z',
+    },
+    {
+      id: 'evt-2',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'transfer_solicitada',
+      actorId: PARTY,
+      payload: { from: PARTY, to: BUYER },
+      createdAt: '2026-02-01T10:00:00.000Z',
+    },
+    {
+      id: 'evt-3',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'transfer_aceptada',
+      actorId: BUYER,
+      payload: {},
+      createdAt: '2026-02-02T11:00:00.000Z',
+    },
+    {
+      id: 'evt-4',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'escrow_bloqueado',
+      actorId: PARTY,
+      payload: { escrowContractId: 'CESCROW0001' },
+      txHash: TX_ESCROW,
+      createdAt: '2026-02-03T12:00:00.000Z',
+    },
+    {
+      id: 'evt-5',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'pago_registrado',
+      actorId: BUYER,
+      payload: { paymentEvidenceHash: 'sha256-payment-0001' },
+      createdAt: '2026-02-10T13:00:00.000Z',
+    },
+    {
+      id: 'evt-6',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'pago_validado',
+      actorId: TSE,
+      payload: {},
+      createdAt: '2026-02-20T14:00:00.000Z',
+    },
+    {
+      id: 'evt-7',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'token_liberado',
+      actorId: PARTY,
+      payload: { from: PARTY, to: BUYER },
+      txHash: TX_RELEASE,
+      createdAt: '2026-03-01T12:00:00.000Z',
+    },
+  ],
+};
+
+/** Stable identifiers referenced by tests. */
+export const provenanceFixtureIds = {
+  token: TOKEN,
+  transfer: TRANSFER,
+  party: PARTY,
+  buyer: BUYER,
+  tse: TSE,
+  txEscrow: TX_ESCROW,
+  txRelease: TX_RELEASE,
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -12,6 +12,8 @@ export * from './contracts';
 export * from './contract-model';
 export * from './contract-reader';
 export * from './fixtures/contract-reader';
+export * from './provenance';
+export * from './fixtures/provenance';
 export * from './schemas/common';
 export * from './schemas/auth';
 export * from './schemas/bonds';

--- a/packages/types/src/provenance.ts
+++ b/packages/types/src/provenance.ts
@@ -1,0 +1,139 @@
+import type { AuditEvent } from './audit';
+import type { BondToken } from './bond';
+import type { Transfer, TransferStatus } from './transfer';
+
+/**
+ * Provenance & traceability model (issue #36).
+ *
+ * A `BondProvenance` is the reconstructed, verified history of a bond: the
+ * ordered ownership timeline, every transfer's lifecycle, and an integrity
+ * report with typed anomaly flags. It is derived by PURE functions from the
+ * append-only audit events, transfers and escrow records — the history is never
+ * reordered or mutated (see docs/AGENTS.md §4).
+ */
+
+// ─── Anomalies / integrity ────────────────────────────────────────────────────
+
+/** Categories of provenance integrity anomaly. */
+export const ProvenanceAnomalyType = {
+  /** Events/transfers are not in chronological order. */
+  OUT_OF_ORDER: 'out_of_order',
+  /** An owner's end does not match the next owner's start (a gap in the chain). */
+  OWNERSHIP_GAP: 'ownership_gap',
+  /** A transfer moved between states that the state machine does not allow. */
+  ILLEGAL_TRANSITION: 'illegal_transition',
+  /** On-chain reference (tx hash / owner) disagrees with the off-chain record. */
+  ONCHAIN_OFFCHAIN_MISMATCH: 'onchain_offchain_mismatch',
+  /** A lifecycle stage is reached with no supporting audit event. */
+  MISSING_EVENT: 'missing_event',
+} as const;
+
+export type ProvenanceAnomalyType =
+  (typeof ProvenanceAnomalyType)[keyof typeof ProvenanceAnomalyType];
+
+export type ProvenanceSeverity = 'info' | 'warning' | 'error';
+
+/** A single detected integrity problem, linked to the record that caused it. */
+export interface ProvenanceAnomaly {
+  type: ProvenanceAnomalyType;
+  severity: ProvenanceSeverity;
+  /** Human-readable (Spanish) description. */
+  message: string;
+  transferId?: string | null;
+  eventId?: string | null;
+  ownerId?: string | null;
+  /** ISO-8601 timestamp where the anomaly occurs, when applicable. */
+  at?: string | null;
+}
+
+/** The result of running every integrity check over a reconstruction. */
+export interface IntegrityReport {
+  /** True when there are no `error`-severity anomalies. */
+  ok: boolean;
+  anomalies: ProvenanceAnomaly[];
+  /** ISO-8601 timestamp of when the checks ran. */
+  checkedAt: string;
+}
+
+// ─── Ownership timeline ───────────────────────────────────────────────────────
+
+/** One continuous period during which a single party owned the bond. */
+export interface OwnershipSegment {
+  ownerId: string;
+  /** ISO-8601 start of ownership. */
+  from: string;
+  /** ISO-8601 end of ownership, or null for the current owner. */
+  to: string | null;
+  current: boolean;
+  /** Transfer that handed ownership to this owner (null for the initial owner). */
+  viaTransferId: string | null;
+  /** Audit event that established this owner (e.g. bond_emitido / token_liberado). */
+  viaEventId: string | null;
+}
+
+// ─── Transfer lifecycle (stepper) ─────────────────────────────────────────────
+
+/** Ordered happy-path steps of a transfer, used by the lifecycle stepper. */
+export const TRANSFER_LIFECYCLE_STEPS = [
+  'solicitada',
+  'aceptada',
+  'en_escrow',
+  'pago_registrado',
+  'pago_validado',
+  'liberada',
+] as const;
+
+export type TransferLifecycleStep = (typeof TRANSFER_LIFECYCLE_STEPS)[number];
+
+/** Terminal transfer states that end the flow. */
+export const TERMINAL_TRANSFER_STATUSES = ['liberada', 'rechazada', 'cancelada'] as const;
+
+/** A stage the transfer actually reached, timestamped from its audit event. */
+export interface TransferLifecycleStage {
+  status: TransferStatus;
+  /** ISO-8601 time the stage was reached (null if no supporting event). */
+  at: string | null;
+  eventId: string | null;
+}
+
+/** A transfer's reconstructed lifecycle for the stepper UI. */
+export interface TransferLifecycle {
+  transferId: string;
+  fromOwner: string;
+  toOwner: string;
+  /** Current transfer status. */
+  status: TransferStatus;
+  /** Index into TRANSFER_LIFECYCLE_STEPS for the current step, or -1 if terminal/off-path. */
+  currentStepIndex: number;
+  /** True when the transfer is in a terminal state. */
+  terminal: boolean;
+  /** Ordered history of stages actually reached. */
+  stages: TransferLifecycleStage[];
+}
+
+// ─── Root ─────────────────────────────────────────────────────────────────────
+
+/** The full reconstructed, verified provenance record for a bond. */
+export interface BondProvenance {
+  bond: BondToken;
+  /** Chronological ownership timeline. */
+  ownership: OwnershipSegment[];
+  /** Per-transfer lifecycles. */
+  transfers: TransferLifecycle[];
+  /** The append-only audit events, in order (never reordered/mutated). */
+  events: AuditEvent[];
+  integrity: IntegrityReport;
+  /** ISO-8601 timestamp of when the record was reconstructed. */
+  reconstructedAt: string;
+}
+
+/**
+ * Raw inputs the reconstruction engine consumes. Sourced from Supabase in
+ * production (mocked in tests); shaped here so fixtures and the pure engine
+ * share one contract.
+ */
+export interface ProvenanceInput {
+  bond: BondToken;
+  events: AuditEvent[];
+  transfers: Transfer[];
+}

--- a/packages/types/types/fixtures/provenance.d.ts
+++ b/packages/types/types/fixtures/provenance.d.ts
@@ -1,0 +1,12 @@
+import type { ProvenanceInput } from '../provenance';
+export declare const provenanceFixture: ProvenanceInput;
+/** Stable identifiers referenced by tests. */
+export declare const provenanceFixtureIds: {
+    token: string;
+    transfer: string;
+    party: string;
+    buyer: string;
+    tse: string;
+    txEscrow: string;
+    txRelease: string;
+};

--- a/packages/types/types/fixtures/provenance.js
+++ b/packages/types/types/fixtures/provenance.js
@@ -1,0 +1,128 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.provenanceFixtureIds = exports.provenanceFixture = void 0;
+/**
+ * Development/testing fixture for the provenance engine (issue #36).
+ *
+ * A clean, gap-free history of one bond: emitted to a party, then transferred
+ * to a buyer through the full escrow lifecycle. Reconstructs with NO anomalies.
+ * Anomaly variants (gap, illegal transition, on-chain/off-chain mismatch) are
+ * derived from this base in the engine's tests.
+ *
+ * NOT production data — exists so the engine, API and UI can be built and tested
+ * locally with no VELAR database, secrets or external APIs.
+ */
+const PARTY = 'party-libertad';
+const BUYER = 'buyer-juan';
+const TSE = 'tse-authority';
+const TOKEN = 'bond-token-001';
+const TRANSFER = 'transfer-001';
+const TX_ESCROW = 'stellar-tx-escrow-aaaa';
+const TX_RELEASE = 'stellar-tx-release-bbbb';
+exports.provenanceFixture = {
+    bond: {
+        tokenId: TOKEN,
+        bondId: 'BOND-2026-001',
+        issuerPartyId: PARTY,
+        country: 'CR',
+        currentOwner: BUYER,
+        status: 'transferido',
+        documentHash: 'sha256-bonddoc-0001',
+        faceValue: 1000,
+        currency: 'CRC',
+        createdAt: '2026-01-10T09:00:00.000Z',
+        updatedAt: '2026-03-01T12:00:00.000Z',
+    },
+    transfers: [
+        {
+            id: TRANSFER,
+            bondTokenId: TOKEN,
+            fromOwner: PARTY,
+            toOwner: BUYER,
+            status: 'liberada',
+            escrowContractId: 'CESCROW0001',
+            paymentEvidenceHash: 'sha256-payment-0001',
+            validatedBy: TSE,
+            amount: 1000,
+            createdAt: '2026-02-01T10:00:00.000Z',
+            updatedAt: '2026-03-01T12:00:00.000Z',
+        },
+    ],
+    events: [
+        {
+            id: 'evt-1',
+            bondTokenId: TOKEN,
+            transferId: null,
+            type: 'bond_emitido',
+            actorId: TSE,
+            payload: { owner: PARTY },
+            createdAt: '2026-01-10T09:00:00.000Z',
+        },
+        {
+            id: 'evt-2',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'transfer_solicitada',
+            actorId: PARTY,
+            payload: { from: PARTY, to: BUYER },
+            createdAt: '2026-02-01T10:00:00.000Z',
+        },
+        {
+            id: 'evt-3',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'transfer_aceptada',
+            actorId: BUYER,
+            payload: {},
+            createdAt: '2026-02-02T11:00:00.000Z',
+        },
+        {
+            id: 'evt-4',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'escrow_bloqueado',
+            actorId: PARTY,
+            payload: { escrowContractId: 'CESCROW0001' },
+            txHash: TX_ESCROW,
+            createdAt: '2026-02-03T12:00:00.000Z',
+        },
+        {
+            id: 'evt-5',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'pago_registrado',
+            actorId: BUYER,
+            payload: { paymentEvidenceHash: 'sha256-payment-0001' },
+            createdAt: '2026-02-10T13:00:00.000Z',
+        },
+        {
+            id: 'evt-6',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'pago_validado',
+            actorId: TSE,
+            payload: {},
+            createdAt: '2026-02-20T14:00:00.000Z',
+        },
+        {
+            id: 'evt-7',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'token_liberado',
+            actorId: PARTY,
+            payload: { from: PARTY, to: BUYER },
+            txHash: TX_RELEASE,
+            createdAt: '2026-03-01T12:00:00.000Z',
+        },
+    ],
+};
+/** Stable identifiers referenced by tests. */
+exports.provenanceFixtureIds = {
+    token: TOKEN,
+    transfer: TRANSFER,
+    party: PARTY,
+    buyer: BUYER,
+    tse: TSE,
+    txEscrow: TX_ESCROW,
+    txRelease: TX_RELEASE,
+};

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -12,6 +12,8 @@ export * from './contracts';
 export * from './contract-model';
 export * from './contract-reader';
 export * from './fixtures/contract-reader';
+export * from './provenance';
+export * from './fixtures/provenance';
 export * from './schemas/common';
 export * from './schemas/auth';
 export * from './schemas/bonds';

--- a/packages/types/types/index.js
+++ b/packages/types/types/index.js
@@ -28,6 +28,8 @@ __exportStar(require("./contracts"), exports);
 __exportStar(require("./contract-model"), exports);
 __exportStar(require("./contract-reader"), exports);
 __exportStar(require("./fixtures/contract-reader"), exports);
+__exportStar(require("./provenance"), exports);
+__exportStar(require("./fixtures/provenance"), exports);
 __exportStar(require("./schemas/common"), exports);
 __exportStar(require("./schemas/auth"), exports);
 __exportStar(require("./schemas/bonds"), exports);

--- a/packages/types/types/provenance.d.ts
+++ b/packages/types/types/provenance.d.ts
@@ -1,0 +1,109 @@
+import type { AuditEvent } from './audit';
+import type { BondToken } from './bond';
+import type { Transfer, TransferStatus } from './transfer';
+/**
+ * Provenance & traceability model (issue #36).
+ *
+ * A `BondProvenance` is the reconstructed, verified history of a bond: the
+ * ordered ownership timeline, every transfer's lifecycle, and an integrity
+ * report with typed anomaly flags. It is derived by PURE functions from the
+ * append-only audit events, transfers and escrow records — the history is never
+ * reordered or mutated (see docs/AGENTS.md §4).
+ */
+/** Categories of provenance integrity anomaly. */
+export declare const ProvenanceAnomalyType: {
+    /** Events/transfers are not in chronological order. */
+    readonly OUT_OF_ORDER: "out_of_order";
+    /** An owner's end does not match the next owner's start (a gap in the chain). */
+    readonly OWNERSHIP_GAP: "ownership_gap";
+    /** A transfer moved between states that the state machine does not allow. */
+    readonly ILLEGAL_TRANSITION: "illegal_transition";
+    /** On-chain reference (tx hash / owner) disagrees with the off-chain record. */
+    readonly ONCHAIN_OFFCHAIN_MISMATCH: "onchain_offchain_mismatch";
+    /** A lifecycle stage is reached with no supporting audit event. */
+    readonly MISSING_EVENT: "missing_event";
+};
+export type ProvenanceAnomalyType = (typeof ProvenanceAnomalyType)[keyof typeof ProvenanceAnomalyType];
+export type ProvenanceSeverity = 'info' | 'warning' | 'error';
+/** A single detected integrity problem, linked to the record that caused it. */
+export interface ProvenanceAnomaly {
+    type: ProvenanceAnomalyType;
+    severity: ProvenanceSeverity;
+    /** Human-readable (Spanish) description. */
+    message: string;
+    transferId?: string | null;
+    eventId?: string | null;
+    ownerId?: string | null;
+    /** ISO-8601 timestamp where the anomaly occurs, when applicable. */
+    at?: string | null;
+}
+/** The result of running every integrity check over a reconstruction. */
+export interface IntegrityReport {
+    /** True when there are no `error`-severity anomalies. */
+    ok: boolean;
+    anomalies: ProvenanceAnomaly[];
+    /** ISO-8601 timestamp of when the checks ran. */
+    checkedAt: string;
+}
+/** One continuous period during which a single party owned the bond. */
+export interface OwnershipSegment {
+    ownerId: string;
+    /** ISO-8601 start of ownership. */
+    from: string;
+    /** ISO-8601 end of ownership, or null for the current owner. */
+    to: string | null;
+    current: boolean;
+    /** Transfer that handed ownership to this owner (null for the initial owner). */
+    viaTransferId: string | null;
+    /** Audit event that established this owner (e.g. bond_emitido / token_liberado). */
+    viaEventId: string | null;
+}
+/** Ordered happy-path steps of a transfer, used by the lifecycle stepper. */
+export declare const TRANSFER_LIFECYCLE_STEPS: readonly ["solicitada", "aceptada", "en_escrow", "pago_registrado", "pago_validado", "liberada"];
+export type TransferLifecycleStep = (typeof TRANSFER_LIFECYCLE_STEPS)[number];
+/** Terminal transfer states that end the flow. */
+export declare const TERMINAL_TRANSFER_STATUSES: readonly ["liberada", "rechazada", "cancelada"];
+/** A stage the transfer actually reached, timestamped from its audit event. */
+export interface TransferLifecycleStage {
+    status: TransferStatus;
+    /** ISO-8601 time the stage was reached (null if no supporting event). */
+    at: string | null;
+    eventId: string | null;
+}
+/** A transfer's reconstructed lifecycle for the stepper UI. */
+export interface TransferLifecycle {
+    transferId: string;
+    fromOwner: string;
+    toOwner: string;
+    /** Current transfer status. */
+    status: TransferStatus;
+    /** Index into TRANSFER_LIFECYCLE_STEPS for the current step, or -1 if terminal/off-path. */
+    currentStepIndex: number;
+    /** True when the transfer is in a terminal state. */
+    terminal: boolean;
+    /** Ordered history of stages actually reached. */
+    stages: TransferLifecycleStage[];
+}
+/** The full reconstructed, verified provenance record for a bond. */
+export interface BondProvenance {
+    bond: BondToken;
+    /** Chronological ownership timeline. */
+    ownership: OwnershipSegment[];
+    /** Per-transfer lifecycles. */
+    transfers: TransferLifecycle[];
+    /** The append-only audit events, in order (never reordered/mutated). */
+    events: AuditEvent[];
+    integrity: IntegrityReport;
+    /** ISO-8601 timestamp of when the record was reconstructed. */
+    reconstructedAt: string;
+}
+/**
+ * Raw inputs the reconstruction engine consumes. Sourced from Supabase in
+ * production (mocked in tests); shaped here so fixtures and the pure engine
+ * share one contract.
+ */
+export interface ProvenanceInput {
+    bond: BondToken;
+    events: AuditEvent[];
+    transfers: Transfer[];
+}

--- a/packages/types/types/provenance.js
+++ b/packages/types/types/provenance.js
@@ -1,0 +1,38 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.TERMINAL_TRANSFER_STATUSES = exports.TRANSFER_LIFECYCLE_STEPS = exports.ProvenanceAnomalyType = void 0;
+/**
+ * Provenance & traceability model (issue #36).
+ *
+ * A `BondProvenance` is the reconstructed, verified history of a bond: the
+ * ordered ownership timeline, every transfer's lifecycle, and an integrity
+ * report with typed anomaly flags. It is derived by PURE functions from the
+ * append-only audit events, transfers and escrow records — the history is never
+ * reordered or mutated (see docs/AGENTS.md §4).
+ */
+// ─── Anomalies / integrity ────────────────────────────────────────────────────
+/** Categories of provenance integrity anomaly. */
+exports.ProvenanceAnomalyType = {
+    /** Events/transfers are not in chronological order. */
+    OUT_OF_ORDER: 'out_of_order',
+    /** An owner's end does not match the next owner's start (a gap in the chain). */
+    OWNERSHIP_GAP: 'ownership_gap',
+    /** A transfer moved between states that the state machine does not allow. */
+    ILLEGAL_TRANSITION: 'illegal_transition',
+    /** On-chain reference (tx hash / owner) disagrees with the off-chain record. */
+    ONCHAIN_OFFCHAIN_MISMATCH: 'onchain_offchain_mismatch',
+    /** A lifecycle stage is reached with no supporting audit event. */
+    MISSING_EVENT: 'missing_event',
+};
+// ─── Transfer lifecycle (stepper) ─────────────────────────────────────────────
+/** Ordered happy-path steps of a transfer, used by the lifecycle stepper. */
+exports.TRANSFER_LIFECYCLE_STEPS = [
+    'solicitada',
+    'aceptada',
+    'en_escrow',
+    'pago_registrado',
+    'pago_validado',
+    'liberada',
+];
+/** Terminal transfer states that end the flow. */
+exports.TERMINAL_TRANSFER_STATUSES = ['liberada', 'rechazada', 'cancelada'];


### PR DESCRIPTION
Part of the epic #36 (Provenance & traceability explorer). **PR 1 of a stacked series** — shared foundation only; no runtime/API/UI behavior yet.

## What this adds (`packages/types`, additive)
- **`provenance.ts`** — `BondProvenance` (ownership timeline + per-transfer lifecycle + integrity report), `ProvenanceAnomaly` / `ProvenanceAnomalyType` (`out_of_order`, `ownership_gap`, `illegal_transition`, `onchain_offchain_mismatch`, `missing_event`), `OwnershipSegment`, `TransferLifecycle` (+ `TRANSFER_LIFECYCLE_STEPS`, `TERMINAL_TRANSFER_STATUSES`), and `ProvenanceInput` (the engine's input contract). Built on the existing `AuditEvent` / `Transfer` / `BondToken` types.
- **`fixtures/provenance.ts`** — a clean, gap-free 2-owner history (emission → full escrow transfer) that reconstructs with **no anomalies**; anomaly variants are derived from it in the engine's tests. No production data.
- Re-exported from `index.ts`; the committed `@velar/types` build output was regenerated.

## Stacked plan for #36
1. **types + fixture** ← this PR
2. backend: pure reconstruction/verification engine + unit tests
3. backend: provenance service + `GET /api/bonds/:tokenId/provenance` (guarded + public read) + mocked-Supabase tests + `BACKEND.md`
4. frontend: `OwnershipTimeline` + `TransferLifecycleStepper` + helpers/tests
5. frontend: provenance explorer + integration on the 6 surfaces + export + `FRONTEND_GUIDE.md`

## Testing
- `npm run build --workspace packages/types` and `typecheck` pass. Additive only — existing types unchanged, so `apps/api` / `apps/web` are unaffected. No secrets; no migrations here.

Refs #36.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
