### PR TITLE
feat(web): design system foundation — tokens + theming (PR 1/3) (#42)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -67,6 +67,75 @@
   --velar-glass-strong: #FFFFFF;
 }
 
+/* ─── Tema oscuro ────────────────────────────────────────────────────────────
+   Sobreescribe las MISMAS variables que usan las utilidades de Tailwind
+   (var(--color-*)) y los helpers .velar-*. No se agregan tokens nuevos: solo
+   cambian los valores según el tema activo en <html data-theme="dark">. */
+[data-theme='dark'] {
+  --color-primary: #8DBBFF;
+  --color-primary-container: #2563EB;
+  --color-primary-hover: #3B82F6;
+  --color-primary-fixed: #16233F;
+  --color-primary-fixed-dim: #1E3766;
+  --color-on-primary: #ffffff;
+  --color-institutional: #E6EDF9;
+  --color-secondary: #9FB2D0;
+  --color-secondary-container: #1E2B47;
+  --color-secondary-fixed: #16233F;
+  --color-tertiary: #8DBBFF;
+  --color-tertiary-container: #2563EB;
+  --color-background: #0B1220;
+  --color-surface: #111A2E;
+  --color-surface-variant: #1E2B47;
+  --color-surface-container: #17223A;
+  --color-surface-container-low: #0F1626;
+  --color-surface-container-high: #1E2B47;
+  --color-surface-container-highest: #26365A;
+  --color-surface-container-lowest: #0B1220;
+  --color-on-surface: #E6EDF9;
+  --color-on-surface-variant: #9FB2D0;
+  --color-on-background: #E6EDF9;
+  --color-outline: #33456B;
+  --color-outline-variant: #26365A;
+  --color-inverse-surface: #E6EDF9;
+  --color-inverse-on-surface: #0B1220;
+  --color-error: #FF6B5E;
+  --color-error-container: #4A1A15;
+  --color-success: #34D399;
+  --color-glass-border: #26365A;
+
+  --velar-canvas: #0B1220;
+  --velar-section: #0F1626;
+  --velar-surface: #111A2E;
+  --velar-surface-soft: #17223A;
+  --velar-text: #E6EDF9;
+  --velar-muted: #9FB2D0;
+  --velar-border: #26365A;
+  --velar-border-strong: #33456B;
+  --velar-success: #34D399;
+  --velar-warning: #E0A82E;
+  --velar-error: #FF6B5E;
+  --velar-glass: rgba(17, 26, 46, 0.78);
+  --velar-glass-strong: #111A2E;
+}
+
+/* ─── Branding por país ──────────────────────────────────────────────────────
+   Reajusta solo el acento primario (botones/enlaces) según <html data-country>.
+   CR es el default y no necesita override. Los tonos mantienen contraste AA con
+   texto blanco tanto en claro como en oscuro. */
+[data-country='CO'] {
+  --color-primary-container: #C2410C;
+  --color-primary-hover: #9A3412;
+}
+[data-country='BR'] {
+  --color-primary-container: #15803D;
+  --color-primary-hover: #166534;
+}
+[data-country='AR'] {
+  --color-primary-container: #0369A1;
+  --color-primary-hover: #075985;
+}
+
 html {
   scroll-behavior: smooth;
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { AppProviders } from '../components/AppProviders';
+import { themeInitScript } from '../components/ui/theme';
 
 export const metadata: Metadata = {
   title: 'VELAR | Trazabilidad de Bonos',
@@ -12,8 +13,9 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="es" data-scroll-behavior="smooth">
+    <html lang="es" data-scroll-behavior="smooth" suppressHydrationWarning>
       <body className="min-h-screen bg-background text-on-surface antialiased">
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
         <AppProviders>{children}</AppProviders>
       </body>
     </html>

--- a/apps/web/components/AppProviders.tsx
+++ b/apps/web/components/AppProviders.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
 import { CountryProvider } from '../lib/country';
 import { WalletProvider } from '../lib/wallet';
+import { ThemeProvider } from './ui/theme';
 import { ToastContainer } from './Toast';
 
 function isAuthRoute(pathname: string | null) {
@@ -19,10 +20,12 @@ export function AppProviders({ children }: { children: ReactNode }) {
 
   return (
     <CountryProvider>
-      <WalletProvider>
-        {children}
-        <ToastContainer />
-      </WalletProvider>
+      <ThemeProvider>
+        <WalletProvider>
+          {children}
+          <ToastContainer />
+        </WalletProvider>
+      </ThemeProvider>
     </CountryProvider>
   );
 }

--- a/apps/web/components/ui/index.ts
+++ b/apps/web/components/ui/index.ts
@@ -1,0 +1,6 @@
+/**
+ * VELAR Design System — punto de entrada público.
+ * Importá desde aquí: `import { ThemeSwitcher, colorVar } from '@/components/ui'`.
+ */
+export * from './tokens';
+export { ThemeProvider, ThemeSwitcher, useTheme, themeInitScript } from './theme';

--- a/apps/web/components/ui/theme.tsx
+++ b/apps/web/components/ui/theme.tsx
@@ -1,0 +1,117 @@
+'use client';
+/**
+ * VELAR — Theming (claro/oscuro + branding por país)
+ * ===================================================
+ * `ThemeProvider` refleja dos ejes sobre el elemento <html>:
+ *   - `data-theme="light|dark"`  → paleta clara u oscura (elección del usuario, se persiste).
+ *   - `data-country="CR|CO|BR|AR"` → acento de marca por país (viene de `useCountry`).
+ *
+ * Los VALORES viven en `globals.css`; acá solo conmutamos los atributos. El
+ * script anti-FOUC (`themeInitScript`) aplica el tema guardado antes del primer
+ * paint para que no haya parpadeo.
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { useCountry } from '../../lib/country';
+import { THEMES, type Theme } from './tokens';
+
+const STORE_KEY = 'velar.theme';
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function isTheme(v: unknown): v is Theme {
+  return typeof v === 'string' && (THEMES as readonly string[]).includes(v);
+}
+
+/**
+ * Script inline para <head>: aplica el tema persistido (o la preferencia del
+ * sistema) antes de hidratar, evitando el flash de tema claro. Se inyecta como
+ * string por `dangerouslySetInnerHTML`.
+ */
+export const themeInitScript = `(function(){try{var t=localStorage.getItem('${STORE_KEY}');if(t!=='light'&&t!=='dark'){t=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}document.documentElement.setAttribute('data-theme',t);}catch(e){}})();`;
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('light');
+  const { country } = useCountry();
+
+  // Sincroniza el tema inicial con lo que el script anti-FOUC ya dejó en <html>.
+  useEffect(() => {
+    const current = document.documentElement.getAttribute('data-theme');
+    if (isTheme(current)) {
+      setThemeState(current);
+      return;
+    }
+    try {
+      const stored = localStorage.getItem(STORE_KEY);
+      if (isTheme(stored)) setThemeState(stored);
+    } catch {
+      /* localStorage no disponible */
+    }
+  }, []);
+
+  // Aplica y persiste el tema elegido.
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    try {
+      localStorage.setItem(STORE_KEY, theme);
+    } catch {
+      /* noop */
+    }
+  }, [theme]);
+
+  // Refleja el país activo como acento de marca.
+  useEffect(() => {
+    document.documentElement.setAttribute('data-country', country);
+  }, [country]);
+
+  const setTheme = useCallback((t: Theme) => setThemeState(t), []);
+  const toggleTheme = useCallback(
+    () => setThemeState((prev) => (prev === 'dark' ? 'light' : 'dark')),
+    [],
+  );
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    // Fallback seguro fuera del provider: no crashea, solo no persiste.
+    return { theme: 'light', setTheme: () => {}, toggleTheme: () => {} };
+  }
+  return ctx;
+}
+
+/** Botón accesible para alternar claro/oscuro. */
+export function ThemeSwitcher({ className = '' }: { className?: string }) {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? 'Cambiar a tema claro' : 'Cambiar a tema oscuro'}
+      title={isDark ? 'Tema claro' : 'Tema oscuro'}
+      className={`inline-flex h-9 w-9 items-center justify-center rounded-lg border border-outline-variant text-on-surface-variant transition hover:bg-surface-container hover:text-on-surface focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-container ${className}`}
+    >
+      {isDark ? <Sun size={18} /> : <Moon size={18} />}
+    </button>
+  );
+}

