### PR TITLE
feat(api): provenance service + guarded/public endpoints (#36, PR 3/5)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,6 +17,7 @@ import { ExplorerModule } from './explorer/explorer.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { HealthModule } from './health/health.module';
 import { ContractsModule } from './contracts/contracts.module';
+import { ProvenanceModule } from './provenance/provenance.module';
 import { RolesGuard } from './auth/roles.guard';
 import { AuthGuard } from './auth/auth.guard';
 
@@ -52,6 +53,7 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
     NotificationsModule,
     HealthModule,
     ContractsModule,
+    ProvenanceModule,
   ],
   controllers: [AppController],
   providers: [

--- a/apps/api/src/audit/audit.service.ts
+++ b/apps/api/src/audit/audit.service.ts
@@ -6,6 +6,7 @@ import {
   BondSearchQuery,
   type AuditEvent,
   type BondToken,
+  type ProvenanceInput,
   type Transfer,
   type TraceabilityResponse,
 } from '@velar/types';
@@ -185,6 +186,35 @@ export class AuditService {
     const full = await this.getBondTraceability(tokenId);
     const transfers = full.transfers.map((t) => ({ ...t, sellerMessage: null, buyerMessage: null }));
     return { ...full, transfers };
+  }
+
+  /**
+   * Raw inputs for the provenance engine (issue #36): the bond, its append-only
+   * audit events and its transfers, mapped to the shared @velar/types shapes.
+   * Reuses the traceability row mappers so both features read the DB the same way.
+   */
+  async getProvenanceInput(tokenId: string): Promise<ProvenanceInput> {
+    const { bond, events, transfers } = await this.getBondTimeline(tokenId);
+    return {
+      bond: this.mapBondTraceabilityBond(bond),
+      events: events.map((event) => this.mapAuditEvent(event)),
+      transfers: transfers.map((transfer) => this.mapTransfer(transfer)),
+    };
+  }
+
+  /**
+   * Resolves a token_id (UUID) or a human-readable bond_id (e.g. "SOL-2026-114")
+   * to the token_id, for public lookups. Throws 404 if the bond does not exist.
+   */
+  async resolveTokenId(idOrToken: string): Promise<string> {
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(idOrToken);
+    if (isUuid) return idOrToken;
+    const { data } = await this.supabase.admin
+      .from('bonds').select('token_id').eq('bond_id', idOrToken).maybeSingle();
+    if (!data) {
+      throw new HttpException({ error: 'Bond not found', statusCode: 404 }, HttpStatus.NOT_FOUND);
+    }
+    return data.token_id;
   }
 
   async searchBonds(query: BondSearchQuery) {

--- a/apps/api/src/provenance/provenance-engine.spec.ts
+++ b/apps/api/src/provenance/provenance-engine.spec.ts
@@ -1,0 +1,156 @@
+import type { AuditEvent, ProvenanceInput } from '@velar/types';
+import { provenanceFixture, provenanceFixtureIds } from '@velar/types';
+import {
+  isLegalTransferTransition,
+  reconstructOwnership,
+  reconstructProvenance,
+  reconstructTransferLifecycle,
+} from './provenance-engine';
+
+/** Deep clone so mutating a scenario never leaks into the shared fixture. */
+const clone = (input: ProvenanceInput): ProvenanceInput =>
+  JSON.parse(JSON.stringify(input)) as ProvenanceInput;
+
+const ids = provenanceFixtureIds;
+const FIXED_NOW = new Date('2026-04-01T00:00:00.000Z');
+
+describe('reconstructProvenance — clean history', () => {
+  it('reports no anomalies and ok=true', () => {
+    const result = reconstructProvenance(clone(provenanceFixture), FIXED_NOW);
+    expect(result.integrity.ok).toBe(true);
+    expect(result.integrity.anomalies).toEqual([]);
+    expect(result.reconstructedAt).toBe(FIXED_NOW.toISOString());
+  });
+
+  it('reconstructs the two-owner ownership timeline in order', () => {
+    const { ownership } = reconstructProvenance(clone(provenanceFixture), FIXED_NOW);
+    expect(ownership).toHaveLength(2);
+    expect(ownership[0]).toMatchObject({ ownerId: ids.party, current: false });
+    expect(ownership[0].to).not.toBeNull();
+    expect(ownership[1]).toMatchObject({
+      ownerId: ids.buyer,
+      current: true,
+      to: null,
+      viaTransferId: ids.transfer,
+    });
+    // The first owner's end joins the second owner's start (no gap).
+    expect(ownership[0].to).toBe(ownership[1].from);
+  });
+
+  it('reconstructs the transfer lifecycle through every happy-path stage', () => {
+    const { transfers } = reconstructProvenance(clone(provenanceFixture), FIXED_NOW);
+    expect(transfers).toHaveLength(1);
+    const lifecycle = transfers[0];
+    expect(lifecycle.status).toBe('liberada');
+    expect(lifecycle.terminal).toBe(true);
+    expect(lifecycle.stages.map((s) => s.status)).toEqual([
+      'solicitada',
+      'aceptada',
+      'en_escrow',
+      'pago_registrado',
+      'pago_validado',
+      'liberada',
+    ]);
+  });
+
+  it('never mutates or reorders the input events', () => {
+    const input = clone(provenanceFixture);
+    const before = input.events.map((e) => e.id);
+    reconstructProvenance(input, FIXED_NOW);
+    expect(input.events.map((e) => e.id)).toEqual(before);
+  });
+});
+
+describe('reconstructProvenance — integrity anomalies', () => {
+  it('flags OUT_OF_ORDER when events are not chronological', () => {
+    const input = clone(provenanceFixture);
+    // Swap two adjacent events so timestamps go backwards.
+    [input.events[2], input.events[3]] = [input.events[3], input.events[2]];
+    const { integrity } = reconstructProvenance(input, FIXED_NOW);
+    expect(integrity.ok).toBe(false);
+    expect(integrity.anomalies.some((a) => a.type === 'out_of_order')).toBe(true);
+  });
+
+  it('flags OWNERSHIP_GAP when a release hands over from the wrong owner', () => {
+    const input = clone(provenanceFixture);
+    const release = input.events.find((e) => e.type === 'token_liberado') as AuditEvent;
+    release.payload = { ...release.payload, from: 'someone-else' };
+    const { integrity } = reconstructProvenance(input, FIXED_NOW);
+    const gap = integrity.anomalies.find((a) => a.type === 'ownership_gap');
+    expect(gap).toBeDefined();
+    expect(gap?.severity).toBe('error');
+    expect(integrity.ok).toBe(false);
+  });
+
+  it('flags ILLEGAL_TRANSITION when a stage skips backwards', () => {
+    const input = clone(provenanceFixture);
+    // Turn "pago_registrado" into a second "pago_validado", so the sequence is
+    // ... en_escrow -> pago_validado -> pago_validado -> liberada, with an illegal
+    // en_escrow -> pago_validado jump.
+    const registered = input.events.find((e) => e.type === 'pago_registrado') as AuditEvent;
+    registered.type = 'pago_validado';
+    const { integrity } = reconstructProvenance(input, FIXED_NOW);
+    expect(integrity.anomalies.some((a) => a.type === 'illegal_transition')).toBe(true);
+    expect(integrity.ok).toBe(false);
+  });
+
+  it('flags ONCHAIN_OFFCHAIN_MISMATCH when the bond owner disagrees with history', () => {
+    const input = clone(provenanceFixture);
+    input.bond.currentOwner = 'ghost-owner';
+    const { integrity } = reconstructProvenance(input, FIXED_NOW);
+    const mismatch = integrity.anomalies.find((a) => a.type === 'onchain_offchain_mismatch');
+    expect(mismatch).toBeDefined();
+    expect(integrity.ok).toBe(false);
+  });
+
+  it('flags ONCHAIN_OFFCHAIN_MISMATCH when a release targets the wrong owner', () => {
+    const input = clone(provenanceFixture);
+    const release = input.events.find((e) => e.type === 'token_liberado') as AuditEvent;
+    release.payload = { ...release.payload, to: 'wrong-buyer' };
+    const { integrity } = reconstructProvenance(input, FIXED_NOW);
+    expect(integrity.anomalies.some((a) => a.type === 'onchain_offchain_mismatch')).toBe(true);
+  });
+
+  it('flags MISSING_EVENT when a completed transfer skips an intermediate stage', () => {
+    const input = clone(provenanceFixture);
+    input.events = input.events.filter((e) => e.type !== 'pago_validado');
+    const { integrity } = reconstructProvenance(input, FIXED_NOW);
+    const missing = integrity.anomalies.find((a) => a.type === 'missing_event');
+    expect(missing).toBeDefined();
+    expect(missing?.severity).toBe('warning');
+  });
+});
+
+describe('transfer state machine', () => {
+  it('accepts happy-path transitions and rejects illegal ones', () => {
+    expect(isLegalTransferTransition('solicitada', 'aceptada')).toBe(true);
+    expect(isLegalTransferTransition('pago_validado', 'liberada')).toBe(true);
+    expect(isLegalTransferTransition('en_escrow', 'pago_validado')).toBe(false);
+    expect(isLegalTransferTransition('liberada', 'aceptada')).toBe(false);
+  });
+
+  it('allows cancellation from any active state but not from terminal states', () => {
+    expect(isLegalTransferTransition('aceptada', 'cancelada')).toBe(true);
+    expect(isLegalTransferTransition('rechazada', 'cancelada')).toBe(false);
+  });
+});
+
+describe('reconstruction of degenerate inputs', () => {
+  it('returns an empty timeline when there are no ownership events', () => {
+    const input = clone(provenanceFixture);
+    input.events = input.events.filter(
+      (e) => e.type !== 'bond_emitido' && e.type !== 'token_liberado',
+    );
+    const ownership = reconstructOwnership(input.events, input.bond, input.transfers);
+    expect(ownership).toEqual([]);
+  });
+
+  it('marks a still-open transfer as non-terminal with the right step index', () => {
+    const input = clone(provenanceFixture);
+    const transfer = input.transfers[0];
+    transfer.status = 'en_escrow';
+    const lifecycle = reconstructTransferLifecycle(transfer, input.events);
+    expect(lifecycle.terminal).toBe(false);
+    expect(lifecycle.currentStepIndex).toBe(2); // index of 'en_escrow'
+  });
+});

--- a/apps/api/src/provenance/provenance-engine.ts
+++ b/apps/api/src/provenance/provenance-engine.ts
@@ -1,0 +1,284 @@
+import type {
+  AuditEvent,
+  AuditEventType,
+  BondProvenance,
+  IntegrityReport,
+  OwnershipSegment,
+  ProvenanceAnomaly,
+  ProvenanceInput,
+  Transfer,
+  TransferLifecycle,
+  TransferLifecycleStage,
+  TransferStatus,
+} from '@velar/types';
+import { TERMINAL_TRANSFER_STATUSES, TRANSFER_LIFECYCLE_STEPS } from '@velar/types';
+
+/**
+ * Provenance reconstruction & verification engine (issue #36).
+ *
+ * PURE functions: given a bond's audit events, transfers and escrow records,
+ * reconstruct the ordered ownership timeline and each transfer's lifecycle, and
+ * produce an integrity report with typed anomaly flags. The append-only history
+ * is never mutated — events are sorted into a COPY for analysis only.
+ */
+
+// ─── Transfer state machine (for legality checks) ─────────────────────────────
+
+/** Allowed transfer status transitions. */
+export const TRANSFER_TRANSITIONS: Readonly<Record<TransferStatus, readonly TransferStatus[]>> = {
+  solicitada: ['aceptada', 'contraoferta', 'rechazada', 'cancelada'],
+  contraoferta: ['aceptada', 'rechazada', 'cancelada'],
+  aceptada: ['en_escrow', 'cancelada'],
+  en_escrow: ['pago_registrado', 'cancelada'],
+  pago_registrado: ['pago_validado', 'cancelada'],
+  pago_validado: ['liberada'],
+  liberada: [],
+  rechazada: [],
+  cancelada: [],
+};
+
+export function isLegalTransferTransition(from: TransferStatus, to: TransferStatus): boolean {
+  return TRANSFER_TRANSITIONS[from]?.includes(to) ?? false;
+}
+
+/** Maps an audit event type to the transfer status it represents, if any. */
+const EVENT_TO_TRANSFER_STATUS: Partial<Record<AuditEventType, TransferStatus>> = {
+  transfer_solicitada: 'solicitada',
+  counter_offer_sent: 'contraoferta',
+  transfer_aceptada: 'aceptada',
+  escrow_bloqueado: 'en_escrow',
+  pago_registrado: 'pago_registrado',
+  pago_validado: 'pago_validado',
+  token_liberado: 'liberada',
+  transfer_rechazada: 'rechazada',
+  transfer_cancelada: 'cancelada',
+};
+
+const OWNERSHIP_EVENT_TYPES: AuditEventType[] = ['bond_emitido', 'bond_asignado', 'token_liberado'];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const asTime = (iso: string): number => new Date(iso).getTime();
+
+/** Events sorted ascending by createdAt (stable). Does NOT mutate the input. */
+function sortedByTime(events: AuditEvent[]): AuditEvent[] {
+  return [...events]
+    .map((e, i) => ({ e, i }))
+    .sort((a, b) => asTime(a.e.createdAt) - asTime(b.e.createdAt) || a.i - b.i)
+    .map(({ e }) => e);
+}
+
+function ownerFromEvent(event: AuditEvent, bond: ProvenanceInput['bond']): string | null {
+  const payload = event.payload ?? {};
+  if (event.type === 'bond_emitido') {
+    return (payload.owner as string) ?? bond.issuerPartyId ?? null;
+  }
+  if (event.type === 'bond_asignado') {
+    return (payload.owner as string) ?? (payload.to as string) ?? null;
+  }
+  if (event.type === 'token_liberado') {
+    return (payload.to as string) ?? null;
+  }
+  return null;
+}
+
+// ─── Ownership timeline ───────────────────────────────────────────────────────
+
+export function reconstructOwnership(
+  events: AuditEvent[],
+  bond: ProvenanceInput['bond'],
+  transfers: Transfer[],
+): OwnershipSegment[] {
+  const ordered = sortedByTime(events);
+  const transferById = new Map(transfers.map((t) => [t.id, t]));
+  const segments: OwnershipSegment[] = [];
+
+  for (const event of ordered) {
+    if (!OWNERSHIP_EVENT_TYPES.includes(event.type)) continue;
+    let ownerId = ownerFromEvent(event, bond);
+    if (event.type === 'token_liberado' && !ownerId && event.transferId) {
+      ownerId = transferById.get(event.transferId)?.toOwner ?? null;
+    }
+    if (!ownerId) continue;
+
+    // Close the previous open segment at this event's time.
+    const open = segments[segments.length - 1];
+    if (open && open.to === null) open.to = event.createdAt;
+
+    segments.push({
+      ownerId,
+      from: event.createdAt,
+      to: null,
+      current: false,
+      viaTransferId: event.transferId ?? null,
+      viaEventId: event.id,
+    });
+  }
+
+  if (segments.length > 0) segments[segments.length - 1].current = true;
+  return segments;
+}
+
+// ─── Transfer lifecycle ───────────────────────────────────────────────────────
+
+export function reconstructTransferLifecycle(
+  transfer: Transfer,
+  events: AuditEvent[],
+): TransferLifecycle {
+  const ordered = sortedByTime(events.filter((e) => e.transferId === transfer.id));
+  const stages: TransferLifecycleStage[] = [];
+  for (const event of ordered) {
+    const status = EVENT_TO_TRANSFER_STATUS[event.type];
+    if (!status) continue;
+    stages.push({ status, at: event.createdAt, eventId: event.id });
+  }
+
+  const terminal = (TERMINAL_TRANSFER_STATUSES as readonly string[]).includes(transfer.status);
+  const currentStepIndex = (TRANSFER_LIFECYCLE_STEPS as readonly string[]).indexOf(transfer.status);
+
+  return {
+    transferId: transfer.id,
+    fromOwner: transfer.fromOwner,
+    toOwner: transfer.toOwner,
+    status: transfer.status,
+    currentStepIndex,
+    terminal,
+    stages,
+  };
+}
+
+// ─── Integrity checks ─────────────────────────────────────────────────────────
+
+export function checkIntegrity(
+  input: ProvenanceInput,
+  ownership: OwnershipSegment[],
+  lifecycles: TransferLifecycle[],
+): ProvenanceAnomaly[] {
+  const anomalies: ProvenanceAnomaly[] = [];
+  const { bond, events, transfers } = input;
+  const transferById = new Map(transfers.map((t) => [t.id, t]));
+
+  // 1. Chronological order: the events must already be in ascending time order.
+  for (let i = 1; i < events.length; i++) {
+    if (asTime(events[i].createdAt) < asTime(events[i - 1].createdAt)) {
+      anomalies.push({
+        type: 'out_of_order',
+        severity: 'error',
+        message: `El evento ${events[i].id} está fuera de orden cronológico.`,
+        eventId: events[i].id,
+        at: events[i].createdAt,
+      });
+    }
+  }
+
+  // 2. Ownership gaps: each release must hand over from the current owner.
+  for (let i = 1; i < ownership.length; i++) {
+    const prev = ownership[i - 1];
+    const seg = ownership[i];
+    const event = events.find((e) => e.id === seg.viaEventId);
+    const declaredFrom = (event?.payload?.from as string | undefined) ?? undefined;
+    if (declaredFrom && declaredFrom !== prev.ownerId) {
+      anomalies.push({
+        type: 'ownership_gap',
+        severity: 'error',
+        message: `La transferencia entrega desde ${declaredFrom} pero el dueño previo era ${prev.ownerId}.`,
+        eventId: seg.viaEventId,
+        transferId: seg.viaTransferId,
+        ownerId: prev.ownerId,
+        at: seg.from,
+      });
+    }
+  }
+
+  // 3. State-machine legality: consecutive transfer stages must be legal transitions.
+  for (const lifecycle of lifecycles) {
+    for (let i = 1; i < lifecycle.stages.length; i++) {
+      const from = lifecycle.stages[i - 1].status;
+      const to = lifecycle.stages[i].status;
+      if (from === to) continue;
+      if (!isLegalTransferTransition(from, to)) {
+        anomalies.push({
+          type: 'illegal_transition',
+          severity: 'error',
+          message: `Transición ilegal "${from}" → "${to}" en la transferencia ${lifecycle.transferId}.`,
+          transferId: lifecycle.transferId,
+          eventId: lifecycle.stages[i].eventId,
+          at: lifecycle.stages[i].at,
+        });
+      }
+    }
+  }
+
+  // 4. On-chain/off-chain agreement: the bond's recorded owner must match the
+  //    owner established by the last ownership event, and a release event's
+  //    target must match its transfer's toOwner.
+  const lastSegment = ownership[ownership.length - 1];
+  if (lastSegment && bond.currentOwner && bond.currentOwner !== lastSegment.ownerId) {
+    anomalies.push({
+      type: 'onchain_offchain_mismatch',
+      severity: 'error',
+      message: `El dueño registrado del bono (${bond.currentOwner}) no coincide con el historial (${lastSegment.ownerId}).`,
+      ownerId: bond.currentOwner,
+    });
+  }
+  for (const event of events) {
+    if (event.type !== 'token_liberado' || !event.transferId) continue;
+    const transfer = transferById.get(event.transferId);
+    const to = event.payload?.to as string | undefined;
+    if (transfer && to && to !== transfer.toOwner) {
+      anomalies.push({
+        type: 'onchain_offchain_mismatch',
+        severity: 'error',
+        message: `El evento on-chain libera a ${to} pero la transferencia apunta a ${transfer.toOwner}.`,
+        eventId: event.id,
+        transferId: transfer.id,
+        at: event.createdAt,
+      });
+    }
+  }
+
+  // 5. Missing supporting events: a completed transfer must have every prior
+  //    happy-path stage backed by an event.
+  for (const lifecycle of lifecycles) {
+    if (lifecycle.currentStepIndex < 0) continue;
+    const reached = new Set(lifecycle.stages.map((s) => s.status));
+    for (let step = 0; step <= lifecycle.currentStepIndex; step++) {
+      const expected = TRANSFER_LIFECYCLE_STEPS[step];
+      if (!reached.has(expected)) {
+        anomalies.push({
+          type: 'missing_event',
+          severity: 'warning',
+          message: `Falta el evento de la etapa "${expected}" en la transferencia ${lifecycle.transferId}.`,
+          transferId: lifecycle.transferId,
+        });
+      }
+    }
+  }
+
+  return anomalies;
+}
+
+// ─── Root ─────────────────────────────────────────────────────────────────────
+
+/** Reconstructs and verifies the full provenance of a bond from raw inputs. */
+export function reconstructProvenance(input: ProvenanceInput, now = new Date()): BondProvenance {
+  const events = sortedByTime(input.events);
+  const ownership = reconstructOwnership(input.events, input.bond, input.transfers);
+  const transfers = input.transfers.map((t) => reconstructTransferLifecycle(t, input.events));
+  const anomalies = checkIntegrity(input, ownership, transfers);
+
+  const integrity: IntegrityReport = {
+    ok: !anomalies.some((a) => a.severity === 'error'),
+    anomalies,
+    checkedAt: now.toISOString(),
+  };
+
+  return {
+    bond: input.bond,
+    ownership,
+    transfers,
+    events,
+    integrity,
+    reconstructedAt: now.toISOString(),
+  };
+}

--- a/apps/api/src/provenance/provenance.controller.ts
+++ b/apps/api/src/provenance/provenance.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { Public } from '../auth/public.decorator';
+import { ProvenanceService } from './provenance.service';
+
+/**
+ * Provenance & traceability explorer (issue #36).
+ *
+ * Authenticated read: any signed-in role can reconstruct a bond's full history
+ * (the global AuthGuard protects this route since it is not marked @Public).
+ */
+@ApiTags('provenance')
+@ApiBearerAuth()
+@Controller('bonds')
+export class ProvenanceController {
+  constructor(private provenance: ProvenanceService) {}
+
+  @Get(':tokenId/provenance')
+  get(@Param('tokenId') tokenId: string) {
+    return this.provenance.getBondProvenance(tokenId);
+  }
+}
+
+/**
+ * Public read for citizen verification — no auth. Accepts a token_id or the
+ * human-readable bond_id (e.g. "SOL-2026-114").
+ */
+@Public()
+@ApiTags('provenance')
+@Controller('public')
+export class PublicProvenanceController {
+  constructor(private provenance: ProvenanceService) {}
+
+  @Get('bonds/:idOrToken/provenance')
+  get(@Param('idOrToken') idOrToken: string) {
+    return this.provenance.getPublicBondProvenance(idOrToken);
+  }
+}

--- a/apps/api/src/provenance/provenance.module.ts
+++ b/apps/api/src/provenance/provenance.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { AuditModule } from '../audit/audit.module';
+import { ProvenanceController, PublicProvenanceController } from './provenance.controller';
+import { ProvenanceService } from './provenance.service';
+
+/**
+ * Provenance & traceability explorer (issue #36). Depends on AuditModule for the
+ * raw ProvenanceInput (bond + append-only events + transfers).
+ */
+@Module({
+  imports: [AuditModule],
+  providers: [ProvenanceService],
+  controllers: [ProvenanceController, PublicProvenanceController],
+  exports: [ProvenanceService],
+})
+export class ProvenanceModule {}

--- a/apps/api/src/provenance/provenance.service.spec.ts
+++ b/apps/api/src/provenance/provenance.service.spec.ts
@@ -1,0 +1,42 @@
+import { provenanceFixture, provenanceFixtureIds } from '@velar/types';
+import { AuditService } from '../audit/audit.service';
+import { ProvenanceService } from './provenance.service';
+
+describe('ProvenanceService', () => {
+  const ids = provenanceFixtureIds;
+  let audit: jest.Mocked<Pick<AuditService, 'getProvenanceInput' | 'resolveTokenId'>>;
+  let service: ProvenanceService;
+
+  beforeEach(() => {
+    audit = {
+      getProvenanceInput: jest.fn().mockResolvedValue(provenanceFixture),
+      resolveTokenId: jest.fn().mockResolvedValue(ids.token),
+    };
+    service = new ProvenanceService(audit as unknown as AuditService);
+  });
+
+  it('reconstructs and verifies provenance for an authenticated caller', async () => {
+    const result = await service.getBondProvenance(ids.token);
+    expect(audit.getProvenanceInput).toHaveBeenCalledWith(ids.token);
+    expect(result.integrity.ok).toBe(true);
+    expect(result.ownership).toHaveLength(2);
+    expect(result.transfers[0].status).toBe('liberada');
+  });
+
+  it('resolves a readable bond_id before reconstructing for public callers', async () => {
+    const result = await service.getPublicBondProvenance('BOND-2026-001');
+    expect(audit.resolveTokenId).toHaveBeenCalledWith('BOND-2026-001');
+    expect(audit.getProvenanceInput).toHaveBeenCalledWith(ids.token);
+    expect(result.bond.tokenId).toBe(ids.token);
+  });
+
+  it('surfaces integrity anomalies from the engine', async () => {
+    audit.getProvenanceInput.mockResolvedValueOnce({
+      ...provenanceFixture,
+      bond: { ...provenanceFixture.bond, currentOwner: 'ghost-owner' },
+    });
+    const result = await service.getBondProvenance(ids.token);
+    expect(result.integrity.ok).toBe(false);
+    expect(result.integrity.anomalies.some((a) => a.type === 'onchain_offchain_mismatch')).toBe(true);
+  });
+});

--- a/apps/api/src/provenance/provenance.service.ts
+++ b/apps/api/src/provenance/provenance.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@nestjs/common';
+import type { BondProvenance } from '@velar/types';
+import { AuditService } from '../audit/audit.service';
+import { reconstructProvenance } from './provenance-engine';
+
+/**
+ * Provenance & traceability (issue #36).
+ *
+ * Thin orchestration layer: pulls the raw ProvenanceInput from AuditService
+ * (which owns all Supabase row-mapping) and runs the pure reconstruction &
+ * verification engine. No business rules or I/O live here.
+ */
+@Injectable()
+export class ProvenanceService {
+  constructor(private audit: AuditService) {}
+
+  /** Full reconstructed + verified provenance for an authenticated caller. */
+  async getBondProvenance(tokenId: string): Promise<BondProvenance> {
+    const input = await this.audit.getProvenanceInput(tokenId);
+    return reconstructProvenance(input);
+  }
+
+  /**
+   * Public provenance for citizen verification. Accepts a token_id or the
+   * readable bond_id. The output carries no private negotiation messages
+   * (transfer lifecycles expose only status/timestamps).
+   */
+  async getPublicBondProvenance(idOrToken: string): Promise<BondProvenance> {
+    const tokenId = await this.audit.resolveTokenId(idOrToken);
+    return this.getBondProvenance(tokenId);
+  }
+}

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -365,3 +365,39 @@ Se reemplaza por ClamAV/VirusTotal sin tocar el resto del módulo.
 
 El TSE (revisión/observación/aprobación) es un **epic aparte**; este issue cubre el
 lado del partido y el dominio compartido de reporte/conciliación.
+
+## 9. Procedencia y trazabilidad: reconstrucción de historia + integridad (issue #36)
+
+Reconstruye la **historia verificada** de un bono a partir de la bitácora
+append-only (`audit_events`), las `transfers` y los registros de escrow, y produce
+un reporte de integridad con anomalías tipadas. La bitácora nunca se reordena ni
+se muta (ver `docs/AGENTS.md` §4): el motor ordena una **copia**.
+
+### Motor puro (`provenance/provenance-engine.ts`)
+Funciones sin dependencias (ni Nest ni Supabase), fáciles de testear:
+- `reconstructOwnership` — línea de tiempo de dueños (`OwnershipSegment[]`) a partir
+  de los eventos de propiedad (`bond_emitido`, `bond_asignado`, `token_liberado`).
+- `reconstructTransferLifecycle` — mapea los eventos de una transferencia a etapas
+  ordenadas + índice de paso actual (`TRANSFER_LIFECYCLE_STEPS`) y si es terminal.
+- `checkIntegrity` — anomalías tipadas: `out_of_order`, `ownership_gap`,
+  `illegal_transition` (contra la máquina de estados `TRANSFER_TRANSITIONS`),
+  `onchain_offchain_mismatch`, `missing_event`.
+- `reconstructProvenance` — arma el `BondProvenance` + `IntegrityReport`.
+
+### Servicio y endpoints (`provenance/`)
+`ProvenanceService` es delgado: pide el `ProvenanceInput` a `AuditService`
+(`getProvenanceInput` / `resolveTokenId`, que reutilizan los mappers de
+trazabilidad) y corre el motor.
+- `GET /bonds/:tokenId/provenance` — **autenticado** (cualquier rol): historia completa.
+- `GET /public/bonds/:idOrToken/provenance` — **público** (verificación ciudadana);
+  acepta `token_id` o el `bond_id` legible. La salida no expone mensajes privados
+  de negociación (los lifecycles solo llevan estado + fechas).
+
+### Tipos (`@velar/types`)
+`BondProvenance`, `OwnershipSegment`, `TransferLifecycle`, `ProvenanceAnomaly` /
+`ProvenanceAnomalyType`, `IntegrityReport`, `ProvenanceInput`, más el fixture
+`provenanceFixture` para pruebas locales sin base de datos.
+
+### Comprobación local sin credenciales
+`npx jest` en `apps/api` (motor + servicio con `AuditService` mockeado). El motor
+no toca la red ni la base; el servicio se prueba con dobles.

--- a/packages/types/src/fixtures/provenance.ts
+++ b/packages/types/src/fixtures/provenance.ts
@@ -1,0 +1,130 @@
+import type { ProvenanceInput } from '../provenance';
+
+/**
+ * Development/testing fixture for the provenance engine (issue #36).
+ *
+ * A clean, gap-free history of one bond: emitted to a party, then transferred
+ * to a buyer through the full escrow lifecycle. Reconstructs with NO anomalies.
+ * Anomaly variants (gap, illegal transition, on-chain/off-chain mismatch) are
+ * derived from this base in the engine's tests.
+ *
+ * NOT production data — exists so the engine, API and UI can be built and tested
+ * locally with no VELAR database, secrets or external APIs.
+ */
+
+const PARTY = 'party-libertad';
+const BUYER = 'buyer-juan';
+const TSE = 'tse-authority';
+const TOKEN = 'bond-token-001';
+const TRANSFER = 'transfer-001';
+const TX_ESCROW = 'stellar-tx-escrow-aaaa';
+const TX_RELEASE = 'stellar-tx-release-bbbb';
+
+export const provenanceFixture: ProvenanceInput = {
+  bond: {
+    tokenId: TOKEN,
+    bondId: 'BOND-2026-001',
+    issuerPartyId: PARTY,
+    country: 'CR',
+    currentOwner: BUYER,
+    status: 'transferido',
+    documentHash: 'sha256-bonddoc-0001',
+    faceValue: 1000,
+    currency: 'CRC',
+    createdAt: '2026-01-10T09:00:00.000Z',
+    updatedAt: '2026-03-01T12:00:00.000Z',
+  },
+  transfers: [
+    {
+      id: TRANSFER,
+      bondTokenId: TOKEN,
+      fromOwner: PARTY,
+      toOwner: BUYER,
+      status: 'liberada',
+      escrowContractId: 'CESCROW0001',
+      paymentEvidenceHash: 'sha256-payment-0001',
+      validatedBy: TSE,
+      amount: 1000,
+      createdAt: '2026-02-01T10:00:00.000Z',
+      updatedAt: '2026-03-01T12:00:00.000Z',
+    },
+  ],
+  events: [
+    {
+      id: 'evt-1',
+      bondTokenId: TOKEN,
+      transferId: null,
+      type: 'bond_emitido',
+      actorId: TSE,
+      payload: { owner: PARTY },
+      createdAt: '2026-01-10T09:00:00.000Z',
+    },
+    {
+      id: 'evt-2',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'transfer_solicitada',
+      actorId: PARTY,
+      payload: { from: PARTY, to: BUYER },
+      createdAt: '2026-02-01T10:00:00.000Z',
+    },
+    {
+      id: 'evt-3',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'transfer_aceptada',
+      actorId: BUYER,
+      payload: {},
+      createdAt: '2026-02-02T11:00:00.000Z',
+    },
+    {
+      id: 'evt-4',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'escrow_bloqueado',
+      actorId: PARTY,
+      payload: { escrowContractId: 'CESCROW0001' },
+      txHash: TX_ESCROW,
+      createdAt: '2026-02-03T12:00:00.000Z',
+    },
+    {
+      id: 'evt-5',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'pago_registrado',
+      actorId: BUYER,
+      payload: { paymentEvidenceHash: 'sha256-payment-0001' },
+      createdAt: '2026-02-10T13:00:00.000Z',
+    },
+    {
+      id: 'evt-6',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'pago_validado',
+      actorId: TSE,
+      payload: {},
+      createdAt: '2026-02-20T14:00:00.000Z',
+    },
+    {
+      id: 'evt-7',
+      bondTokenId: TOKEN,
+      transferId: TRANSFER,
+      type: 'token_liberado',
+      actorId: PARTY,
+      payload: { from: PARTY, to: BUYER },
+      txHash: TX_RELEASE,
+      createdAt: '2026-03-01T12:00:00.000Z',
+    },
+  ],
+};
+
+/** Stable identifiers referenced by tests. */
+export const provenanceFixtureIds = {
+  token: TOKEN,
+  transfer: TRANSFER,
+  party: PARTY,
+  buyer: BUYER,
+  tse: TSE,
+  txEscrow: TX_ESCROW,
+  txRelease: TX_RELEASE,
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -12,6 +12,8 @@ export * from './contracts';
 export * from './contract-model';
 export * from './contract-reader';
 export * from './fixtures/contract-reader';
+export * from './provenance';
+export * from './fixtures/provenance';
 export * from './schemas/common';
 export * from './schemas/auth';
 export * from './schemas/bonds';

--- a/packages/types/src/provenance.ts
+++ b/packages/types/src/provenance.ts
@@ -1,0 +1,139 @@
+import type { AuditEvent } from './audit';
+import type { BondToken } from './bond';
+import type { Transfer, TransferStatus } from './transfer';
+
+/**
+ * Provenance & traceability model (issue #36).
+ *
+ * A `BondProvenance` is the reconstructed, verified history of a bond: the
+ * ordered ownership timeline, every transfer's lifecycle, and an integrity
+ * report with typed anomaly flags. It is derived by PURE functions from the
+ * append-only audit events, transfers and escrow records — the history is never
+ * reordered or mutated (see docs/AGENTS.md §4).
+ */
+
+// ─── Anomalies / integrity ────────────────────────────────────────────────────
+
+/** Categories of provenance integrity anomaly. */
+export const ProvenanceAnomalyType = {
+  /** Events/transfers are not in chronological order. */
+  OUT_OF_ORDER: 'out_of_order',
+  /** An owner's end does not match the next owner's start (a gap in the chain). */
+  OWNERSHIP_GAP: 'ownership_gap',
+  /** A transfer moved between states that the state machine does not allow. */
+  ILLEGAL_TRANSITION: 'illegal_transition',
+  /** On-chain reference (tx hash / owner) disagrees with the off-chain record. */
+  ONCHAIN_OFFCHAIN_MISMATCH: 'onchain_offchain_mismatch',
+  /** A lifecycle stage is reached with no supporting audit event. */
+  MISSING_EVENT: 'missing_event',
+} as const;
+
+export type ProvenanceAnomalyType =
+  (typeof ProvenanceAnomalyType)[keyof typeof ProvenanceAnomalyType];
+
+export type ProvenanceSeverity = 'info' | 'warning' | 'error';
+
+/** A single detected integrity problem, linked to the record that caused it. */
+export interface ProvenanceAnomaly {
+  type: ProvenanceAnomalyType;
+  severity: ProvenanceSeverity;
+  /** Human-readable (Spanish) description. */
+  message: string;
+  transferId?: string | null;
+  eventId?: string | null;
+  ownerId?: string | null;
+  /** ISO-8601 timestamp where the anomaly occurs, when applicable. */
+  at?: string | null;
+}
+
+/** The result of running every integrity check over a reconstruction. */
+export interface IntegrityReport {
+  /** True when there are no `error`-severity anomalies. */
+  ok: boolean;
+  anomalies: ProvenanceAnomaly[];
+  /** ISO-8601 timestamp of when the checks ran. */
+  checkedAt: string;
+}
+
+// ─── Ownership timeline ───────────────────────────────────────────────────────
+
+/** One continuous period during which a single party owned the bond. */
+export interface OwnershipSegment {
+  ownerId: string;
+  /** ISO-8601 start of ownership. */
+  from: string;
+  /** ISO-8601 end of ownership, or null for the current owner. */
+  to: string | null;
+  current: boolean;
+  /** Transfer that handed ownership to this owner (null for the initial owner). */
+  viaTransferId: string | null;
+  /** Audit event that established this owner (e.g. bond_emitido / token_liberado). */
+  viaEventId: string | null;
+}
+
+// ─── Transfer lifecycle (stepper) ─────────────────────────────────────────────
+
+/** Ordered happy-path steps of a transfer, used by the lifecycle stepper. */
+export const TRANSFER_LIFECYCLE_STEPS = [
+  'solicitada',
+  'aceptada',
+  'en_escrow',
+  'pago_registrado',
+  'pago_validado',
+  'liberada',
+] as const;
+
+export type TransferLifecycleStep = (typeof TRANSFER_LIFECYCLE_STEPS)[number];
+
+/** Terminal transfer states that end the flow. */
+export const TERMINAL_TRANSFER_STATUSES = ['liberada', 'rechazada', 'cancelada'] as const;
+
+/** A stage the transfer actually reached, timestamped from its audit event. */
+export interface TransferLifecycleStage {
+  status: TransferStatus;
+  /** ISO-8601 time the stage was reached (null if no supporting event). */
+  at: string | null;
+  eventId: string | null;
+}
+
+/** A transfer's reconstructed lifecycle for the stepper UI. */
+export interface TransferLifecycle {
+  transferId: string;
+  fromOwner: string;
+  toOwner: string;
+  /** Current transfer status. */
+  status: TransferStatus;
+  /** Index into TRANSFER_LIFECYCLE_STEPS for the current step, or -1 if terminal/off-path. */
+  currentStepIndex: number;
+  /** True when the transfer is in a terminal state. */
+  terminal: boolean;
+  /** Ordered history of stages actually reached. */
+  stages: TransferLifecycleStage[];
+}
+
+// ─── Root ─────────────────────────────────────────────────────────────────────
+
+/** The full reconstructed, verified provenance record for a bond. */
+export interface BondProvenance {
+  bond: BondToken;
+  /** Chronological ownership timeline. */
+  ownership: OwnershipSegment[];
+  /** Per-transfer lifecycles. */
+  transfers: TransferLifecycle[];
+  /** The append-only audit events, in order (never reordered/mutated). */
+  events: AuditEvent[];
+  integrity: IntegrityReport;
+  /** ISO-8601 timestamp of when the record was reconstructed. */
+  reconstructedAt: string;
+}
+
+/**
+ * Raw inputs the reconstruction engine consumes. Sourced from Supabase in
+ * production (mocked in tests); shaped here so fixtures and the pure engine
+ * share one contract.
+ */
+export interface ProvenanceInput {
+  bond: BondToken;
+  events: AuditEvent[];
+  transfers: Transfer[];
+}

--- a/packages/types/types/fixtures/provenance.d.ts
+++ b/packages/types/types/fixtures/provenance.d.ts
@@ -1,0 +1,12 @@
+import type { ProvenanceInput } from '../provenance';
+export declare const provenanceFixture: ProvenanceInput;
+/** Stable identifiers referenced by tests. */
+export declare const provenanceFixtureIds: {
+    token: string;
+    transfer: string;
+    party: string;
+    buyer: string;
+    tse: string;
+    txEscrow: string;
+    txRelease: string;
+};

--- a/packages/types/types/fixtures/provenance.js
+++ b/packages/types/types/fixtures/provenance.js
@@ -1,0 +1,128 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.provenanceFixtureIds = exports.provenanceFixture = void 0;
+/**
+ * Development/testing fixture for the provenance engine (issue #36).
+ *
+ * A clean, gap-free history of one bond: emitted to a party, then transferred
+ * to a buyer through the full escrow lifecycle. Reconstructs with NO anomalies.
+ * Anomaly variants (gap, illegal transition, on-chain/off-chain mismatch) are
+ * derived from this base in the engine's tests.
+ *
+ * NOT production data — exists so the engine, API and UI can be built and tested
+ * locally with no VELAR database, secrets or external APIs.
+ */
+const PARTY = 'party-libertad';
+const BUYER = 'buyer-juan';
+const TSE = 'tse-authority';
+const TOKEN = 'bond-token-001';
+const TRANSFER = 'transfer-001';
+const TX_ESCROW = 'stellar-tx-escrow-aaaa';
+const TX_RELEASE = 'stellar-tx-release-bbbb';
+exports.provenanceFixture = {
+    bond: {
+        tokenId: TOKEN,
+        bondId: 'BOND-2026-001',
+        issuerPartyId: PARTY,
+        country: 'CR',
+        currentOwner: BUYER,
+        status: 'transferido',
+        documentHash: 'sha256-bonddoc-0001',
+        faceValue: 1000,
+        currency: 'CRC',
+        createdAt: '2026-01-10T09:00:00.000Z',
+        updatedAt: '2026-03-01T12:00:00.000Z',
+    },
+    transfers: [
+        {
+            id: TRANSFER,
+            bondTokenId: TOKEN,
+            fromOwner: PARTY,
+            toOwner: BUYER,
+            status: 'liberada',
+            escrowContractId: 'CESCROW0001',
+            paymentEvidenceHash: 'sha256-payment-0001',
+            validatedBy: TSE,
+            amount: 1000,
+            createdAt: '2026-02-01T10:00:00.000Z',
+            updatedAt: '2026-03-01T12:00:00.000Z',
+        },
+    ],
+    events: [
+        {
+            id: 'evt-1',
+            bondTokenId: TOKEN,
+            transferId: null,
+            type: 'bond_emitido',
+            actorId: TSE,
+            payload: { owner: PARTY },
+            createdAt: '2026-01-10T09:00:00.000Z',
+        },
+        {
+            id: 'evt-2',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'transfer_solicitada',
+            actorId: PARTY,
+            payload: { from: PARTY, to: BUYER },
+            createdAt: '2026-02-01T10:00:00.000Z',
+        },
+        {
+            id: 'evt-3',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'transfer_aceptada',
+            actorId: BUYER,
+            payload: {},
+            createdAt: '2026-02-02T11:00:00.000Z',
+        },
+        {
+            id: 'evt-4',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'escrow_bloqueado',
+            actorId: PARTY,
+            payload: { escrowContractId: 'CESCROW0001' },
+            txHash: TX_ESCROW,
+            createdAt: '2026-02-03T12:00:00.000Z',
+        },
+        {
+            id: 'evt-5',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'pago_registrado',
+            actorId: BUYER,
+            payload: { paymentEvidenceHash: 'sha256-payment-0001' },
+            createdAt: '2026-02-10T13:00:00.000Z',
+        },
+        {
+            id: 'evt-6',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'pago_validado',
+            actorId: TSE,
+            payload: {},
+            createdAt: '2026-02-20T14:00:00.000Z',
+        },
+        {
+            id: 'evt-7',
+            bondTokenId: TOKEN,
+            transferId: TRANSFER,
+            type: 'token_liberado',
+            actorId: PARTY,
+            payload: { from: PARTY, to: BUYER },
+            txHash: TX_RELEASE,
+            createdAt: '2026-03-01T12:00:00.000Z',
+        },
+    ],
+};
+/** Stable identifiers referenced by tests. */
+exports.provenanceFixtureIds = {
+    token: TOKEN,
+    transfer: TRANSFER,
+    party: PARTY,
+    buyer: BUYER,
+    tse: TSE,
+    txEscrow: TX_ESCROW,
+    txRelease: TX_RELEASE,
+};

--- a/packages/types/types/index.d.ts
+++ b/packages/types/types/index.d.ts
@@ -12,6 +12,8 @@ export * from './contracts';
 export * from './contract-model';
 export * from './contract-reader';
 export * from './fixtures/contract-reader';
+export * from './provenance';
+export * from './fixtures/provenance';
 export * from './schemas/common';
 export * from './schemas/auth';
 export * from './schemas/bonds';

--- a/packages/types/types/index.js
+++ b/packages/types/types/index.js
@@ -28,6 +28,8 @@ __exportStar(require("./contracts"), exports);
 __exportStar(require("./contract-model"), exports);
 __exportStar(require("./contract-reader"), exports);
 __exportStar(require("./fixtures/contract-reader"), exports);
+__exportStar(require("./provenance"), exports);
+__exportStar(require("./fixtures/provenance"), exports);
 __exportStar(require("./schemas/common"), exports);
 __exportStar(require("./schemas/auth"), exports);
 __exportStar(require("./schemas/bonds"), exports);

--- a/packages/types/types/provenance.d.ts
+++ b/packages/types/types/provenance.d.ts
@@ -1,0 +1,109 @@
+import type { AuditEvent } from './audit';
+import type { BondToken } from './bond';
+import type { Transfer, TransferStatus } from './transfer';
+/**
+ * Provenance & traceability model (issue #36).
+ *
+ * A `BondProvenance` is the reconstructed, verified history of a bond: the
+ * ordered ownership timeline, every transfer's lifecycle, and an integrity
+ * report with typed anomaly flags. It is derived by PURE functions from the
+ * append-only audit events, transfers and escrow records — the history is never
+ * reordered or mutated (see docs/AGENTS.md §4).
+ */
+/** Categories of provenance integrity anomaly. */
+export declare const ProvenanceAnomalyType: {
+    /** Events/transfers are not in chronological order. */
+    readonly OUT_OF_ORDER: "out_of_order";
+    /** An owner's end does not match the next owner's start (a gap in the chain). */
+    readonly OWNERSHIP_GAP: "ownership_gap";
+    /** A transfer moved between states that the state machine does not allow. */
+    readonly ILLEGAL_TRANSITION: "illegal_transition";
+    /** On-chain reference (tx hash / owner) disagrees with the off-chain record. */
+    readonly ONCHAIN_OFFCHAIN_MISMATCH: "onchain_offchain_mismatch";
+    /** A lifecycle stage is reached with no supporting audit event. */
+    readonly MISSING_EVENT: "missing_event";
+};
+export type ProvenanceAnomalyType = (typeof ProvenanceAnomalyType)[keyof typeof ProvenanceAnomalyType];
+export type ProvenanceSeverity = 'info' | 'warning' | 'error';
+/** A single detected integrity problem, linked to the record that caused it. */
+export interface ProvenanceAnomaly {
+    type: ProvenanceAnomalyType;
+    severity: ProvenanceSeverity;
+    /** Human-readable (Spanish) description. */
+    message: string;
+    transferId?: string | null;
+    eventId?: string | null;
+    ownerId?: string | null;
+    /** ISO-8601 timestamp where the anomaly occurs, when applicable. */
+    at?: string | null;
+}
+/** The result of running every integrity check over a reconstruction. */
+export interface IntegrityReport {
+    /** True when there are no `error`-severity anomalies. */
+    ok: boolean;
+    anomalies: ProvenanceAnomaly[];
+    /** ISO-8601 timestamp of when the checks ran. */
+    checkedAt: string;
+}
+/** One continuous period during which a single party owned the bond. */
+export interface OwnershipSegment {
+    ownerId: string;
+    /** ISO-8601 start of ownership. */
+    from: string;
+    /** ISO-8601 end of ownership, or null for the current owner. */
+    to: string | null;
+    current: boolean;
+    /** Transfer that handed ownership to this owner (null for the initial owner). */
+    viaTransferId: string | null;
+    /** Audit event that established this owner (e.g. bond_emitido / token_liberado). */
+    viaEventId: string | null;
+}
+/** Ordered happy-path steps of a transfer, used by the lifecycle stepper. */
+export declare const TRANSFER_LIFECYCLE_STEPS: readonly ["solicitada", "aceptada", "en_escrow", "pago_registrado", "pago_validado", "liberada"];
+export type TransferLifecycleStep = (typeof TRANSFER_LIFECYCLE_STEPS)[number];
+/** Terminal transfer states that end the flow. */
+export declare const TERMINAL_TRANSFER_STATUSES: readonly ["liberada", "rechazada", "cancelada"];
+/** A stage the transfer actually reached, timestamped from its audit event. */
+export interface TransferLifecycleStage {
+    status: TransferStatus;
+    /** ISO-8601 time the stage was reached (null if no supporting event). */
+    at: string | null;
+    eventId: string | null;
+}
+/** A transfer's reconstructed lifecycle for the stepper UI. */
+export interface TransferLifecycle {
+    transferId: string;
+    fromOwner: string;
+    toOwner: string;
+    /** Current transfer status. */
+    status: TransferStatus;
+    /** Index into TRANSFER_LIFECYCLE_STEPS for the current step, or -1 if terminal/off-path. */
+    currentStepIndex: number;
+    /** True when the transfer is in a terminal state. */
+    terminal: boolean;
+    /** Ordered history of stages actually reached. */
+    stages: TransferLifecycleStage[];
+}
+/** The full reconstructed, verified provenance record for a bond. */
+export interface BondProvenance {
+    bond: BondToken;
+    /** Chronological ownership timeline. */
+    ownership: OwnershipSegment[];
+    /** Per-transfer lifecycles. */
+    transfers: TransferLifecycle[];
+    /** The append-only audit events, in order (never reordered/mutated). */
+    events: AuditEvent[];
+    integrity: IntegrityReport;
+    /** ISO-8601 timestamp of when the record was reconstructed. */
+    reconstructedAt: string;
+}
+/**
+ * Raw inputs the reconstruction engine consumes. Sourced from Supabase in
+ * production (mocked in tests); shaped here so fixtures and the pure engine
+ * share one contract.
+ */
+export interface ProvenanceInput {
+    bond: BondToken;
+    events: AuditEvent[];
+    transfers: Transfer[];
+}

--- a/packages/types/types/provenance.js
+++ b/packages/types/types/provenance.js
@@ -1,0 +1,38 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.TERMINAL_TRANSFER_STATUSES = exports.TRANSFER_LIFECYCLE_STEPS = exports.ProvenanceAnomalyType = void 0;
+/**
+ * Provenance & traceability model (issue #36).
+ *
+ * A `BondProvenance` is the reconstructed, verified history of a bond: the
+ * ordered ownership timeline, every transfer's lifecycle, and an integrity
+ * report with typed anomaly flags. It is derived by PURE functions from the
+ * append-only audit events, transfers and escrow records — the history is never
+ * reordered or mutated (see docs/AGENTS.md §4).
+ */
+// ─── Anomalies / integrity ────────────────────────────────────────────────────
+/** Categories of provenance integrity anomaly. */
+exports.ProvenanceAnomalyType = {
+    /** Events/transfers are not in chronological order. */
+    OUT_OF_ORDER: 'out_of_order',
+    /** An owner's end does not match the next owner's start (a gap in the chain). */
+    OWNERSHIP_GAP: 'ownership_gap',
+    /** A transfer moved between states that the state machine does not allow. */
+    ILLEGAL_TRANSITION: 'illegal_transition',
+    /** On-chain reference (tx hash / owner) disagrees with the off-chain record. */
+    ONCHAIN_OFFCHAIN_MISMATCH: 'onchain_offchain_mismatch',
+    /** A lifecycle stage is reached with no supporting audit event. */
+    MISSING_EVENT: 'missing_event',
+};
+// ─── Transfer lifecycle (stepper) ─────────────────────────────────────────────
+/** Ordered happy-path steps of a transfer, used by the lifecycle stepper. */
+exports.TRANSFER_LIFECYCLE_STEPS = [
+    'solicitada',
+    'aceptada',
+    'en_escrow',
+    'pago_registrado',
+    'pago_validado',
+    'liberada',
+];
+/** Terminal transfer states that end the flow. */
+exports.TERMINAL_TRANSFER_STATUSES = ['liberada', 'rechazada', 'cancelada'];


### PR DESCRIPTION
Part of the epic #36 — **PR 3 of a stacked series**. Exposes the engine over HTTP. **Stacked on #57 → #56**; until those merge, the diff also shows the engine and types.

## What this adds
- **`AuditService`** (extends the existing traceability owner): `getProvenanceInput(tokenId)` returns the `ProvenanceInput` (bond + append-only events + transfers) reusing the same row mappers as `/traceability`, and `resolveTokenId(idOrToken)` resolves a readable `bond_id` → `token_id` (404 if absent).
- **`ProvenanceService`** — thin orchestration: pull the input, run `reconstructProvenance`. No business rules or I/O of its own.
- **Endpoints**
  - `GET /api/bonds/:tokenId/provenance` — **authenticated** (any signed-in role; protected by the global `AuthGuard`).
  - `GET /api/public/bonds/:idOrToken/provenance` — **public** citizen verification; accepts `token_id` or the readable `bond_id`. Output carries **no private negotiation messages** (transfer lifecycles expose only status + timestamps), mirroring the public `/traceability` precedent.
- `ProvenanceModule` registered in `AppModule`; `docs/BACKEND.md` §9.

## Testing
- `provenance.service.spec.ts`: 3 tests with a **mocked `AuditService`** (clean reconstruction, `bond_id` resolution path, anomaly surfaced). No DB or secrets.
- `npx jest` in `apps/api` → **146 passed** (21 suites); `nest build` clean; ESLint 0 errors (the 6 `any` warnings are pre-existing in the audit mappers — my additions add none).

Refs #36.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
