### PR TITLE
feat(explorer): public bond search, drill-down and pagination

### DIFF
--- a/apps/api/src/explorer/explorer.controller.ts
+++ b/apps/api/src/explorer/explorer.controller.ts
@@ -1,122 +1,30 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { Public } from '../auth/public.decorator';
-import { SupabaseService } from '../common/supabase/supabase.service';
-import {
-  EXPLORER_NETWORK,
-  explorerAccountUrl,
-  explorerAssetUrl,
-  explorerContractUrl,
-} from '../escrow/stellar.config';
-import { WalletService } from '../escrow/wallet.service';
+import { ExplorerService } from './explorer.service';
 
 /**
  * Endpoints PÚBLICOS (sin auth) para el explorador del ledger de VELAR.
  * Cualquiera puede consultarlos para verificar el estado on-chain.
  */
+@ApiTags('explorer')
 @Public()
 @Controller('explorer')
 export class ExplorerController {
-  constructor(
-    private supabase: SupabaseService,
-    private wallets: WalletService,
-  ) {}
+  constructor(private explorer: ExplorerService) {}
 
   @Get('snapshot')
-  async snapshot() {
-    const db = this.supabase.admin;
-    const issuer = this.wallets.platformAddress ?? '';
-    const escrow = this.wallets.escrowAddress ?? '';
-
-    const [bondsRes, transfersRes, partiesRes, sorobanRes, twRes] = await Promise.all([
-      db.from('bonds').select('bond_id, status, face_value, currency, soroban_contract_id, created_at, parties(name)').order('created_at', { ascending: false }).limit(20),
-      db.from('transfers').select('id, amount, status, created_at, bonds(bond_id), escrow_contract_id').order('created_at', { ascending: false }).limit(20),
-      db.from('parties').select('id, name, code, stellar_wallet'),
-      db.from('bonds').select('soroban_contract_id, bond_id').not('soroban_contract_id', 'is', null).order('created_at', { ascending: false }).limit(10),
-      db.from('transfers').select('escrow_contract_id, id, status, bonds(bond_id)').not('escrow_contract_id', 'is', null).order('created_at', { ascending: false }).limit(10),
-    ]);
-
-    const bonds = bondsRes.data ?? [];
-    const transfers = transfersRes.data ?? [];
-    const liberadas = transfers.filter((t: any) => t.status === 'liberada');
-    const totalVolume = liberadas.reduce((s: number, t: any) => s + (Number(t.amount) || 0), 0);
-    const totalEmitted = bonds.reduce((s: number, b: any) => s + (Number(b.face_value) || 0), 0);
-
-    return {
-      network: EXPLORER_NETWORK,
-
-      // Accounts críticas
-      platform_account: {
-        address: issuer,
-        explorer_url: explorerAccountUrl(issuer),
-      },
-      escrow_account: {
-        address: escrow,
-        explorer_url: explorerAccountUrl(escrow),
-      },
-
-      // Assets emitidos por la plataforma
-      assets: {
-        vcrc: {
-          symbol: 'VCRC',
-          issuer,
-          purpose: 'Representación on-chain del precio de cada venta en colones',
-          explorer_url: explorerAssetUrl('VCRC', issuer),
-        },
-      },
-
-      // Resumen
-      stats: {
-        total_bonds: bonds.length,
-        total_emitted_crc: totalEmitted,
-        total_sales: liberadas.length,
-        total_volume_crc: totalVolume,
-        sorobanContracts: (sorobanRes.data ?? []).length,
-        trustlessWorkContracts: (twRes.data ?? []).length,
-      },
-
-      // Últimos bonos (con link al asset y al contrato Soroban si tienen)
-      recent_bonds: bonds.map((b: any) => ({
-        bond_id: b.bond_id,
-        party: b.parties?.name,
-        face_value: b.face_value,
-        currency: b.currency ?? 'CRC',
-        status: b.status,
-        asset_url: explorerAssetUrl(assetCode(b.bond_id), issuer),
-        soroban_contract_url: b.soroban_contract_id
-          ? explorerContractUrl(b.soroban_contract_id)
-          : null,
-        soroban_contract_id: b.soroban_contract_id,
-      })),
-
-      // Últimos contratos Soroban VelarBond (NFT del bono)
-      soroban_nfts: (sorobanRes.data ?? []).map((b: any) => ({
-        bond_id: b.bond_id,
-        contract_id: b.soroban_contract_id,
-        url: explorerContractUrl(b.soroban_contract_id),
-      })),
-
-      // Últimos contratos Trustless Work (escrow de coordinación)
-      trustless_work_contracts: (twRes.data ?? []).map((t: any) => ({
-        transfer_id: t.id,
-        bond_id: t.bonds?.bond_id,
-        status: t.status,
-        contract_id: t.escrow_contract_id,
-        url: explorerContractUrl(t.escrow_contract_id),
-      })),
-
-      // Glosario de memos para que cualquiera entienda las txs
-      memo_glossary: [
-        { prefix: 'VELAR:issue:', meaning: 'Emisión inicial de un bono al partido emisor' },
-        { prefix: 'escrow:',      meaning: 'Token del bono bloqueado en escrow durante una venta' },
-        { prefix: 'sold:',        meaning: 'Token liberado al comprador + monto pagado en CRC' },
-        { prefix: 'return:',      meaning: 'Bono devuelto al dueño original (cancelación TSE)' },
-        { prefix: 'bond:',        meaning: 'Pago de VCRC vinculado a una venta específica' },
-      ],
-    };
+  snapshot(@Query('page') page: string | undefined, @Query('limit') limit: string | undefined) {
+    return this.explorer.snapshot(page, limit);
   }
-}
 
-function assetCode(bondId: string): string {
-  const code = bondId.replace(/[^A-Za-z0-9]/g, '').slice(0, 12);
-  return code || 'BOND';
+  @Get('search')
+  search(@Query('q') q: string | undefined) {
+    return this.explorer.search(q ?? '');
+  }
+
+  @Get('bonds/:bondId')
+  bondDetail(@Param('bondId') bondId: string) {
+    return this.explorer.findBondDetail(bondId);
+  }
 }

--- a/apps/api/src/explorer/explorer.module.ts
+++ b/apps/api/src/explorer/explorer.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 import { ExplorerController } from './explorer.controller';
+import { ExplorerService } from './explorer.service';
 import { SupabaseModule } from '../common/supabase/supabase.module';
 import { EscrowModule } from '../escrow/escrow.module';
 
 @Module({
   imports: [SupabaseModule, EscrowModule],
   controllers: [ExplorerController],
+  providers: [ExplorerService],
 })
 export class ExplorerModule {}

--- a/apps/api/src/explorer/explorer.service.spec.ts
+++ b/apps/api/src/explorer/explorer.service.spec.ts
@@ -1,0 +1,190 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ExplorerService } from './explorer.service';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import { WalletService } from '../escrow/wallet.service';
+
+/**
+ * Mockea el query builder fluido de Supabase: cada método de la cadena
+ * devuelve el mismo objeto, que además es "thenable" (como el builder real)
+ * para poder hacer `await db.from(...).select()...` sin llamar `.single()`.
+ */
+function chain(result: { data?: any; error?: any; count?: number | null }) {
+  const obj: any = {
+    select: jest.fn(() => obj),
+    eq: jest.fn(() => obj),
+    ilike: jest.fn(() => obj),
+    in: jest.fn(() => obj),
+    or: jest.fn(() => obj),
+    not: jest.fn(() => obj),
+    order: jest.fn(() => obj),
+    range: jest.fn(() => obj),
+    limit: jest.fn(() => obj),
+    maybeSingle: jest.fn(() => Promise.resolve(result)),
+    single: jest.fn(() => Promise.resolve(result)),
+    then: (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject),
+  };
+  return obj;
+}
+
+describe('ExplorerService', () => {
+  let service: ExplorerService;
+  let fromMock: jest.Mock;
+
+  beforeEach(async () => {
+    fromMock = jest.fn();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExplorerService,
+        { provide: SupabaseService, useValue: { admin: { from: fromMock } } },
+        { provide: WalletService, useValue: { platformAddress: 'GPLATFORM', escrowAddress: 'GESCROW' } },
+      ],
+    }).compile();
+
+    service = module.get(ExplorerService);
+  });
+
+  describe('snapshot', () => {
+    it('pagina las listas y calcula stats sobre toda la tabla, no solo la página', async () => {
+      fromMock
+        // recent_bonds (página)
+        .mockReturnValueOnce(chain({
+          data: [{ bond_id: 'B-1', status: 'activo', face_value: 1000, currency: 'CRC', soroban_contract_id: 'C1', created_at: 't', parties: { name: 'Partido X' } }],
+        }))
+        // total_bonds (count exacto)
+        .mockReturnValueOnce(chain({ count: 42 }))
+        // todos los face_value, para el total emitido
+        .mockReturnValueOnce(chain({ data: [{ face_value: 1000 }, { face_value: 2000 }] }))
+        // transfers liberadas, para ventas/volumen
+        .mockReturnValueOnce(chain({ data: [{ amount: 500 }, { amount: 1500 }] }))
+        // soroban_nfts (página)
+        .mockReturnValueOnce(chain({ data: [{ soroban_contract_id: 'C1', bond_id: 'B-1' }] }))
+        // soroban count
+        .mockReturnValueOnce(chain({ count: 5 }))
+        // trustless_work_contracts (página)
+        .mockReturnValueOnce(chain({ data: [{ escrow_contract_id: 'E1', id: 't1', status: 'liberada', bonds: { bond_id: 'B-1' } }] }))
+        // trustless work count
+        .mockReturnValueOnce(chain({ count: 7 }));
+
+      const result = await service.snapshot('1', '20');
+
+      expect(result.stats).toEqual({
+        total_bonds: 42,
+        total_emitted_crc: 3000,
+        total_sales: 2,
+        total_volume_crc: 2000,
+        sorobanContracts: 5,
+        trustlessWorkContracts: 7,
+      });
+      expect(result.recent_bonds).toEqual({
+        data: [{
+          bond_id: 'B-1',
+          party: 'Partido X',
+          face_value: 1000,
+          currency: 'CRC',
+          status: 'activo',
+          asset_url: expect.stringContaining('B1-GPLATFORM'),
+          soroban_contract_url: expect.stringContaining('C1'),
+          soroban_contract_id: 'C1',
+        }],
+        total: 42,
+        page: 1,
+        limit: 20,
+      });
+      expect(result.soroban_nfts.total).toBe(5);
+      expect(result.trustless_work_contracts.total).toBe(7);
+    });
+  });
+
+  describe('findBondDetail', () => {
+    it('devuelve el bono con partido, dueño, historial y links on-chain', async () => {
+      fromMock
+        .mockReturnValueOnce(chain({
+          data: {
+            token_id: 'tok-1',
+            bond_id: 'B-1',
+            status: 'activo',
+            face_value: 1000,
+            currency: 'CRC',
+            document_hash: 'hash',
+            soroban_contract_id: 'C1',
+            created_at: 't1',
+            updated_at: 't2',
+            parties: { name: 'Partido X', code: 'PX', stellar_wallet: 'GPARTY' },
+            profiles: { id: 'u1', full_name: 'Juan', email: 'j@x.com', stellar_wallet: 'GUSER' },
+          },
+        }))
+        .mockReturnValueOnce(chain({
+          data: [{
+            id: 'tr-1',
+            status: 'liberada',
+            amount: 500,
+            escrow_contract_id: 'ESC1',
+            payment_evidence_hash: 'ph',
+            created_at: 'ta',
+            updated_at: 'tb',
+            from_profile: { id: 'u0', full_name: 'Vendedor', email: 'v@x.com' },
+            to_profile: { id: 'u1', full_name: 'Juan', email: 'j@x.com' },
+          }],
+        }));
+
+      const result = await service.findBondDetail('B-1');
+
+      expect(result.party).toEqual({ name: 'Partido X', code: 'PX', wallet: 'GPARTY' });
+      expect(result.current_owner).toEqual({ id: 'u1', name: 'Juan', email: 'j@x.com', wallet: 'GUSER' });
+      expect(result.soroban_contract_url).toContain('C1');
+      expect(result.trustless_work_contracts).toEqual([
+        { transfer_id: 'tr-1', status: 'liberada', contract_id: 'ESC1', url: expect.stringContaining('ESC1') },
+      ]);
+      expect(result.transfers).toHaveLength(1);
+      expect(result.transfers[0].from).toEqual({ id: 'u0', name: 'Vendedor' });
+      expect(result.transfers[0].to).toEqual({ id: 'u1', name: 'Juan' });
+    });
+
+    it('lanza 404 cuando el bono no existe', async () => {
+      fromMock.mockReturnValueOnce(chain({ data: null, error: null }));
+
+      await expect(service.findBondDetail('no-existe')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('search', () => {
+    it('rechaza una búsqueda vacía sin consultar la base', async () => {
+      await expect(service.search('  ')).rejects.toThrow(BadRequestException);
+      expect(fromMock).not.toHaveBeenCalled();
+    });
+
+    it('combina resultados por bond_id y por partido, sin duplicados', async () => {
+      const bondRow = {
+        bond_id: 'B-1', status: 'activo', face_value: 1000, currency: 'CRC',
+        soroban_contract_id: null, created_at: 't', parties: { name: 'Partido X' },
+      };
+      fromMock
+        // by bond_id
+        .mockReturnValueOnce(chain({ data: [bondRow] }))
+        // parties by name
+        .mockReturnValueOnce(chain({ data: [{ id: 'p1' }] }))
+        // parties by wallet
+        .mockReturnValueOnce(chain({ data: [] }))
+        // profiles by wallet
+        .mockReturnValueOnce(chain({ data: [] }))
+        // bonds by party id (mismo bono, debe deduplicarse)
+        .mockReturnValueOnce(chain({ data: [bondRow] }));
+
+      const result = await service.search('Partido X');
+
+      expect(result.count).toBe(1);
+      expect(result.results).toEqual([{
+        bond_id: 'B-1',
+        party: 'Partido X',
+        face_value: 1000,
+        currency: 'CRC',
+        status: 'activo',
+        asset_url: expect.any(String),
+        soroban_contract_url: null,
+        soroban_contract_id: null,
+      }]);
+    });
+  });
+});

--- a/apps/api/src/explorer/explorer.service.ts
+++ b/apps/api/src/explorer/explorer.service.ts
@@ -1,0 +1,270 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import {
+  EXPLORER_NETWORK,
+  explorerAccountUrl,
+  explorerAssetUrl,
+  explorerContractUrl,
+} from '../escrow/stellar.config';
+import { WalletService } from '../escrow/wallet.service';
+import { paginatedResponse, parsePagination } from '../common/pagination';
+
+const SEARCH_RESULT_LIMIT = 50;
+
+/**
+ * Lógica del explorador público del ledger de VELAR (sin auth). Cualquiera
+ * puede consultarla para verificar el estado on-chain.
+ */
+@Injectable()
+export class ExplorerService {
+  constructor(
+    private supabase: SupabaseService,
+    private wallets: WalletService,
+  ) {}
+
+  async snapshot(page?: string, limit?: string) {
+    const db = this.supabase.admin;
+    const { page: p, limit: l, from, to } = parsePagination(page, limit);
+    const issuer = this.wallets.platformAddress ?? '';
+    const escrow = this.wallets.escrowAddress ?? '';
+
+    const [
+      bondsPageRes,
+      bondsCountRes,
+      allBondsRes,
+      liberadasRes,
+      sorobanPageRes,
+      sorobanCountRes,
+      twPageRes,
+      twCountRes,
+    ] = await Promise.all([
+      db.from('bonds').select('bond_id, status, face_value, currency, soroban_contract_id, created_at, parties(name)').order('created_at', { ascending: false }).range(from, to),
+      db.from('bonds').select('bond_id', { count: 'exact', head: true }),
+      db.from('bonds').select('face_value'),
+      db.from('transfers').select('amount').eq('status', 'liberada'),
+      db.from('bonds').select('soroban_contract_id, bond_id').not('soroban_contract_id', 'is', null).order('created_at', { ascending: false }).range(from, to),
+      db.from('bonds').select('bond_id', { count: 'exact', head: true }).not('soroban_contract_id', 'is', null),
+      db.from('transfers').select('escrow_contract_id, id, status, bonds(bond_id)').not('escrow_contract_id', 'is', null).order('created_at', { ascending: false }).range(from, to),
+      db.from('transfers').select('id', { count: 'exact', head: true }).not('escrow_contract_id', 'is', null),
+    ]);
+
+    const bonds = bondsPageRes.data ?? [];
+    const allBonds = allBondsRes.data ?? [];
+    const liberadas = liberadasRes.data ?? [];
+    const totalVolume = liberadas.reduce((s: number, t: any) => s + (Number(t.amount) || 0), 0);
+    const totalEmitted = allBonds.reduce((s: number, b: any) => s + (Number(b.face_value) || 0), 0);
+
+    return {
+      network: EXPLORER_NETWORK,
+
+      // Accounts críticas
+      platform_account: {
+        address: issuer,
+        explorer_url: explorerAccountUrl(issuer),
+      },
+      escrow_account: {
+        address: escrow,
+        explorer_url: explorerAccountUrl(escrow),
+      },
+
+      // Assets emitidos por la plataforma
+      assets: {
+        vcrc: {
+          symbol: 'VCRC',
+          issuer,
+          purpose: 'Representación on-chain del precio de cada venta en colones',
+          explorer_url: explorerAssetUrl('VCRC', issuer),
+        },
+      },
+
+      // Resumen (conteos reales sobre toda la tabla, no solo la página actual)
+      stats: {
+        total_bonds: bondsCountRes.count ?? 0,
+        total_emitted_crc: totalEmitted,
+        total_sales: liberadas.length,
+        total_volume_crc: totalVolume,
+        sorobanContracts: sorobanCountRes.count ?? 0,
+        trustlessWorkContracts: twCountRes.count ?? 0,
+      },
+
+      // Bonos (con link al asset y al contrato Soroban si tienen), paginado.
+      recent_bonds: paginatedResponse(
+        bonds.map((b: any) => ({
+          bond_id: b.bond_id,
+          party: b.parties?.name,
+          face_value: b.face_value,
+          currency: b.currency ?? 'CRC',
+          status: b.status,
+          asset_url: explorerAssetUrl(assetCode(b.bond_id), issuer),
+          soroban_contract_url: b.soroban_contract_id
+            ? explorerContractUrl(b.soroban_contract_id)
+            : null,
+          soroban_contract_id: b.soroban_contract_id,
+        })),
+        bondsCountRes.count ?? 0,
+        p,
+        l,
+      ),
+
+      // Contratos Soroban VelarBond (NFT del bono), paginado.
+      soroban_nfts: paginatedResponse(
+        (sorobanPageRes.data ?? []).map((b: any) => ({
+          bond_id: b.bond_id,
+          contract_id: b.soroban_contract_id,
+          url: explorerContractUrl(b.soroban_contract_id),
+        })),
+        sorobanCountRes.count ?? 0,
+        p,
+        l,
+      ),
+
+      // Contratos Trustless Work (escrow de coordinación), paginado.
+      trustless_work_contracts: paginatedResponse(
+        (twPageRes.data ?? []).map((t: any) => ({
+          transfer_id: t.id,
+          bond_id: t.bonds?.bond_id,
+          status: t.status,
+          contract_id: t.escrow_contract_id,
+          url: explorerContractUrl(t.escrow_contract_id),
+        })),
+        twCountRes.count ?? 0,
+        p,
+        l,
+      ),
+
+      // Glosario de memos para que cualquiera entienda las txs
+      memo_glossary: [
+        { prefix: 'VELAR:issue:', meaning: 'Emisión inicial de un bono al partido emisor' },
+        { prefix: 'escrow:', meaning: 'Token del bono bloqueado en escrow durante una venta' },
+        { prefix: 'sold:', meaning: 'Token liberado al comprador + monto pagado en CRC' },
+        { prefix: 'return:', meaning: 'Bono devuelto al dueño original (cancelación TSE)' },
+        { prefix: 'bond:', meaning: 'Pago de VCRC vinculado a una venta específica' },
+      ],
+    };
+  }
+
+  /** Detalle completo de un bono: partido, dueño, historial de transferencias y contratos on-chain. */
+  async findBondDetail(bondId: string) {
+    const db = this.supabase.admin;
+    const issuer = this.wallets.platformAddress ?? '';
+
+    const { data: bond, error } = await db
+      .from('bonds')
+      .select(
+        'token_id, bond_id, status, face_value, currency, document_hash, soroban_contract_id, created_at, updated_at, ' +
+          'parties(name, code, stellar_wallet), profiles!bonds_current_owner_fkey(id, full_name, email, stellar_wallet)',
+      )
+      .eq('bond_id', bondId)
+      .maybeSingle();
+
+    if (error || !bond) throw new NotFoundException(`Bono ${bondId} no encontrado`);
+    const b = bond as any;
+
+    const { data: transfersData } = await db
+      .from('transfers')
+      .select(
+        'id, status, amount, escrow_contract_id, payment_evidence_hash, created_at, updated_at, ' +
+          'from_profile:profiles!transfers_from_owner_fkey(id, full_name, email), ' +
+          'to_profile:profiles!transfers_to_owner_fkey(id, full_name, email)',
+      )
+      .eq('bond_token_id', b.token_id)
+      .order('created_at', { ascending: true });
+
+    const transfers = transfersData ?? [];
+
+    const trustlessWorkContracts = transfers
+      .filter((t: any) => t.escrow_contract_id)
+      .map((t: any) => ({
+        transfer_id: t.id,
+        status: t.status,
+        contract_id: t.escrow_contract_id,
+        url: explorerContractUrl(t.escrow_contract_id),
+      }));
+
+    return {
+      bond_id: b.bond_id,
+      status: b.status,
+      face_value: b.face_value,
+      currency: b.currency ?? 'CRC',
+      document_hash: b.document_hash,
+      created_at: b.created_at,
+      updated_at: b.updated_at,
+      party: b.parties
+        ? { name: b.parties.name, code: b.parties.code, wallet: b.parties.stellar_wallet ?? null }
+        : null,
+      current_owner: b.profiles
+        ? { id: b.profiles.id, name: b.profiles.full_name, email: b.profiles.email, wallet: b.profiles.stellar_wallet ?? null }
+        : null,
+      asset_url: explorerAssetUrl(assetCode(b.bond_id), issuer),
+      soroban_contract_id: b.soroban_contract_id,
+      soroban_contract_url: b.soroban_contract_id ? explorerContractUrl(b.soroban_contract_id) : null,
+      trustless_work_contracts: trustlessWorkContracts,
+      transfers: transfers.map((t: any) => ({
+        id: t.id,
+        status: t.status,
+        amount: t.amount,
+        from: t.from_profile ? { id: t.from_profile.id, name: t.from_profile.full_name } : null,
+        to: t.to_profile ? { id: t.to_profile.id, name: t.to_profile.full_name } : null,
+        escrow_contract_id: t.escrow_contract_id,
+        escrow_contract_url: t.escrow_contract_id ? explorerContractUrl(t.escrow_contract_id) : null,
+        created_at: t.created_at,
+        updated_at: t.updated_at,
+      })),
+    };
+  }
+
+  /** Busca bonos por bond_id, nombre de partido o wallet Stellar (del partido o del dueño actual). */
+  async search(q: string) {
+    const query = (q ?? '').trim();
+    if (!query) throw new BadRequestException('El parámetro q es requerido');
+
+    const db = this.supabase.admin;
+    const like = `%${query}%`;
+    const issuer = this.wallets.platformAddress ?? '';
+    const bondColumns = 'bond_id, status, face_value, currency, soroban_contract_id, created_at, parties(name)';
+
+    const [byBondId, partiesByName, partiesByWallet, profilesByWallet] = await Promise.all([
+      db.from('bonds').select(bondColumns).ilike('bond_id', like).limit(SEARCH_RESULT_LIMIT),
+      db.from('parties').select('id').ilike('name', like),
+      db.from('parties').select('id').ilike('stellar_wallet', like),
+      db.from('profiles').select('id').or(`stellar_wallet.ilike.${like},stellar_public_key.ilike.${like}`),
+    ]);
+
+    const partyIds = [
+      ...new Set([...(partiesByName.data ?? []), ...(partiesByWallet.data ?? [])].map((p: any) => p.id)),
+    ];
+    const ownerIds = [...new Set((profilesByWallet.data ?? []).map((p: any) => p.id))];
+
+    const [byParty, byOwner] = await Promise.all([
+      partyIds.length
+        ? db.from('bonds').select(bondColumns).in('issuer_party_id', partyIds).limit(SEARCH_RESULT_LIMIT)
+        : Promise.resolve({ data: [] as any[] }),
+      ownerIds.length
+        ? db.from('bonds').select(bondColumns).in('current_owner', ownerIds).limit(SEARCH_RESULT_LIMIT)
+        : Promise.resolve({ data: [] as any[] }),
+    ]);
+
+    const merged = new Map<string, any>();
+    for (const row of [...(byBondId.data ?? []), ...(byParty.data ?? []), ...(byOwner.data ?? [])]) {
+      merged.set(row.bond_id, row);
+    }
+
+    const results = [...merged.values()].map((b: any) => ({
+      bond_id: b.bond_id,
+      party: b.parties?.name ?? null,
+      face_value: b.face_value,
+      currency: b.currency ?? 'CRC',
+      status: b.status,
+      asset_url: explorerAssetUrl(assetCode(b.bond_id), issuer),
+      soroban_contract_url: b.soroban_contract_id ? explorerContractUrl(b.soroban_contract_id) : null,
+      soroban_contract_id: b.soroban_contract_id,
+    }));
+
+    return { query, count: results.length, results };
+  }
+}
+
+function assetCode(bondId: string): string {
+  const code = bondId.replace(/[^A-Za-z0-9]/g, '').slice(0, 12);
+  return code || 'BOND';
+}

--- a/apps/web/app/explorer/[bondId]/page.tsx
+++ b/apps/web/app/explorer/[bondId]/page.tsx
@@ -1,0 +1,239 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import {
+  ArrowLeft, ExternalLink, ShieldCheck, Boxes, FileText, Wallet, Users, ArrowRightLeft,
+} from 'lucide-react';
+import { publicApiFetch } from '../../../lib/api';
+import { StatusBadge, fmtDate } from '../../../components/status-ui';
+
+type BondDetail = {
+  bond_id: string;
+  status: string;
+  face_value: number;
+  currency: string;
+  document_hash: string;
+  created_at: string;
+  updated_at: string;
+  party: { name: string; code: string; wallet: string | null } | null;
+  current_owner: { id: string; name: string | null; email: string; wallet: string | null } | null;
+  asset_url: string;
+  soroban_contract_id: string | null;
+  soroban_contract_url: string | null;
+  trustless_work_contracts: Array<{ transfer_id: string; status: string; contract_id: string; url: string }>;
+  transfers: Array<{
+    id: string;
+    status: string;
+    amount: number | null;
+    from: { id: string; name: string | null } | null;
+    to: { id: string; name: string | null } | null;
+    escrow_contract_id: string | null;
+    escrow_contract_url: string | null;
+    created_at: string;
+    updated_at: string;
+  }>;
+};
+
+const fmtCRC = (n: number) => new Intl.NumberFormat('es-CR', { style: 'currency', currency: 'CRC', maximumFractionDigits: 0 }).format(n || 0);
+const shortKey = (k: string, n = 8) => (k && k.length > 2 * n + 3 ? `${k.slice(0, n)}…${k.slice(-n)}` : k);
+
+export default function BondDetailPage() {
+  const params = useParams<{ bondId: string }>();
+  const bondId = decodeURIComponent(params.bondId ?? '');
+
+  const [data, setData] = useState<BondDetail | null>(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!bondId) return;
+    setData(null);
+    setError('');
+    publicApiFetch('GET', `/explorer/bonds/${encodeURIComponent(bondId)}`)
+      .then((res) => setData(res as BondDetail))
+      .catch((e: Error) => setError(e.message));
+  }, [bondId]);
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-slate-50 to-white" style={{ fontFamily: 'Inter, sans-serif' }}>
+      <header className="border-b border-slate-200/60 bg-white/85 backdrop-blur-xl">
+        <div className="mx-auto flex h-16 max-w-[1280px] items-center justify-between gap-4 px-6">
+          <div className="flex items-center gap-5">
+            <Link href="/explorer" className="inline-flex items-center gap-2 text-sm text-slate-600 transition hover:text-slate-900">
+              <ArrowLeft size={15} /> Volver al explorador
+            </Link>
+            <span className="hidden h-5 w-px bg-slate-200 sm:block" />
+            <Link href="/" className="hidden items-center gap-2 sm:flex">
+              <div className="flex h-7 w-7 items-center justify-center rounded-md bg-gradient-to-br from-primary-container to-primary text-white">
+                <Boxes size={14} strokeWidth={2.3} />
+              </div>
+              <span className="text-sm font-bold tracking-tight text-slate-900" style={{ fontFamily: 'Geist, sans-serif' }}>
+                VELAR
+                <span className="ml-1 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold tracking-wide text-slate-500">EXPLORER</span>
+              </span>
+            </Link>
+          </div>
+          <Link
+            href="/login"
+            className="inline-flex h-10 items-center gap-1.5 rounded-full bg-primary px-4 text-[13px] font-semibold text-white transition hover:bg-primary-container hover:shadow-lg hover:shadow-primary/25"
+          >
+            Acceder a la plataforma
+            <ExternalLink size={13} />
+          </Link>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-[900px] px-6 py-12 pb-24">
+        {error && (
+          <div className="mx-auto max-w-lg rounded-2xl border border-red-200 bg-white p-6 text-center">
+            <p className="text-sm text-red-600">{error}</p>
+            <Link href="/explorer" className="mt-4 inline-flex items-center gap-1.5 text-[13px] font-semibold text-primary hover:underline">
+              <ArrowLeft size={13} /> Volver al explorador
+            </Link>
+          </div>
+        )}
+
+        {!error && !data && (
+          <div className="flex justify-center py-24">
+            <span className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          </div>
+        )}
+
+        {data && (
+          <>
+            {/* Hero */}
+            <section className="mb-10">
+              <div className="flex flex-wrap items-center gap-3">
+                <h1 className="font-mono text-2xl font-bold text-slate-900 md:text-3xl" style={{ fontFamily: 'JetBrains Mono, monospace' }}>
+                  {data.bond_id}
+                </h1>
+                <StatusBadge status={data.status} />
+              </div>
+              <p className="mt-2 text-2xl font-bold text-slate-900" style={{ fontFamily: 'Geist, sans-serif' }}>
+                {fmtCRC(data.face_value)} <span className="text-sm font-medium text-slate-400">{data.currency}</span>
+              </p>
+            </section>
+
+            {/* Partido y dueño */}
+            <section className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="rounded-2xl border border-slate-200 bg-white p-5">
+                <div className="mb-3 flex items-center gap-2 text-slate-500">
+                  <Users size={15} />
+                  <p className="text-[11px] font-semibold uppercase tracking-wide">Partido emisor</p>
+                </div>
+                {data.party ? (
+                  <>
+                    <p className="text-lg font-bold text-slate-900" style={{ fontFamily: 'Geist, sans-serif' }}>{data.party.name}</p>
+                    <p className="text-[13px] text-slate-500">Código: {data.party.code}</p>
+                    {data.party.wallet && <p className="mt-2 font-mono text-[11px] text-slate-400">{shortKey(data.party.wallet)}</p>}
+                  </>
+                ) : (
+                  <p className="text-sm text-slate-400">Sin dato</p>
+                )}
+              </div>
+
+              <div className="rounded-2xl border border-slate-200 bg-white p-5">
+                <div className="mb-3 flex items-center gap-2 text-slate-500">
+                  <Wallet size={15} />
+                  <p className="text-[11px] font-semibold uppercase tracking-wide">Dueño actual</p>
+                </div>
+                {data.current_owner ? (
+                  <>
+                    <p className="text-lg font-bold text-slate-900" style={{ fontFamily: 'Geist, sans-serif' }}>{data.current_owner.name ?? 'Sin nombre'}</p>
+                    <p className="text-[13px] text-slate-500">{data.current_owner.email}</p>
+                    {data.current_owner.wallet && <p className="mt-2 font-mono text-[11px] text-slate-400">{shortKey(data.current_owner.wallet)}</p>}
+                  </>
+                ) : (
+                  <p className="text-sm text-slate-400">Sin dueño asignado</p>
+                )}
+              </div>
+            </section>
+
+            {/* On-chain */}
+            <section className="mb-8">
+              <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-500">
+                <FileText size={14} /> Verificación on-chain
+              </h2>
+              <div className="flex flex-wrap gap-2">
+                <a href={data.asset_url} target="_blank" rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3.5 py-1.5 text-[12.5px] font-medium text-slate-700 transition hover:border-primary hover:text-primary">
+                  Ver asset Stellar <ExternalLink size={11} />
+                </a>
+                {data.soroban_contract_url && (
+                  <a href={data.soroban_contract_url} target="_blank" rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1.5 rounded-full border border-purple-200 bg-purple-50 px-3.5 py-1.5 text-[12.5px] font-medium text-purple-700 transition hover:bg-purple-100">
+                    Ver contrato Soroban (NFT) <ExternalLink size={11} />
+                  </a>
+                )}
+              </div>
+              <p className="mt-3 text-[11px] text-slate-400">Hash del documento: <span className="font-mono">{data.document_hash}</span></p>
+            </section>
+
+            {/* Trustless Work */}
+            {data.trustless_work_contracts.length > 0 && (
+              <section className="mb-8">
+                <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-500">
+                  <ShieldCheck size={14} className="text-emerald-700" /> Contratos Trustless Work
+                </h2>
+                <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+                  {data.trustless_work_contracts.map((c) => (
+                    <a key={c.contract_id} href={c.url} target="_blank" rel="noopener noreferrer"
+                      className="group flex items-center justify-between border-b border-slate-100 px-5 py-3 transition last:border-0 hover:bg-emerald-50/40">
+                      <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600">{c.status}</span>
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono text-[11px] text-slate-500">{shortKey(c.contract_id, 6)}</span>
+                        <ExternalLink size={13} className="text-emerald-600 transition group-hover:scale-110" />
+                      </div>
+                    </a>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* Historial de transferencias */}
+            <section className="mb-6">
+              <h2 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-500">
+                <ArrowRightLeft size={14} /> Historial de transferencias
+              </h2>
+              {data.transfers.length === 0 ? (
+                <div className="rounded-2xl border border-slate-200 bg-white p-6 text-center text-sm text-slate-400">
+                  Este bono todavía no tuvo transferencias.
+                </div>
+              ) : (
+                <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+                  <div className="hidden grid-cols-[1fr_1fr_110px_130px_130px] gap-3 border-b border-slate-100 bg-slate-50 px-5 py-3 text-[10.5px] font-semibold uppercase tracking-wide text-slate-500 md:grid">
+                    <span>De</span>
+                    <span>A</span>
+                    <span>Monto</span>
+                    <span>Estado</span>
+                    <span className="text-right">Fecha</span>
+                  </div>
+                  {data.transfers.map((t) => (
+                    <div key={t.id} className="grid grid-cols-1 items-center gap-2 border-b border-slate-100 px-5 py-3.5 last:border-0 md:grid-cols-[1fr_1fr_110px_130px_130px]">
+                      <span className="text-sm text-slate-700">{t.from?.name ?? '—'}</span>
+                      <span className="text-sm text-slate-700">{t.to?.name ?? '—'}</span>
+                      <span className="text-sm font-semibold text-slate-900">{t.amount != null ? fmtCRC(t.amount) : '—'}</span>
+                      <span><StatusBadge status={t.status} /></span>
+                      <div className="flex items-center justify-end gap-2 text-[12px] text-slate-500">
+                        {fmtDate(t.created_at)}
+                        {t.escrow_contract_url && (
+                          <a href={t.escrow_contract_url} target="_blank" rel="noopener noreferrer" className="text-emerald-600 hover:text-emerald-700">
+                            <ExternalLink size={12} />
+                          </a>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+
+            <p className="text-center text-[12px] text-slate-400">
+              Emitido el {fmtDate(data.created_at)} · Última actualización {fmtDate(data.updated_at)}
+            </p>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/explorer/page.tsx
+++ b/apps/web/app/explorer/page.tsx
@@ -1,11 +1,25 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import Link from 'next/link';
 import {
   ArrowLeft, ExternalLink, ShieldCheck, Coins, Server, Lock, Activity, Eye, BookOpen, Boxes,
+  Search, X,
 } from 'lucide-react';
+import { publicApiFetch } from '../../lib/api';
+import { PaginationControls } from '../../components/PaginationControls';
+import { StatusBadge } from '../../components/status-ui';
+import type { PaginatedResponse } from '@velar/types';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001/api';
+type BondSummary = {
+  bond_id: string;
+  party?: string | null;
+  face_value: number;
+  currency: string;
+  status: string;
+  asset_url: string;
+  soroban_contract_url: string | null;
+  soroban_contract_id: string | null;
+};
 
 type Snapshot = {
   network: string;
@@ -22,35 +36,58 @@ type Snapshot = {
     sorobanContracts: number;
     trustlessWorkContracts: number;
   };
-  recent_bonds: Array<{
-    bond_id: string;
-    party?: string;
-    face_value: number;
-    currency: string;
-    status: string;
-    asset_url: string;
-    soroban_contract_url: string | null;
-    soroban_contract_id: string | null;
-  }>;
-  soroban_nfts: Array<{ bond_id: string; contract_id: string; url: string }>;
-  trustless_work_contracts: Array<{ transfer_id: string; bond_id?: string; status: string; contract_id: string; url: string }>;
+  recent_bonds: PaginatedResponse<BondSummary>;
+  soroban_nfts: PaginatedResponse<{ bond_id: string; contract_id: string; url: string }>;
+  trustless_work_contracts: PaginatedResponse<{ transfer_id: string; bond_id?: string; status: string; contract_id: string; url: string }>;
   memo_glossary: Array<{ prefix: string; meaning: string }>;
 };
+
+type SearchResponse = { query: string; count: number; results: BondSummary[] };
 
 const fmtCRC = (n: number) => new Intl.NumberFormat('es-CR', { style: 'currency', currency: 'CRC', maximumFractionDigits: 0 }).format(n || 0);
 const fmtNum = (n: number) => new Intl.NumberFormat('es-CR').format(n || 0);
 const shortKey = (k: string, n = 8) => k.length > 2 * n + 3 ? `${k.slice(0, n)}…${k.slice(-n)}` : k;
+const PAGE_LIMIT = 20;
 
 export default function ExplorerPage() {
   const [data, setData] = useState<Snapshot | null>(null);
   const [error, setError] = useState('');
+  const [page, setPage] = useState(1);
+
+  const [query, setQuery] = useState('');
+  const [searchResult, setSearchResult] = useState<SearchResponse | null>(null);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState('');
 
   useEffect(() => {
-    fetch(`${API_URL}/explorer/snapshot`)
-      .then((r) => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
-      .then(setData)
-      .catch((e) => setError(e.message));
-  }, []);
+    setError('');
+    publicApiFetch('GET', `/explorer/snapshot?page=${page}&limit=${PAGE_LIMIT}`)
+      .then((res) => setData(res as Snapshot))
+      .catch((e: Error) => setError(e.message));
+  }, [page]);
+
+  async function runSearch(e: FormEvent) {
+    e.preventDefault();
+    const q = query.trim();
+    if (!q) return;
+    setSearching(true);
+    setSearchError('');
+    try {
+      const res = await publicApiFetch('GET', `/explorer/search?q=${encodeURIComponent(q)}`);
+      setSearchResult(res as SearchResponse);
+    } catch (e: any) {
+      setSearchError(e.message ?? 'No se pudo buscar');
+      setSearchResult(null);
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  function clearSearch() {
+    setQuery('');
+    setSearchResult(null);
+    setSearchError('');
+  }
 
   if (error) {
     return (
@@ -104,7 +141,7 @@ export default function ExplorerPage() {
       <div className="mx-auto max-w-[1280px] px-6 py-12 pb-24">
 
         {/* Hero */}
-        <section className="mb-12 text-center">
+        <section className="mb-10 text-center">
           <span className="inline-flex items-center gap-2 rounded-full border border-emerald-200 bg-emerald-50 px-3.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-emerald-700">
             <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
             Red Stellar · {data.network}
@@ -118,6 +155,77 @@ export default function ExplorerPage() {
             Cada enlace abre directamente la fuente de verdad en Stellar Expert.
             No necesitás cuenta ni confiar en VELAR para verificar.
           </p>
+        </section>
+
+        {/* Búsqueda */}
+        <section className="mb-12">
+          <form onSubmit={runSearch} className="mx-auto flex max-w-xl items-center gap-2">
+            <div className="relative flex-1">
+              <Search size={16} className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-slate-400" />
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Buscar por ID de bono, partido o wallet Stellar…"
+                className="h-11 w-full rounded-full border border-slate-200 bg-white pl-10 pr-9 text-sm text-slate-800 outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/15"
+              />
+              {query && (
+                <button
+                  type="button"
+                  onClick={clearSearch}
+                  aria-label="Limpiar búsqueda"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 transition hover:text-slate-600"
+                >
+                  <X size={15} />
+                </button>
+              )}
+            </div>
+            <button
+              type="submit"
+              disabled={searching || !query.trim()}
+              className="inline-flex h-11 items-center gap-1.5 rounded-full bg-primary px-5 text-[13px] font-semibold text-white transition hover:bg-primary-container disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {searching ? 'Buscando…' : 'Buscar'}
+            </button>
+          </form>
+
+          {searchError && (
+            <p className="mx-auto mt-3 max-w-xl text-center text-sm text-red-600">{searchError}</p>
+          )}
+
+          {searchResult && (
+            <div className="mx-auto mt-6 max-w-3xl overflow-hidden rounded-2xl border border-slate-200 bg-white">
+              <div className="flex items-center justify-between border-b border-slate-100 bg-slate-50 px-5 py-3">
+                <p className="text-[13px] font-semibold text-slate-700">
+                  {searchResult.count === 0
+                    ? `Sin resultados para "${searchResult.query}"`
+                    : `${searchResult.count} resultado${searchResult.count === 1 ? '' : 's'} para "${searchResult.query}"`}
+                </p>
+                <button onClick={clearSearch} className="text-[12px] font-medium text-slate-500 transition hover:text-slate-800">
+                  Limpiar
+                </button>
+              </div>
+              {searchResult.results.length === 0 ? (
+                <div className="flex flex-col items-center gap-2 px-5 py-10 text-center">
+                  <Eye size={22} className="text-slate-300" />
+                  <p className="text-sm text-slate-500">No encontramos ningún bono, partido o wallet que coincida.</p>
+                </div>
+              ) : (
+                searchResult.results.map((b) => (
+                  <Link
+                    key={b.bond_id}
+                    href={`/explorer/${encodeURIComponent(b.bond_id)}`}
+                    className="flex items-center justify-between gap-3 border-b border-slate-100 px-5 py-3.5 transition last:border-0 hover:bg-slate-50"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-mono text-sm font-bold text-primary" style={{ fontFamily: 'JetBrains Mono, monospace' }}>{b.bond_id}</p>
+                      <p className="truncate text-[12.5px] text-slate-500">{b.party ?? 'Sin partido'} · {fmtCRC(b.face_value)}</p>
+                    </div>
+                    <StatusBadge status={b.status} />
+                  </Link>
+                ))
+              )}
+            </div>
+          )}
         </section>
 
         {/* Stats */}
@@ -206,61 +314,67 @@ export default function ExplorerPage() {
         </section>
 
         {/* Soroban NFTs */}
-        {data.soroban_nfts.length > 0 && (
+        {data.soroban_nfts.data.length > 0 && (
           <section className="mb-12">
             <h2 className="mb-1 flex items-center gap-2 text-xl font-semibold text-slate-900" style={{ fontFamily: 'Geist, sans-serif' }}>
-              Soroban NFTs <span className="rounded-full bg-purple-100 px-2 py-0.5 text-[12px] font-semibold text-purple-700">{data.soroban_nfts.length}</span>
+              Soroban NFTs <span className="rounded-full bg-purple-100 px-2 py-0.5 text-[12px] font-semibold text-purple-700">{data.soroban_nfts.total}</span>
             </h2>
             <p className="mb-6 text-sm text-slate-500">Cada bono nuevo es un contrato Soroban con toda su metadata on-chain.</p>
 
             <div className="grid grid-cols-1 gap-2 md:grid-cols-2 lg:grid-cols-3">
-              {data.soroban_nfts.map((n) => (
-                <a key={n.contract_id} href={n.url} target="_blank" rel="noopener noreferrer"
+              {data.soroban_nfts.data.map((n) => (
+                <Link key={n.contract_id} href={`/explorer/${encodeURIComponent(n.bond_id)}`}
                   className="group flex items-center justify-between gap-3 rounded-xl border border-purple-100 bg-purple-50/40 px-4 py-3 transition hover:bg-purple-50">
                   <div className="min-w-0">
                     <p className="font-mono text-sm font-bold text-purple-900" style={{ fontFamily: 'JetBrains Mono, monospace' }}>{n.bond_id}</p>
                     <p className="truncate font-mono text-[11px] text-purple-700">{shortKey(n.contract_id, 6)}</p>
                   </div>
                   <ExternalLink size={14} className="shrink-0 text-purple-600 transition group-hover:scale-110" />
-                </a>
+                </Link>
               ))}
             </div>
           </section>
         )}
 
         {/* Trustless Work contracts */}
-        {data.trustless_work_contracts.length > 0 && (
+        {data.trustless_work_contracts.data.length > 0 && (
           <section className="mb-12">
             <h2 className="mb-1 flex items-center gap-2 text-xl font-semibold text-slate-900" style={{ fontFamily: 'Geist, sans-serif' }}>
               <ShieldCheck size={18} className="text-emerald-700" />
-              Contratos Trustless Work <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[12px] font-semibold text-emerald-700">{data.trustless_work_contracts.length}</span>
+              Contratos Trustless Work <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[12px] font-semibold text-emerald-700">{data.trustless_work_contracts.total}</span>
             </h2>
             <p className="mb-6 text-sm text-slate-500">Cada venta crea un contrato Soroban Single-Release como registro inmutable del trade.</p>
 
             <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
-              {data.trustless_work_contracts.map((c) => (
-                <a key={c.contract_id} href={c.url} target="_blank" rel="noopener noreferrer"
+              {data.trustless_work_contracts.data.map((c) => (
+                <div key={c.contract_id}
                   className="group flex items-center justify-between border-b border-slate-100 px-5 py-3 transition last:border-0 hover:bg-emerald-50/40">
                   <div className="flex items-center gap-3">
-                    <span className="font-mono text-sm font-bold text-emerald-700" style={{ fontFamily: 'JetBrains Mono, monospace' }}>{c.bond_id ?? 'Bono'}</span>
+                    {c.bond_id ? (
+                      <Link href={`/explorer/${encodeURIComponent(c.bond_id)}`} className="font-mono text-sm font-bold text-emerald-700 hover:underline" style={{ fontFamily: 'JetBrains Mono, monospace' }}>
+                        {c.bond_id}
+                      </Link>
+                    ) : (
+                      <span className="font-mono text-sm font-bold text-emerald-700" style={{ fontFamily: 'JetBrains Mono, monospace' }}>Bono</span>
+                    )}
                     <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600">{c.status}</span>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <a href={c.url} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2">
                     <span className="font-mono text-[11px] text-slate-500">{shortKey(c.contract_id, 6)}</span>
                     <ExternalLink size={13} className="text-emerald-600 transition group-hover:scale-110" />
-                  </div>
-                </a>
+                  </a>
+                </div>
               ))}
             </div>
           </section>
         )}
 
         {/* Bonos recientes */}
-        {data.recent_bonds.length > 0 && (
+        {data.recent_bonds.data.length > 0 && (
           <section className="mb-12">
             <h2 className="mb-1 flex items-center gap-2 text-xl font-semibold text-slate-900" style={{ fontFamily: 'Geist, sans-serif' }}>
               <Activity size={18} className="text-primary" />
-              Últimos bonos emitidos
+              Bonos emitidos
             </h2>
             <p className="mb-6 text-sm text-slate-500">Cada uno con su asset Stellar (clásico) y opcionalmente su contrato Soroban (NFT con metadata).</p>
 
@@ -272,12 +386,14 @@ export default function ExplorerPage() {
                 <span>Estado</span>
                 <span className="text-right">On-chain</span>
               </div>
-              {data.recent_bonds.map((b) => (
+              {data.recent_bonds.data.map((b) => (
                 <div key={b.bond_id} className="grid grid-cols-1 items-center gap-3 border-b border-slate-100 px-5 py-3 last:border-0 md:grid-cols-[140px_1fr_120px_120px_240px]">
-                  <span className="font-mono text-sm font-bold text-primary" style={{ fontFamily: 'JetBrains Mono, monospace' }}>{b.bond_id}</span>
+                  <Link href={`/explorer/${encodeURIComponent(b.bond_id)}`} className="font-mono text-sm font-bold text-primary hover:underline" style={{ fontFamily: 'JetBrains Mono, monospace' }}>
+                    {b.bond_id}
+                  </Link>
                   <span className="text-sm text-slate-700">{b.party ?? '—'}</span>
                   <span className="text-sm font-semibold text-slate-900">{fmtCRC(b.face_value)}</span>
-                  <span><span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-600">{b.status}</span></span>
+                  <span><StatusBadge status={b.status} /></span>
                   <div className="flex items-center justify-end gap-2">
                     <a href={b.asset_url} target="_blank" rel="noopener noreferrer"
                       className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2.5 py-0.5 text-[11px] font-medium text-slate-700 transition hover:border-primary hover:text-primary">
@@ -292,6 +408,12 @@ export default function ExplorerPage() {
                   </div>
                 </div>
               ))}
+              <PaginationControls
+                page={data.recent_bonds.page}
+                limit={data.recent_bonds.limit}
+                total={data.recent_bonds.total}
+                onPageChange={setPage}
+              />
             </div>
           </section>
         )}


### PR DESCRIPTION
## Summary

- `GET /explorer/bonds/:bondId` — full detail for one bond: party, current owner, face value/status, complete transfer history, Soroban contract link, and Trustless Work escrow contract link(s). Returns 404 for an unknown bond id.
- `GET /explorer/search?q=` — matches on `bond_id`, party name, or Stellar wallet address (party wallet or current owner's wallet), returning summarized bonds.
- `snapshot()`'s `recent_bonds`, `soroban_nfts`, and `trustless_work_contracts` are now paginated with the shared `parsePagination`/`paginatedResponse` helpers (`apps/api/src/common/pagination.ts`) instead of hardcoded `limit(20)`/`limit(10)`; `stats` is now derived from real table counts instead of just the fetched page.
- Explorer logic moved out of the controller into a new, unit-tested `ExplorerService`; the controller is a thin `@Public()` wrapper — no `AuthGuard` added, matching the transparency-surface requirement.
- `apps/web/app/explorer/` now has a real search bar (bond id / party / wallet) and a per-bond drill-down page (`/explorer/[bondId]`) with party, owner, on-chain links, Trustless Work contracts, and full transfer history, plus pagination controls on the bonds list.

## Test plan

- [x] `npm run build`, `npm run lint`, `npm run test` pass in `apps/api` (498 tests) and `apps/web` (52 tests), with no real VELAR/Supabase credentials (placeholder local `.env`/`.env.local`, gitignored).
- [x] New `ExplorerService` unit tests cover: paginated `snapshot()` with stats derived from full-table counts, `findBondDetail()` success + 404, and `search()` merging/deduping bond_id + party + wallet matches (400 on empty `q`).
- [x] Verified live against a running API (no seed data): `GET /explorer/snapshot?page=1&limit=5` returns the paginated envelope, `GET /explorer/bonds/:bondId` 404s for an unknown id, `GET /explorer/search?q=` returns `{query, count, results}` and 400s on empty `q`.
- [x] Verified in the browser: `/explorer` renders the search bar, stats, on-chain infra cards, and glossary; searching renders a graceful "sin resultados" empty state; `/explorer/[bondId]` renders the 404 state with a link back to the explorer.
- [x] All explorer endpoints remain `@Public()` (no auth).

Closes #79