--- a/apps/web/components/ui/tokens.ts
+++ b/apps/web/components/ui/tokens.ts
@@ -1,0 +1,110 @@
+/**
+ * VELAR — Design tokens (fuente de verdad tipada)
+ * ================================================
+ * Espejo en TypeScript de las variables CSS declaradas en `app/globals.css`.
+ * Los VALORES viven en el CSS (`@theme` + `:root`) para que theming (claro/oscuro
+ * y branding por país) funcione en runtime cambiando las variables. Este módulo
+ * expone los MISMOS nombres de forma tipada para consumir tokens desde TS/JS
+ * (charts, estilos inline, lógica) sin hardcodear hex ni px sueltos.
+ *
+ * Regla: si agregás un token, declaralo en `globals.css` y acá con el mismo nombre.
+ * No dupliques valores que puedan divergir: para colores temáticos usá
+ * `cssVar('--color-...')`, no el hex literal.
+ */
+
+/** Referencia a una variable CSS, p. ej. `cssVar('--color-primary')`. */
+export function cssVar(name: string): string {
+  return `var(${name})`;
+}
+
+/**
+ * Colores semánticos. Los valores son los del tema CLARO (default). En dark /
+ * branding se sobreescriben vía CSS; por eso, para pintar en runtime preferí
+ * `colorVar('primary')` sobre `colors.primary` (el primero respeta el tema).
+ */
+export const colors = {
+  primary: '#174EA6',
+  primaryContainer: '#2563EB',
+  primaryHover: '#1D4ED8',
+  primaryFixed: '#EEF5FF',
+  primaryFixedDim: '#8DBBFF',
+  onPrimary: '#ffffff',
+  institutional: '#0B1739',
+  secondary: '#52627A',
+  secondaryContainer: '#D9E6F8',
+  secondaryFixed: '#EEF5FF',
+  tertiary: '#174EA6',
+  tertiaryContainer: '#2563EB',
+  background: '#F7FAFF',
+  surface: '#FFFFFF',
+  surfaceVariant: '#D9E6F8',
+  surfaceContainer: '#EEF5FF',
+  surfaceContainerLow: '#F1F6FD',
+  surfaceContainerHigh: '#E6F0FF',
+  surfaceContainerHighest: '#D9E6F8',
+  surfaceContainerLowest: '#ffffff',
+  onSurface: '#0B1739',
+  onSurfaceVariant: '#52627A',
+  onBackground: '#0B1739',
+  outline: '#B8CBE8',
+  outlineVariant: '#D9E6F8',
+  inverseSurface: '#0B1739',
+  inverseOnSurface: '#F7FAFF',
+  error: '#B42318',
+  errorContainer: '#FEE4E2',
+  success: '#15803D',
+  warning: '#B7791F',
+  glassBorder: '#D9E6F8',
+} as const;
+
+/** Nombre de token → variable CSS temática (respeta claro/oscuro/país). */
+export function colorVar(token: keyof typeof colors): string {
+  // camelCase → kebab-case: primaryContainer → --color-primary-container
+  const kebab = token.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+  return cssVar(`--color-${kebab}`);
+}
+
+/** Escala de espaciado (px). Espejo de `--velar-space-*`. */
+export const space = {
+  2: '8px',
+  3: '12px',
+  4: '16px',
+  5: '20px',
+  6: '24px',
+} as const;
+
+/** Radios de borde. Espejo de `--velar-radius-*`. */
+export const radius = {
+  sm: '8px',
+  md: '12px',
+  lg: '16px',
+  pill: '999px',
+} as const;
+
+/** Sombras. Espejo de `--shadow-*`. */
+export const shadow = {
+  card: '0 2px 8px rgba(11, 23, 57, 0.06)',
+  glass: '0 8px 18px rgba(11, 23, 57, 0.06)',
+  glassStrong: '0 16px 36px rgba(11, 23, 57, 0.10)',
+} as const;
+
+/** Familias tipográficas. Espejo de `--font-*`. */
+export const font = {
+  sans: '"Inter", sans-serif',
+  display: '"Geist", sans-serif',
+  mono: '"JetBrains Mono", monospace',
+} as const;
+
+/** Duraciones de motion usadas en la UI (ms). */
+export const duration = {
+  fast: 120,
+  base: 180,
+  slow: 400,
+} as const;
+
+/** Los dos temas soportados. */
+export const THEMES = ['light', 'dark'] as const;
+export type Theme = (typeof THEMES)[number];
+
+export const tokens = { colors, space, radius, shadow, font, duration } as const;
+export type Tokens = typeof tokens;


