### PR TITLE
feat(auth): add account lifecycle endpoints with audit trail

### DIFF
--- a/apps/api/src/auth/auth-lifecycle.service.spec.ts
+++ b/apps/api/src/auth/auth-lifecycle.service.spec.ts
@@ -1,0 +1,158 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { AuthService } from './auth.service';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import { WalletService } from '../escrow/wallet.service';
+import { AuditService } from '../audit/audit.service';
+
+/**
+ * Ciclo de vida de la cuenta (issue #77). Todo contra un SupabaseService
+ * mockeado: no se necesita base de datos ni credenciales de VELAR.
+ */
+describe('AuthService — ciclo de vida de la cuenta', () => {
+  let service: AuthService;
+  let audit: { emit: jest.Mock };
+  let resetPasswordForEmail: jest.Mock;
+  let verifyOtp: jest.Mock;
+  let updateUserById: jest.Mock;
+  let generateLink: jest.Mock;
+
+  beforeEach(async () => {
+    resetPasswordForEmail = jest.fn().mockResolvedValue({ data: {}, error: null });
+    verifyOtp = jest.fn();
+    updateUserById = jest.fn().mockResolvedValue({ error: null });
+    generateLink = jest.fn().mockResolvedValue({ data: {}, error: null });
+    audit = { emit: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: SupabaseService,
+          useValue: {
+            admin: {
+              auth: {
+                resetPasswordForEmail,
+                verifyOtp,
+                admin: { updateUserById, generateLink },
+              },
+            },
+          },
+        },
+        { provide: WalletService, useValue: { createWalletRecord: jest.fn() } },
+        { provide: AuditService, useValue: audit },
+        { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue(undefined) } },
+      ],
+    }).compile();
+
+    service = module.get(AuthService);
+  });
+
+  describe('forgotPassword()', () => {
+    it('responde ok y audita cuando la cuenta existe', async () => {
+      const result = await service.forgotPassword('existe@velar.cr');
+
+      expect(result).toEqual({ ok: true });
+      expect(resetPasswordForEmail).toHaveBeenCalledWith('existe@velar.cr', undefined);
+      expect(audit.emit).toHaveBeenCalledWith({
+        type: 'auth_password_reset_requested',
+        payload: { email: 'existe@velar.cr' },
+      });
+    });
+
+    it('responde EXACTAMENTE igual si el email no existe (no filtra su existencia)', async () => {
+      const existente = await service.forgotPassword('existe@velar.cr');
+
+      resetPasswordForEmail.mockRejectedValueOnce(new Error('User not found'));
+      const inexistente = await service.forgotPassword('fantasma@velar.cr');
+
+      expect(inexistente).toEqual(existente);
+      expect(inexistente).toEqual({ ok: true });
+    });
+
+    it('no propaga el error de Supabase al cliente', async () => {
+      resetPasswordForEmail.mockRejectedValueOnce(new Error('rate limit exceeded'));
+
+      await expect(service.forgotPassword('a@velar.cr')).resolves.toEqual({ ok: true });
+    });
+
+    it('audita el intento aunque la cuenta no exista, para detectar abuso', async () => {
+      resetPasswordForEmail.mockRejectedValueOnce(new Error('User not found'));
+
+      await service.forgotPassword('fantasma@velar.cr');
+
+      expect(audit.emit).toHaveBeenCalledWith({
+        type: 'auth_password_reset_requested',
+        payload: { email: 'fantasma@velar.cr' },
+      });
+    });
+
+    it('rechaza email vacío', async () => {
+      await expect(service.forgotPassword('')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('resetPassword()', () => {
+    it('canjea el token y fija la contraseña nueva', async () => {
+      verifyOtp.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+
+      const result = await service.resetPassword('hash-123', 'NuevaClave123!');
+
+      expect(verifyOtp).toHaveBeenCalledWith({ token_hash: 'hash-123', type: 'recovery' });
+      expect(updateUserById).toHaveBeenCalledWith('user-1', { password: 'NuevaClave123!' });
+      expect(result).toEqual({ ok: true });
+      expect(audit.emit).toHaveBeenCalledWith({
+        type: 'auth_password_reset_completed',
+        actorId: 'user-1',
+      });
+    });
+
+    it('rechaza un token inválido o vencido sin tocar la contraseña', async () => {
+      verifyOtp.mockResolvedValue({ data: null, error: { message: 'Token has expired' } });
+
+      await expect(service.resetPassword('vencido', 'NuevaClave123!'))
+        .rejects.toThrow(BadRequestException);
+      expect(updateUserById).not.toHaveBeenCalled();
+      expect(audit.emit).not.toHaveBeenCalled();
+    });
+
+    it('no audita si la actualización de contraseña falla', async () => {
+      verifyOtp.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+      updateUserById.mockResolvedValueOnce({ error: { message: 'weak password' } });
+
+      await expect(service.resetPassword('hash-123', 'x')).rejects.toThrow(BadRequestException);
+      expect(audit.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('changeEmail()', () => {
+    it('genera el enlace de confirmación y audita el cambio pedido', async () => {
+      const result = await service.changeEmail('user-1', 'viejo@velar.cr', 'nuevo@velar.cr');
+
+      expect(generateLink).toHaveBeenCalledWith({
+        type: 'email_change_new',
+        email: 'viejo@velar.cr',
+        newEmail: 'nuevo@velar.cr',
+      });
+      expect(result).toEqual({ ok: true });
+      expect(audit.emit).toHaveBeenCalledWith({
+        type: 'auth_email_change_requested',
+        actorId: 'user-1',
+        payload: { from: 'viejo@velar.cr', to: 'nuevo@velar.cr' },
+      });
+    });
+
+    it('NO aplica el cambio de inmediato: solo genera el enlace', async () => {
+      await service.changeEmail('user-1', 'viejo@velar.cr', 'nuevo@velar.cr');
+
+      expect(updateUserById).not.toHaveBeenCalled();
+    });
+
+    it('rechaza si el email nuevo es igual al actual', async () => {
+      await expect(service.changeEmail('user-1', 'mismo@velar.cr', 'mismo@velar.cr'))
+        .rejects.toThrow(BadRequestException);
+      expect(generateLink).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,9 +1,17 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { Public } from './public.decorator';
+import { AuthGuard } from './auth.guard';
+import { CurrentUser } from './current-user.decorator';
 import { AuthService } from './auth.service';
-import { LoginDto, RegisterDto } from './dto/auth.dto';
+import {
+  ChangeEmailDto,
+  ForgotPasswordDto,
+  LoginDto,
+  RegisterDto,
+  ResetPasswordDto,
+} from './dto/auth.dto';
 
 @ApiTags('auth')
 @Public()
@@ -13,6 +21,7 @@ export class AuthController {
 
   /** Registro público: perspectiva 'usuario' o 'partido' (TSE/admin se siembran). */
   @Post('register')
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
   register(@Body() body: RegisterDto) {
     return this.auth.register(body);
   }
@@ -21,5 +30,41 @@ export class AuthController {
   @Throttle({ default: { limit: 10, ttl: 60000 } })
   login(@Body() body: LoginDto) {
     return this.auth.login(body);
+  }
+
+  /**
+   * Dispara el correo de recuperación. Responde igual exista o no la cuenta.
+   * Límite más bajo que el de login: es un endpoint anónimo que provoca envío
+   * de correo, así que sirve tanto para enumerar cuentas como para spamear.
+   */
+  @Post('forgot-password')
+  @Throttle({ default: { limit: 3, ttl: 60000 } })
+  forgotPassword(@Body() body: ForgotPasswordDto) {
+    return this.auth.forgotPassword(body.email);
+  }
+
+  /** Completa la recuperación con el token del enlace. */
+  @Post('reset-password')
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  resetPassword(@Body() body: ResetPasswordDto) {
+    return this.auth.resetPassword(body.tokenHash, body.password);
+  }
+}
+
+/**
+ * Cambio de email: va en un controller aparte porque exige sesión, y el
+ * controller de `auth` es `@Public()` entero.
+ */
+@ApiTags('auth')
+@ApiBearerAuth()
+@Controller('auth')
+@UseGuards(AuthGuard)
+export class AuthAccountController {
+  constructor(private auth: AuthService) {}
+
+  @Post('change-email')
+  @Throttle({ default: { limit: 3, ttl: 60000 } })
+  changeEmail(@CurrentUser() user: any, @Body() body: ChangeEmailDto) {
+    return this.auth.changeEmail(user.id, user.email, body.email);
   }
 }

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,13 +1,15 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { AuthGuard } from './auth.guard';
 import { AuthService } from './auth.service';
-import { AuthController } from './auth.controller';
+import { AuthAccountController, AuthController } from './auth.controller';
 import { EscrowModule } from '../escrow/escrow.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
-  imports: [EscrowModule],
+  // forwardRef: AuditModule ya importa AuthModule (ciclo Auth → Escrow → Audit → Auth).
+  imports: [EscrowModule, forwardRef(() => AuditModule)],
   providers: [AuthGuard, AuthService],
-  controllers: [AuthController],
+  controllers: [AuthController, AuthAccountController],
   exports: [AuthGuard],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,6 +1,9 @@
-import { Injectable, BadRequestException, Logger, UnauthorizedException } from '@nestjs/common';
+import { Inject, Injectable, BadRequestException, Logger, UnauthorizedException, forwardRef } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { SupabaseService } from '../common/supabase/supabase.service';
 import { WalletService } from '../escrow/wallet.service';
+import { AuditService } from '../audit/audit.service';
+import { AuditEventType } from '@velar/types';
 import type { LoginRequest, RegisterRequest } from '@velar/types';
 
 export type Perspectiva = RegisterRequest['perspectiva'];
@@ -23,6 +26,8 @@ export class AuthService {
   constructor(
     private supabase: SupabaseService,
     private wallets: WalletService,
+    @Inject(forwardRef(() => AuditService)) private audit: AuditService,
+    private cfg: ConfigService,
   ) {}
 
   async login(input: LoginInput) {
@@ -163,6 +168,98 @@ export class AuthService {
       await db.auth.admin.deleteUser(userId).catch(() => undefined);
       throw e;
     }
+  }
+
+  /* ─── Ciclo de vida de la cuenta (issue #77) ─────────────────────────────── */
+
+  /**
+   * Dispara el correo de recuperación de Supabase.
+   *
+   * SIEMPRE responde `{ ok: true }`, exista la cuenta o no, y nunca propaga el
+   * error de Supabase: si la respuesta (o el tiempo, o el código) dependiera de
+   * si el email está registrado, el endpoint se volvería un oráculo para
+   * enumerar cuentas. Por eso el fallo solo se loguea.
+   */
+  async forgotPassword(email: string) {
+    if (!email) throw new BadRequestException('email es obligatorio');
+
+    try {
+      const redirectTo = this.cfg.get<string>('AUTH_PASSWORD_RESET_REDIRECT_URL');
+      await this.supabase.admin.auth.resetPasswordForEmail(
+        email,
+        redirectTo ? { redirectTo } : undefined,
+      );
+    } catch (e) {
+      // Deliberadamente silencioso hacia el cliente (ver doc de arriba).
+      this.logger.warn(`forgotPassword falló para ${email}: ${(e as Error).message}`);
+    }
+
+    // Se audita el intento aunque la cuenta no exista: sirve para detectar abuso.
+    // No se registra si el email existía, porque eso es justo lo que no se filtra.
+    await this.audit.emit({
+      type: AuditEventType.AUTH_PASSWORD_RESET_REQUESTED,
+      payload: { email },
+    });
+
+    return { ok: true as const };
+  }
+
+  /**
+   * Completa la recuperación: canjea el `token_hash` del enlace por el usuario y
+   * le fija la contraseña nueva con el service role.
+   */
+  async resetPassword(tokenHash: string, password: string) {
+    if (!tokenHash || !password) {
+      throw new BadRequestException('tokenHash y password son obligatorios');
+    }
+
+    const { data, error } = await this.supabase.admin.auth.verifyOtp({
+      token_hash: tokenHash,
+      type: 'recovery',
+    });
+    if (error || !data?.user) {
+      throw new BadRequestException('El enlace de recuperación es inválido o venció');
+    }
+
+    const { error: updateError } = await this.supabase.admin.auth.admin.updateUserById(
+      data.user.id,
+      { password },
+    );
+    if (updateError) throw new BadRequestException(updateError.message);
+
+    await this.audit.emit({
+      type: AuditEventType.AUTH_PASSWORD_RESET_COMPLETED,
+      actorId: data.user.id,
+    });
+
+    return { ok: true as const };
+  }
+
+  /**
+   * Arranca el cambio de email. No lo aplica: genera el enlace de confirmación
+   * de Supabase, así que la dirección nueva solo queda activa cuando su dueño
+   * confirma. Evita que un token robado mueva la cuenta a otro correo.
+   */
+  async changeEmail(userId: string, currentEmail: string, newEmail: string) {
+    if (!newEmail) throw new BadRequestException('email es obligatorio');
+    if (newEmail === currentEmail) {
+      throw new BadRequestException('El email nuevo es igual al actual');
+    }
+
+    const { error } = await this.supabase.admin.auth.admin.generateLink({
+      type: 'email_change_new',
+      email: currentEmail,
+      newEmail,
+    });
+    if (error) throw new BadRequestException(error.message);
+
+    await this.audit.emit({
+      type: AuditEventType.AUTH_EMAIL_CHANGE_REQUESTED,
+      actorId: userId,
+      payload: { from: currentEmail, to: newEmail },
+    });
+
+    return { ok: true as const };
   }
 
   private fullName(i: RegisterInput): string {

--- a/apps/api/src/auth/dto/auth.dto.ts
+++ b/apps/api/src/auth/dto/auth.dto.ts
@@ -20,6 +20,30 @@ export class LoginDto implements LoginInput {
   password!: string;
 }
 
+export class ForgotPasswordDto {
+  @ApiProperty({ example: 'comprador@velar.cr' })
+  @IsEmail()
+  email!: string;
+}
+
+export class ResetPasswordDto {
+  @ApiProperty({ description: 'token_hash del enlace de recuperación' })
+  @IsString()
+  @IsNotEmpty()
+  tokenHash!: string;
+
+  @ApiProperty({ minLength: 8, example: 'Velar12345!' })
+  @IsString()
+  @MinLength(8)
+  password!: string;
+}
+
+export class ChangeEmailDto {
+  @ApiProperty({ example: 'nuevo@velar.cr' })
+  @IsEmail()
+  email!: string;
+}
+
 export class RegisterDto implements RegisterInput {
   @ApiProperty({ example: 'nuevo@velar.cr' })
   @IsEmail()

--- a/apps/api/src/users/users-lifecycle.service.spec.ts
+++ b/apps/api/src/users/users-lifecycle.service.spec.ts
@@ -1,0 +1,108 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import { WalletService } from '../escrow/wallet.service';
+import { AuditService } from '../audit/audit.service';
+
+/**
+ * Desactivación/reactivación de cuentas (issue #77), contra un SupabaseService
+ * mockeado. Sin base de datos ni credenciales.
+ */
+describe('UsersService — desactivación de cuentas', () => {
+  let service: UsersService;
+  let audit: { emit: jest.Mock };
+  let updateUserById: jest.Mock;
+
+  beforeEach(async () => {
+    updateUserById = jest.fn().mockResolvedValue({ error: null });
+    audit = { emit: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: SupabaseService,
+          useValue: { admin: { auth: { admin: { updateUserById } }, from: jest.fn() } },
+        },
+        { provide: WalletService, useValue: { createWalletRecord: jest.fn() } },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+
+    service = module.get(UsersService);
+  });
+
+  describe('deactivate()', () => {
+    it('banea la cuenta por un plazo efectivamente infinito', async () => {
+      const result = await service.deactivate('target-1', 'admin', 'admin-1');
+
+      expect(updateUserById).toHaveBeenCalledWith('target-1', { ban_duration: '876000h' });
+      expect(result).toEqual({ ok: true, userId: 'target-1', active: false });
+    });
+
+    it('audita con el admin como actor y la cuenta afectada en el payload', async () => {
+      await service.deactivate('target-1', 'admin', 'admin-1');
+
+      expect(audit.emit).toHaveBeenCalledWith({
+        type: 'auth_account_deactivated',
+        actorId: 'admin-1',
+        payload: { targetUserId: 'target-1' },
+      });
+    });
+
+    it.each(['comprador', 'emisor', 'tse', 'recomprador', 'validador'] as const)(
+      'rechaza al rol %s: es admin-only',
+      async (role) => {
+        await expect(service.deactivate('target-1', role, 'actor-1'))
+          .rejects.toThrow(ForbiddenException);
+        expect(updateUserById).not.toHaveBeenCalled();
+        expect(audit.emit).not.toHaveBeenCalled();
+      },
+    );
+
+    it('impide que un admin se desactive a sí mismo', async () => {
+      await expect(service.deactivate('admin-1', 'admin', 'admin-1'))
+        .rejects.toThrow(BadRequestException);
+      expect(updateUserById).not.toHaveBeenCalled();
+    });
+
+    it('no audita si Supabase falla', async () => {
+      updateUserById.mockResolvedValueOnce({ error: { message: 'user not found' } });
+
+      await expect(service.deactivate('fantasma', 'admin', 'admin-1'))
+        .rejects.toThrow(BadRequestException);
+      expect(audit.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reactivate()', () => {
+    it('levanta el ban y devuelve la cuenta a activa', async () => {
+      const result = await service.reactivate('target-1', 'admin', 'admin-1');
+
+      expect(updateUserById).toHaveBeenCalledWith('target-1', { ban_duration: 'none' });
+      expect(result).toEqual({ ok: true, userId: 'target-1', active: true });
+      expect(audit.emit).toHaveBeenCalledWith({
+        type: 'auth_account_reactivated',
+        actorId: 'admin-1',
+        payload: { targetUserId: 'target-1' },
+      });
+    });
+
+    it('también es admin-only', async () => {
+      await expect(service.reactivate('target-1', 'tse', 'actor-1'))
+        .rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('ciclo completo', () => {
+    it('desactivar y reactivar deja la cuenta como al inicio, con dos eventos auditados', async () => {
+      await service.deactivate('target-1', 'admin', 'admin-1');
+      await service.reactivate('target-1', 'admin', 'admin-1');
+
+      expect(updateUserById).toHaveBeenNthCalledWith(1, 'target-1', { ban_duration: '876000h' });
+      expect(updateUserById).toHaveBeenNthCalledWith(2, 'target-1', { ban_duration: 'none' });
+      expect(audit.emit).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -39,4 +39,16 @@ export class UsersController {
   setRole(@Param('id') id: string, @Body() body: { role: Role }, @CurrentUser() user: any) {
     return this.users.setRole(id, body.role, user.profile?.role as Role);
   }
+
+  /** Desactiva una cuenta (admin). Bloquea el login hasta reactivarla. */
+  @Patch(':id/deactivate')
+  deactivate(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.users.deactivate(id, user.profile?.role as Role, user.id);
+  }
+
+  /** Reactiva una cuenta desactivada (admin). */
+  @Patch(':id/reactivate')
+  reactivate(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.users.reactivate(id, user.profile?.role as Role, user.id);
+  }
 }

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -3,9 +3,10 @@ import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { AuthModule } from '../auth/auth.module';
 import { EscrowModule } from '../escrow/escrow.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
-  imports: [AuthModule, EscrowModule],
+  imports: [AuthModule, EscrowModule, AuditModule],
   providers: [UsersService],
   controllers: [UsersController],
   exports: [UsersService],

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,7 +1,17 @@
 import { Injectable, BadRequestException, ForbiddenException } from '@nestjs/common';
 import { SupabaseService } from '../common/supabase/supabase.service';
 import { WalletService } from '../escrow/wallet.service';
-import { Role } from '@velar/types';
+import { AuditService } from '../audit/audit.service';
+import { AuditEventType, Role } from '@velar/types';
+
+/**
+ * Desactivar = banear en Supabase Auth por un plazo efectivamente infinito
+ * (100 años). Se usa el primitivo de Auth en vez de una columna nueva porque
+ * bloquea el login en el propio emisor del token: sin esto habría que acordarse
+ * de chequear la bandera en cada camino de autenticación.
+ */
+const DEACTIVATED_BAN_DURATION = '876000h';
+const ACTIVE_BAN_DURATION = 'none';
 
 type ProfileRow = {
   id: string;
@@ -14,6 +24,7 @@ export class UsersService {
   constructor(
     private supabase: SupabaseService,
     private wallets: WalletService,
+    private audit: AuditService,
   ) {}
 
   async getProfile(userId: string) {
@@ -115,5 +126,48 @@ export class UsersService {
       .from('profiles').update({ role }).eq('id', targetId).select().single();
     if (error) throw new BadRequestException(error.message);
     return data;
+  }
+
+  /* ─── Ciclo de vida de la cuenta (issue #77) ─────────────────────────────── */
+
+  /** Desactiva una cuenta: bloquea el login hasta que un admin la reactive. */
+  async deactivate(targetId: string, actorRole: Role, actorId: string) {
+    return this.setAccountActive(targetId, false, actorRole, actorId);
+  }
+
+  /** Reactiva una cuenta previamente desactivada. */
+  async reactivate(targetId: string, actorRole: Role, actorId: string) {
+    return this.setAccountActive(targetId, true, actorRole, actorId);
+  }
+
+  /**
+   * Mismo criterio de autorización que `setRole`: solo `admin`. Se auditan las
+   * dos direcciones, con el admin como actor y la cuenta afectada en el payload.
+   */
+  private async setAccountActive(
+    targetId: string,
+    active: boolean,
+    actorRole: Role,
+    actorId: string,
+  ) {
+    if (actorRole !== 'admin') throw new ForbiddenException('Admin only');
+    if (targetId === actorId) {
+      throw new BadRequestException('No podés desactivar tu propia cuenta');
+    }
+
+    const { error } = await this.supabase.admin.auth.admin.updateUserById(targetId, {
+      ban_duration: active ? ACTIVE_BAN_DURATION : DEACTIVATED_BAN_DURATION,
+    });
+    if (error) throw new BadRequestException(error.message);
+
+    await this.audit.emit({
+      type: active
+        ? AuditEventType.AUTH_ACCOUNT_REACTIVATED
+        : AuditEventType.AUTH_ACCOUNT_DEACTIVATED,
+      actorId,
+      payload: { targetUserId: targetId },
+    });
+
+    return { ok: true as const, userId: targetId, active };
   }
 }

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -604,3 +604,79 @@ npm run test --workspace apps/api -- --testPathPatterns contracts
 ```
 Funciones puras fixture-driven sin mocks (`domain/*.spec.ts`) + servicio con
 `SupabaseService`/`AuditService` mockeados (`contracts.service.spec.ts`).
+
+---
+
+## 12. Ciclo de vida de la cuenta (issue #77)
+
+`AuthService` solo tenía `login` y `register`: quien olvidaba la contraseña no podía
+recuperarla, no había forma de cambiar el email, y no existía manera de desactivar una
+cuenta comprometida. Esta capa cierra ese hueco **usando primitivos que Supabase Auth ya
+provee**, sin agregar tablas ni columnas.
+
+### Endpoints
+
+```
+POST  /api/auth/forgot-password   (público, 3/min)
+POST  /api/auth/reset-password    (público, 5/min)
+POST  /api/auth/change-email      (autenticado, 3/min)
+PATCH /api/users/:id/deactivate   (admin)
+PATCH /api/users/:id/reactivate   (admin)
+```
+
+Todos registrados en `apiContracts` (`@velar/types`) y cubiertos por
+`controller-contract-coverage.spec.ts`.
+
+### Decisiones que conviene conocer antes de tocar esto
+
+**`forgot-password` responde siempre `{ ok: true }`.** Exista la cuenta o no, y aunque
+Supabase falle. Si la respuesta, el código o el mensaje dependieran de si el email está
+registrado, el endpoint se convertiría en un oráculo para enumerar cuentas. El error solo
+se loguea. **No "arregles" esto devolviendo 404 cuando el usuario no existe.**
+
+**El intento se audita igual, exista o no la cuenta.** Sirve para detectar abuso. Lo que
+NO se registra es si el email existía, porque es justo el dato que no se filtra.
+
+**Desactivar = banear en Supabase Auth** (`ban_duration: '876000h'`, ~100 años; `'none'`
+para reactivar). Se usa el primitivo de Auth en vez de una columna `active` porque el
+bloqueo ocurre en el emisor del token: con una bandera propia habría que acordarse de
+chequearla en cada camino de autenticación, y el día que se olvide, la cuenta desactivada
+vuelve a entrar. Por eso tampoco hace falta migración.
+
+**`change-email` no aplica el cambio**: genera el enlace de confirmación de Supabase
+(`generateLink`, tipo `email_change_new`), así que la dirección nueva solo queda activa
+cuando su dueño confirma. Un token robado no alcanza para mudar la cuenta a otro correo.
+
+**Un admin no puede desactivarse a sí mismo** — evita que el último admin se deje afuera.
+
+### Eventos de auditoría
+
+Todos vía `AuditService.emit()`, con los tipos nuevos en `@velar/types`:
+
+| Evento | `actorId` | Payload |
+|---|---|---|
+| `auth_password_reset_requested` | `null` (anónimo) | `{ email }` |
+| `auth_password_reset_completed` | dueño de la cuenta | — |
+| `auth_email_change_requested` | dueño de la cuenta | `{ from, to }` |
+| `auth_account_deactivated` | **el admin** | `{ targetUserId }` |
+| `auth_account_reactivated` | **el admin** | `{ targetUserId }` |
+
+### Rate limiting
+
+`@nestjs/throttler` ya estaba en el proyecto y `login` ya llevaba `@Throttle` (10/min): se
+extendió el mismo patrón en vez de introducir otro. `register` quedó en 5/min y
+`forgot-password` en 3/min — más bajo porque es anónimo y provoca envío de correo, así que
+sirve tanto para enumerar cuentas como para spamear una bandeja ajena.
+
+### Configuración opcional
+
+`AUTH_PASSWORD_RESET_REDIRECT_URL` — a dónde vuelve el usuario desde el enlace de
+recuperación. Si no está, se usa el default de Supabase.
+
+### Comprobación local sin credenciales
+```bash
+npm run test --workspace apps/api -- --testPathPatterns lifecycle
+```
+`SupabaseService` y `AuditService` mockeados en `auth/auth-lifecycle.service.spec.ts` y
+`users/users-lifecycle.service.spec.ts`. Sin base de datos, sin `service_role`, sin correo
+real.

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -34,6 +34,13 @@ export const AuditEventType = {
   REPORT_SLA_ESCALATED: 'report_sla_escalated',
   REPORT_EXPORTED: 'report_exported',
   REPORT_MARKED_REVIEWED: 'report_marked_reviewed',
+  // Ciclo de vida de la cuenta (issue #77). `actorId` es el dueño de la cuenta,
+  // salvo en (des)activación, donde es el admin que ejecuta la acción.
+  AUTH_PASSWORD_RESET_REQUESTED: 'auth_password_reset_requested',
+  AUTH_PASSWORD_RESET_COMPLETED: 'auth_password_reset_completed',
+  AUTH_EMAIL_CHANGE_REQUESTED: 'auth_email_change_requested',
+  AUTH_ACCOUNT_DEACTIVATED: 'auth_account_deactivated',
+  AUTH_ACCOUNT_REACTIVATED: 'auth_account_reactivated',
 } as const;
 
 export type AuditEventType =

--- a/packages/types/src/contracts.ts
+++ b/packages/types/src/contracts.ts
@@ -1,5 +1,15 @@
 import { z, type ZodTypeAny } from 'zod';
-import { loginRequestSchema, loginResponseSchema, registerRequestSchema, registerResponseSchema } from './schemas/auth';
+import {
+  accountStatusResponseSchema,
+  changeEmailRequestSchema,
+  forgotPasswordRequestSchema,
+  forgotPasswordResponseSchema,
+  loginRequestSchema,
+  loginResponseSchema,
+  registerRequestSchema,
+  registerResponseSchema,
+  resetPasswordRequestSchema,
+} from './schemas/auth';
 import {
   availableBondsQuerySchema,
   bondRequestRowSchema,
@@ -101,6 +111,9 @@ const transferMutationResponseSchema = z.union([transferRowSchema, transactionRe
 export const apiContracts = {
   'auth.register': endpoint({ method: 'POST', path: '/auth/register', module: 'auth', auth: false, body: registerRequestSchema, params: noParams, query: noQuery, response: registerResponseSchema }),
   'auth.login': endpoint({ method: 'POST', path: '/auth/login', module: 'auth', auth: false, body: loginRequestSchema, params: noParams, query: noQuery, response: loginResponseSchema }),
+  'auth.forgotPassword': endpoint({ method: 'POST', path: '/auth/forgot-password', module: 'auth', auth: false, body: forgotPasswordRequestSchema, params: noParams, query: noQuery, response: forgotPasswordResponseSchema }),
+  'auth.resetPassword': endpoint({ method: 'POST', path: '/auth/reset-password', module: 'auth', auth: false, body: resetPasswordRequestSchema, params: noParams, query: noQuery, response: forgotPasswordResponseSchema }),
+  'auth.changeEmail': endpoint({ method: 'POST', path: '/auth/change-email', module: 'auth', auth: true, body: changeEmailRequestSchema, params: noParams, query: noQuery, response: forgotPasswordResponseSchema }),
 
   'bonds.list': endpoint({ method: 'GET', path: '/bonds', module: 'bonds', auth: true, body: noBody, params: noParams, query: bondsQuerySchema, response: paginatedSchema(bondRowSchema) }),
   'bonds.requests.list': endpoint({ method: 'GET', path: '/bonds/requests', module: 'bonds', auth: true, body: noBody, params: noParams, query: noQuery, response: z.array(bondRequestRowSchema) }),
@@ -168,6 +181,8 @@ export const apiContracts = {
   'users.list': endpoint({ method: 'GET', path: '/users', module: 'users', auth: true, body: noBody, params: noParams, query: noQuery, response: z.array(profileRowSchema) }),
   'users.recipients': endpoint({ method: 'GET', path: '/users/recompradores', module: 'users', auth: true, body: noBody, params: noParams, query: noQuery, response: z.array(recipientRowSchema) }),
   'users.setRole': endpoint({ method: 'PATCH', path: '/users/:id/role', module: 'users', auth: true, body: setRoleRequestSchema, params: paramsIdSchema, query: noQuery, response: profileRowSchema }),
+  'users.deactivate': endpoint({ method: 'PATCH', path: '/users/:id/deactivate', module: 'users', auth: true, body: noBody, params: paramsIdSchema, query: noQuery, response: accountStatusResponseSchema }),
+  'users.reactivate': endpoint({ method: 'PATCH', path: '/users/:id/reactivate', module: 'users', auth: true, body: noBody, params: paramsIdSchema, query: noQuery, response: accountStatusResponseSchema }),
 } as const;
 
 export type EndpointName = keyof typeof apiContracts;

--- a/packages/types/src/schemas/auth.ts
+++ b/packages/types/src/schemas/auth.ts
@@ -50,6 +50,42 @@ export const loginResponseSchema = z.object({
   user: z.unknown(),
 }).passthrough();
 
+/* ─── Ciclo de vida de la cuenta (issue #77) ───────────────────────────────── */
+
+export const forgotPasswordRequestSchema = z.object({
+  email: requiredStringSchema.email('validation.email'),
+}).strict();
+
+export const resetPasswordRequestSchema = z.object({
+  /** `token_hash` del enlace de recuperación que Supabase envía por correo. */
+  tokenHash: requiredStringSchema,
+  password: requiredStringSchema.min(8, 'validation.password'),
+}).strict();
+
+export const changeEmailRequestSchema = z.object({
+  email: requiredStringSchema.email('validation.email'),
+}).strict();
+
+/**
+ * Respuesta uniforme de `forgot-password`. Es intencionalmente opaca: se
+ * devuelve lo mismo exista o no la cuenta, para no filtrar qué correos están
+ * registrados (enumeración de usuarios).
+ */
+export const forgotPasswordResponseSchema = z.object({
+  ok: z.literal(true),
+}).strict();
+
+export const accountStatusResponseSchema = z.object({
+  ok: z.literal(true),
+  userId: requiredStringSchema,
+  active: z.boolean(),
+}).strict();
+
 export type LoginRequest = z.input<typeof loginRequestSchema>;
 export type RegisterRequest = z.input<typeof registerRequestSchema>;
 export type RegisterResponse = z.output<typeof registerResponseSchema>;
+export type ForgotPasswordRequest = z.input<typeof forgotPasswordRequestSchema>;
+export type ResetPasswordRequest = z.input<typeof resetPasswordRequestSchema>;
+export type ChangeEmailRequest = z.input<typeof changeEmailRequestSchema>;
+export type ForgotPasswordResponse = z.output<typeof forgotPasswordResponseSchema>;
+export type AccountStatusResponse = z.output<typeof accountStatusResponseSchema>;

--- a/packages/types/types/audit.d.ts
+++ b/packages/types/types/audit.d.ts
@@ -34,6 +34,11 @@ export declare const AuditEventType: {
     readonly REPORT_SLA_ESCALATED: "report_sla_escalated";
     readonly REPORT_EXPORTED: "report_exported";
     readonly REPORT_MARKED_REVIEWED: "report_marked_reviewed";
+    readonly AUTH_PASSWORD_RESET_REQUESTED: "auth_password_reset_requested";
+    readonly AUTH_PASSWORD_RESET_COMPLETED: "auth_password_reset_completed";
+    readonly AUTH_EMAIL_CHANGE_REQUESTED: "auth_email_change_requested";
+    readonly AUTH_ACCOUNT_DEACTIVATED: "auth_account_deactivated";
+    readonly AUTH_ACCOUNT_REACTIVATED: "auth_account_reactivated";
 };
 export type AuditEventType = (typeof AuditEventType)[keyof typeof AuditEventType];
 export interface AuditEvent {

--- a/packages/types/types/audit.js
+++ b/packages/types/types/audit.js
@@ -37,4 +37,11 @@ exports.AuditEventType = {
     REPORT_SLA_ESCALATED: 'report_sla_escalated',
     REPORT_EXPORTED: 'report_exported',
     REPORT_MARKED_REVIEWED: 'report_marked_reviewed',
+    // Ciclo de vida de la cuenta (issue #77). `actorId` es el dueño de la cuenta,
+    // salvo en (des)activación, donde es el admin que ejecuta la acción.
+    AUTH_PASSWORD_RESET_REQUESTED: 'auth_password_reset_requested',
+    AUTH_PASSWORD_RESET_COMPLETED: 'auth_password_reset_completed',
+    AUTH_EMAIL_CHANGE_REQUESTED: 'auth_email_change_requested',
+    AUTH_ACCOUNT_DEACTIVATED: 'auth_account_deactivated',
+    AUTH_ACCOUNT_REACTIVATED: 'auth_account_reactivated',
 };

--- a/packages/types/types/contracts.d.ts
+++ b/packages/types/types/contracts.d.ts
@@ -63,6 +63,49 @@ export declare const apiContracts: {
             user: z.ZodUnknown;
         }, z.core.$loose>;
     };
+    readonly 'auth.forgotPassword': {
+        method: HttpMethod;
+        path: string;
+        module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users" | "contracts";
+        auth: boolean;
+        body: z.ZodObject<{
+            email: z.ZodString;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
+        response: z.ZodObject<{
+            ok: z.ZodLiteral<true>;
+        }, z.core.$strict>;
+    };
+    readonly 'auth.resetPassword': {
+        method: HttpMethod;
+        path: string;
+        module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users" | "contracts";
+        auth: boolean;
+        body: z.ZodObject<{
+            tokenHash: z.ZodString;
+            password: z.ZodString;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
+        response: z.ZodObject<{
+            ok: z.ZodLiteral<true>;
+        }, z.core.$strict>;
+    };
+    readonly 'auth.changeEmail': {
+        method: HttpMethod;
+        path: string;
+        module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users" | "contracts";
+        auth: boolean;
+        body: z.ZodObject<{
+            email: z.ZodString;
+        }, z.core.$strict>;
+        params: z.ZodObject<{}, z.core.$strict>;
+        query: z.ZodObject<{}, z.core.$strict>;
+        response: z.ZodObject<{
+            ok: z.ZodLiteral<true>;
+        }, z.core.$strict>;
+    };
     readonly 'bonds.list': {
         method: HttpMethod;
         path: string;
@@ -2184,6 +2227,38 @@ export declare const apiContracts: {
             created_at: z.ZodString;
             updated_at: z.ZodString;
         }, z.core.$loose>;
+    };
+    readonly 'users.deactivate': {
+        method: HttpMethod;
+        path: string;
+        module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users" | "contracts";
+        auth: boolean;
+        body: z.ZodUndefined;
+        params: z.ZodObject<{
+            id: z.ZodString;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
+        response: z.ZodObject<{
+            ok: z.ZodLiteral<true>;
+            userId: z.ZodString;
+            active: z.ZodBoolean;
+        }, z.core.$strict>;
+    };
+    readonly 'users.reactivate': {
+        method: HttpMethod;
+        path: string;
+        module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users" | "contracts";
+        auth: boolean;
+        body: z.ZodUndefined;
+        params: z.ZodObject<{
+            id: z.ZodString;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
+        response: z.ZodObject<{
+            ok: z.ZodLiteral<true>;
+            userId: z.ZodString;
+            active: z.ZodBoolean;
+        }, z.core.$strict>;
     };
 };
 export type EndpointName = keyof typeof apiContracts;

--- a/packages/types/types/contracts.js
+++ b/packages/types/types/contracts.js
@@ -26,6 +26,9 @@ const transferMutationResponseSchema = zod_1.z.union([transfers_1.transferRowSch
 exports.apiContracts = {
     'auth.register': endpoint({ method: 'POST', path: '/auth/register', module: 'auth', auth: false, body: auth_1.registerRequestSchema, params: noParams, query: noQuery, response: auth_1.registerResponseSchema }),
     'auth.login': endpoint({ method: 'POST', path: '/auth/login', module: 'auth', auth: false, body: auth_1.loginRequestSchema, params: noParams, query: noQuery, response: auth_1.loginResponseSchema }),
+    'auth.forgotPassword': endpoint({ method: 'POST', path: '/auth/forgot-password', module: 'auth', auth: false, body: auth_1.forgotPasswordRequestSchema, params: noParams, query: noQuery, response: auth_1.forgotPasswordResponseSchema }),
+    'auth.resetPassword': endpoint({ method: 'POST', path: '/auth/reset-password', module: 'auth', auth: false, body: auth_1.resetPasswordRequestSchema, params: noParams, query: noQuery, response: auth_1.forgotPasswordResponseSchema }),
+    'auth.changeEmail': endpoint({ method: 'POST', path: '/auth/change-email', module: 'auth', auth: true, body: auth_1.changeEmailRequestSchema, params: noParams, query: noQuery, response: auth_1.forgotPasswordResponseSchema }),
     'bonds.list': endpoint({ method: 'GET', path: '/bonds', module: 'bonds', auth: true, body: noBody, params: noParams, query: bonds_1.bondsQuerySchema, response: (0, common_1.paginatedSchema)(bonds_1.bondRowSchema) }),
     'bonds.requests.list': endpoint({ method: 'GET', path: '/bonds/requests', module: 'bonds', auth: true, body: noBody, params: noParams, query: noQuery, response: zod_1.z.array(bonds_1.bondRequestRowSchema) }),
     'bonds.requests.create': endpoint({ method: 'POST', path: '/bonds/requests', module: 'bonds', auth: true, body: bonds_1.createBondRequestRequestSchema, params: noParams, query: noQuery, response: bonds_1.bondRequestRowSchema }),
@@ -87,6 +90,8 @@ exports.apiContracts = {
     'users.list': endpoint({ method: 'GET', path: '/users', module: 'users', auth: true, body: noBody, params: noParams, query: noQuery, response: zod_1.z.array(users_1.profileRowSchema) }),
     'users.recipients': endpoint({ method: 'GET', path: '/users/recompradores', module: 'users', auth: true, body: noBody, params: noParams, query: noQuery, response: zod_1.z.array(users_1.recipientRowSchema) }),
     'users.setRole': endpoint({ method: 'PATCH', path: '/users/:id/role', module: 'users', auth: true, body: users_1.setRoleRequestSchema, params: common_1.paramsIdSchema, query: noQuery, response: users_1.profileRowSchema }),
+    'users.deactivate': endpoint({ method: 'PATCH', path: '/users/:id/deactivate', module: 'users', auth: true, body: noBody, params: common_1.paramsIdSchema, query: noQuery, response: auth_1.accountStatusResponseSchema }),
+    'users.reactivate': endpoint({ method: 'PATCH', path: '/users/:id/reactivate', module: 'users', auth: true, body: noBody, params: common_1.paramsIdSchema, query: noQuery, response: auth_1.accountStatusResponseSchema }),
 };
 function normalizedPath(value) {
     const path = value.split('?')[0].replace(/^https?:\/\/[^/]+/i, '').replace(/^\/api(?=\/|$)/, '');

--- a/packages/types/types/schemas/auth.d.ts
+++ b/packages/types/types/schemas/auth.d.ts
@@ -45,6 +45,34 @@ export declare const loginResponseSchema: z.ZodObject<{
     token_type: z.ZodString;
     user: z.ZodUnknown;
 }, z.core.$loose>;
+export declare const forgotPasswordRequestSchema: z.ZodObject<{
+    email: z.ZodString;
+}, z.core.$strict>;
+export declare const resetPasswordRequestSchema: z.ZodObject<{
+    tokenHash: z.ZodString;
+    password: z.ZodString;
+}, z.core.$strict>;
+export declare const changeEmailRequestSchema: z.ZodObject<{
+    email: z.ZodString;
+}, z.core.$strict>;
+/**
+ * Respuesta uniforme de `forgot-password`. Es intencionalmente opaca: se
+ * devuelve lo mismo exista o no la cuenta, para no filtrar qué correos están
+ * registrados (enumeración de usuarios).
+ */
+export declare const forgotPasswordResponseSchema: z.ZodObject<{
+    ok: z.ZodLiteral<true>;
+}, z.core.$strict>;
+export declare const accountStatusResponseSchema: z.ZodObject<{
+    ok: z.ZodLiteral<true>;
+    userId: z.ZodString;
+    active: z.ZodBoolean;
+}, z.core.$strict>;
 export type LoginRequest = z.input<typeof loginRequestSchema>;
 export type RegisterRequest = z.input<typeof registerRequestSchema>;
 export type RegisterResponse = z.output<typeof registerResponseSchema>;
+export type ForgotPasswordRequest = z.input<typeof forgotPasswordRequestSchema>;
+export type ResetPasswordRequest = z.input<typeof resetPasswordRequestSchema>;
+export type ChangeEmailRequest = z.input<typeof changeEmailRequestSchema>;
+export type ForgotPasswordResponse = z.output<typeof forgotPasswordResponseSchema>;
+export type AccountStatusResponse = z.output<typeof accountStatusResponseSchema>;

--- a/packages/types/types/schemas/auth.js
+++ b/packages/types/types/schemas/auth.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.loginResponseSchema = exports.registerResponseSchema = exports.registerRequestSchema = exports.loginRequestSchema = exports.perspectiveSchema = void 0;
+exports.accountStatusResponseSchema = exports.forgotPasswordResponseSchema = exports.changeEmailRequestSchema = exports.resetPasswordRequestSchema = exports.forgotPasswordRequestSchema = exports.loginResponseSchema = exports.registerResponseSchema = exports.registerRequestSchema = exports.loginRequestSchema = exports.perspectiveSchema = void 0;
 const zod_1 = require("zod");
 const common_1 = require("./common");
 exports.perspectiveSchema = zod_1.z.enum(['usuario', 'partido'], { error: 'validation.enum' });
@@ -52,3 +52,28 @@ exports.loginResponseSchema = zod_1.z.object({
     token_type: common_1.requiredStringSchema,
     user: zod_1.z.unknown(),
 }).passthrough();
+/* ─── Ciclo de vida de la cuenta (issue #77) ───────────────────────────────── */
+exports.forgotPasswordRequestSchema = zod_1.z.object({
+    email: common_1.requiredStringSchema.email('validation.email'),
+}).strict();
+exports.resetPasswordRequestSchema = zod_1.z.object({
+    /** `token_hash` del enlace de recuperación que Supabase envía por correo. */
+    tokenHash: common_1.requiredStringSchema,
+    password: common_1.requiredStringSchema.min(8, 'validation.password'),
+}).strict();
+exports.changeEmailRequestSchema = zod_1.z.object({
+    email: common_1.requiredStringSchema.email('validation.email'),
+}).strict();
+/**
+ * Respuesta uniforme de `forgot-password`. Es intencionalmente opaca: se
+ * devuelve lo mismo exista o no la cuenta, para no filtrar qué correos están
+ * registrados (enumeración de usuarios).
+ */
+exports.forgotPasswordResponseSchema = zod_1.z.object({
+    ok: zod_1.z.literal(true),
+}).strict();
+exports.accountStatusResponseSchema = zod_1.z.object({
+    ok: zod_1.z.literal(true),
+    userId: common_1.requiredStringSchema,
+    active: zod_1.z.boolean(),
+}).strict();


### PR DESCRIPTION
Closes #77

Cierra el hueco de ciclo de vida de la cuenta en `AuthService`, que solo tenía `login` y `register`. Usa primitivos que Supabase Auth ya provee, así que **no hay cambios de schema ni tablas nuevas**.

Endpoints: `POST /auth/forgot-password`, `POST /auth/reset-password`, `POST /auth/change-email`, `PATCH /users/:id/deactivate`, `PATCH /users/:id/reactivate`. Todos registrados en `apiContracts`.

Cuatro decisiones que vale la pena revisar:

- **`forgot-password` responde siempre `{ ok: true }`**, exista la cuenta o no y aunque Supabase falle; el error solo se loguea. Si la respuesta dependiera de la existencia del email, el endpoint sería un oráculo para enumerar cuentas. Hay un test que compara ambas respuestas byte a byte.
- **Desactivar es banear en Supabase Auth** (`ban_duration`), no una columna `active`. El bloqueo ocurre en el emisor del token, así que no depende de que cada camino de autenticación se acuerde de chequear una bandera — y por eso no hace falta migración.
- **`change-email` no aplica el cambio**: genera el enlace de confirmación, así que la dirección nueva solo queda activa cuando su dueño confirma. Un token robado no alcanza para mudar la cuenta.
- **El intento de reset se audita aunque la cuenta no exista** (útil para detectar abuso), pero sin registrar si existía.

Un admin no puede desactivarse a sí mismo, para que el último admin no se deje afuera.

Rate limiting: `@nestjs/throttler` ya estaba y `login` ya llevaba `@Throttle`, así que se extendió ese patrón — `register` 5/min, `forgot-password` 3/min (más bajo por ser anónimo y provocar envío de correo).

Tests: 20 casos nuevos con `SupabaseService` y `AuditService` mockeados, sin base de datos ni credenciales. Suite de `apps/api` en 485/485. Build, lint y typecheck pasan en la raíz. `docs/BACKEND.md` §12 documenta endpoints, eventos de auditoría y el porqué de cada decisión.
