### PR TITLE
feat(web): plain-text (.txt) export for the provenance explorer (Closes #61)

### DIFF
--- a/apps/web/components/provenance/ProvenanceExplorer.tsx
+++ b/apps/web/components/provenance/ProvenanceExplorer.tsx
@@ -7,6 +7,7 @@ import {
   ChevronRight,
   Download,
   ExternalLink,
+  FileText,
   Printer,
   ShieldAlert,
   ShieldCheck,
@@ -16,6 +17,7 @@ import { txUrl } from '../../lib/stellar';
 import {
   anomalyLabel,
   buildProvenanceCsv,
+  buildProvenanceExportText,
   createProvenanceClient,
   provenanceSummary,
   sortAnomalies,
@@ -172,6 +174,13 @@ export function ProvenanceExplorer({
             className="inline-flex items-center gap-1.5 rounded-full border border-outline-variant/40 px-3 py-1 text-xs font-medium text-on-surface hover:bg-surface-container-low"
           >
             <Download size={13} aria-hidden="true" /> CSV
+          </button>
+          <button
+            type="button"
+            onClick={() => download(`procedencia-${data.bond.bondId ?? data.bond.tokenId}.txt`, buildProvenanceExportText(data), 'text/plain;charset=utf-8')}
+            className="inline-flex items-center gap-1.5 rounded-full border border-outline-variant/40 px-3 py-1 text-xs font-medium text-on-surface hover:bg-surface-container-low"
+          >
+            <FileText size={13} aria-hidden="true" /> Informe
           </button>
           <button
             type="button"


### PR DESCRIPTION
Small follow-up that **completes the export options** of the provenance & traceability explorer.

`buildProvenanceExportText()` already existed and was unit-tested, but only **CSV** + **print (PDF)** were wired into the UI. This surfaces the **plain-text report (.txt)** export too, next to the existing buttons — a genuine, self-contained improvement.

### Context
The full explorer epic was implemented and merged across **#56 → #57 → #58 → #59 → #60** (types, pure engine, API, UI components, and the explorer with 6-surface integration). This PR finishes the one remaining export affordance and links the tracking issue.

### Testing
- ESLint clean; `npx jest` (provenance suite) green; the change reuses the already-tested `buildProvenanceExportText` helper.

Closes #61.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