### PR DESCRIPTION
## Design System — PR 1/3: Foundation (tokens + theming)

First stacked PR of the design-system epic (#42). Establishes the foundation the component library and adoption PRs will build on. **No visual/behavioral change to the existing light theme** — this PR only formalizes what exists and adds theming infrastructure.

### What's included
- **`components/ui/tokens.ts`** — typed TS mirror of the CSS design tokens (colors, spacing, radius, shadow, font, motion) as the single source of truth for JS/TS consumers, with `cssVar()` / `colorVar()` helpers. No token values changed.
- **`components/ui/theme.tsx`** — `ThemeProvider` + `useTheme` + `ThemeSwitcher`, with `localStorage` persistence and an anti-FOUC init script (applies saved/system theme before first paint).
- **`app/globals.css`** — **dark theme** and **per-country brand** (CR/CO/BR/AR) overrides that reuse the same CSS variables the app + Tailwind utilities already consume. Light theme values are untouched.
- Wired `ThemeProvider` into `AppProviders` (inside `CountryProvider`, its source of the active country) and the init script into `app/layout.tsx`.

### Scope notes
- Frontend only — no changes to `apps/api`, `supabase/`, or `packages/types` (per `docs/AGENTS.md`).
- The `ThemeSwitcher` component exists but is intentionally **not yet mounted in a header** — that belongs to the adoption PR (mounting in `AppShell`).

### Verification
- `npm run typecheck` — clean
- `npm run lint` — 0 errors
- `npm run build` — success
- No VELAR credentials used.

### Next PRs
- **PR 2** — component library (`components/ui/`) + docs route + lint guideline.
- **PR 3** — whole-app adoption (refactor routes to the library, mount the theme switcher).

Closes #42