### PR TITLE
feat(api): add custodial wallet retry and reconciliation

### DIFF
--- a/apps/api/src/users/users-lifecycle.service.spec.ts
+++ b/apps/api/src/users/users-lifecycle.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, ForbiddenException } from '@nestjs/common';
 import { UsersService } from './users.service';
+import { WalletReconciliationService } from './wallet-reconciliation.service';
 import { SupabaseService } from '../common/supabase/supabase.service';
 import { WalletService } from '../escrow/wallet.service';
 import { AuditService } from '../audit/audit.service';
@@ -27,6 +28,7 @@ describe('UsersService — desactivación de cuentas', () => {
         },
         { provide: WalletService, useValue: { createWalletRecord: jest.fn() } },
         { provide: AuditService, useValue: audit },
+        { provide: WalletReconciliationService, useValue: { retryProfile: jest.fn() } },
       ],
     }).compile();
 

--- a/apps/api/src/users/users-wallet-retry.service.spec.ts
+++ b/apps/api/src/users/users-wallet-retry.service.spec.ts
@@ -1,0 +1,180 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { WalletReconciliationService } from './wallet-reconciliation.service';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import { WalletService } from '../escrow/wallet.service';
+import { AuditService } from '../audit/audit.service';
+import { Role } from '@velar/types';
+
+const FUNDED_PUBLIC_KEY = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+type Row = Record<string, unknown>;
+
+function createMemoryAdmin(initial: { profiles?: Row[]; parties?: Row[] }) {
+  const tables: Record<string, Row[]> = {
+    profiles: (initial.profiles ?? []).map((r) => ({ ...r })),
+    parties: (initial.parties ?? []).map((r) => ({ ...r })),
+  };
+
+  const from = jest.fn((table: string) => createQuery(table));
+
+  function createQuery(table: string) {
+    const filters: Array<(row: Row) => boolean> = [];
+    let mode: 'select' | 'update' = 'select';
+    let patch: Row = {};
+    let limitN: number | null = null;
+
+    const apply = () => {
+      let rows = (tables[table] ?? []).filter((r) => filters.every((f) => f(r)));
+      if (mode === 'update') {
+        const ids = new Set(rows.map((r) => r.id));
+        tables[table] = (tables[table] ?? []).map((r) =>
+          ids.has(r.id) ? { ...r, ...patch } : r,
+        );
+        rows = (tables[table] ?? []).filter((r) => ids.has(r.id));
+      }
+      if (limitN != null) rows = rows.slice(0, limitN);
+      return rows;
+    };
+
+    const result = (single: boolean, maybe = false) => {
+      const rows = apply();
+      if (single || maybe) {
+        const data = rows[0] ?? null;
+        return {
+          data,
+          error: single && !data ? { message: 'not found', code: 'PGRST116' } : null,
+        };
+      }
+      return { data: rows, error: null };
+    };
+
+    const q: Record<string, unknown> = {};
+    q.select = () => q;
+    q.update = (p: Row) => {
+      mode = 'update';
+      patch = p;
+      return q;
+    };
+    q.eq = (col: string, val: unknown) => {
+      filters.push((r) => r[col] === val);
+      return q;
+    };
+    q.neq = (col: string, val: unknown) => {
+      filters.push((r) => r[col] !== val);
+      return q;
+    };
+    q.lt = (col: string, val: unknown) => {
+      filters.push((r) => Number(r[col]) < Number(val));
+      return q;
+    };
+    q.lte = (col: string, val: unknown) => {
+      filters.push((r) => Number(r[col]) <= Number(val));
+      return q;
+    };
+    q.is = (col: string, val: unknown) => {
+      filters.push((r) => (val === null ? r[col] == null : r[col] === val));
+      return q;
+    };
+    q.in = (col: string, vals: unknown[]) => {
+      filters.push((r) => vals.includes(r[col]));
+      return q;
+    };
+    q.or = () => q;
+    q.order = () => q;
+    q.limit = (n: number) => {
+      limitN = n;
+      return q;
+    };
+    q.single = () => Promise.resolve(result(true));
+    q.maybeSingle = () => Promise.resolve(result(true, true));
+    q.then = (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
+      Promise.resolve(result(false)).then(onFulfilled, onRejected);
+
+    return q;
+  }
+
+  return { from, tables };
+}
+
+/**
+ * POST /users/:id/wallet/retry — admin-only + auditoría.
+ * WalletService y Supabase mockeados; no hay Friendbot ni credenciales.
+ */
+describe('UsersService — retryWallet', () => {
+  let service: UsersService;
+  let audit: { emit: jest.Mock };
+  let createWalletRecord: jest.Mock;
+  let memory: ReturnType<typeof createMemoryAdmin>;
+
+  beforeEach(async () => {
+    createWalletRecord = jest.fn().mockResolvedValue({
+      publicKey: FUNDED_PUBLIC_KEY,
+      status: 'funded',
+      network: 'testnet',
+    });
+    audit = { emit: jest.fn().mockResolvedValue(undefined) };
+    memory = createMemoryAdmin({
+      profiles: [
+        {
+          id: 'target-1',
+          email: 'comprador@velar.cr',
+          role: 'comprador',
+          stellar_wallet: null,
+          stellar_wallet_status: 'failed',
+          stellar_wallet_error: 'friendbot timeout',
+          stellar_wallet_retry_count: 0,
+          stellar_wallet_last_retry_at: null,
+        },
+      ],
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        WalletReconciliationService,
+        { provide: SupabaseService, useValue: { admin: { from: memory.from } } },
+        { provide: WalletService, useValue: { createWalletRecord } },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+
+    service = module.get(UsersService);
+  });
+
+  it('el admin reintenta y persiste funded/created', async () => {
+    const result = await service.retryWallet('target-1', 'admin', 'admin-1');
+
+    expect(createWalletRecord).toHaveBeenCalled();
+    const updated = memory.tables.profiles[0];
+    expect(updated.stellar_wallet_status).toMatch(/^(funded|created)$/);
+    expect(result).toEqual(
+      expect.objectContaining({
+        stellar_wallet_status: expect.stringMatching(/^(funded|created)$/),
+      }),
+    );
+  });
+
+  it('audita con actorId del admin y targetUserId de la cuenta', async () => {
+    await service.retryWallet('target-1', 'admin', 'admin-1');
+
+    expect(audit.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'admin-1',
+        payload: expect.objectContaining({ targetUserId: 'target-1' }),
+      }),
+    );
+  });
+
+  it.each(['comprador', 'emisor', 'tse', 'recomprador', 'validador'] as const)(
+    'rechaza al rol %s: es admin-only',
+    async (role: Role) => {
+      await expect(service.retryWallet('target-1', role, 'actor-1')).rejects.toThrow(
+        ForbiddenException,
+      );
+      expect(createWalletRecord).not.toHaveBeenCalled();
+      expect(audit.emit).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,7 +1,8 @@
-import { Body, Controller, Get, Param, Patch, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Param, Patch, Post, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { AuthGuard } from '../auth/auth.guard';
+import { Roles } from '../auth/roles.decorator';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { Role } from '@velar/types';
 import { UpdateWalletDto } from './dto/users.dto';
@@ -50,5 +51,12 @@ export class UsersController {
   @Patch(':id/reactivate')
   reactivate(@Param('id') id: string, @CurrentUser() user: any) {
     return this.users.reactivate(id, user.profile?.role as Role, user.id);
+  }
+
+  /** Reintenta la wallet custodial fallida de un usuario (admin). */
+  @Post(':id/wallet/retry')
+  @Roles('admin')
+  retryWallet(@Param('id') id: string, @CurrentUser() user: any) {
+    return this.users.retryWallet(id, user.profile?.role as Role, user.id);
   }
 }

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,14 +1,15 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { WalletReconciliationService } from './wallet-reconciliation.service';
 import { AuthModule } from '../auth/auth.module';
 import { EscrowModule } from '../escrow/escrow.module';
 import { AuditModule } from '../audit/audit.module';
 
 @Module({
   imports: [AuthModule, EscrowModule, AuditModule],
-  providers: [UsersService],
+  providers: [UsersService, WalletReconciliationService],
   controllers: [UsersController],
-  exports: [UsersService],
+  exports: [UsersService, WalletReconciliationService],
 })
 export class UsersModule {}

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -3,6 +3,7 @@ import { SupabaseService } from '../common/supabase/supabase.service';
 import { WalletService } from '../escrow/wallet.service';
 import { AuditService } from '../audit/audit.service';
 import { AuditEventType, Role } from '@velar/types';
+import { WalletReconciliationService } from './wallet-reconciliation.service';
 
 /**
  * Desactivar = banear en Supabase Auth por un plazo efectivamente infinito
@@ -25,6 +26,7 @@ export class UsersService {
     private supabase: SupabaseService,
     private wallets: WalletService,
     private audit: AuditService,
+    private reconciliation: WalletReconciliationService,
   ) {}
 
   async getProfile(userId: string) {
@@ -169,5 +171,41 @@ export class UsersService {
     });
 
     return { ok: true as const, userId: targetId, active };
+  }
+
+  /** Reintenta la wallet custodial fallida de un usuario. Solo admin. */
+  async retryWallet(targetId: string, actorRole: Role, actorId: string) {
+    if (actorRole !== 'admin') throw new ForbiddenException('Admin only');
+
+    const { data: before, error: loadError } = await this.supabase.admin
+      .from('profiles')
+      .select('stellar_wallet_status')
+      .eq('id', targetId)
+      .maybeSingle();
+    if (loadError || !before) throw new BadRequestException('Usuario no encontrado');
+
+    const result = await this.reconciliation.retryProfile(targetId, actorId);
+
+    await this.audit.emit({
+      type: AuditEventType.WALLET_RETRY_REQUESTED,
+      actorId,
+      payload: {
+        targetUserId: targetId,
+        previousStatus: before.stellar_wallet_status ?? null,
+        newStatus: result.stellar_wallet_status,
+        ...(result.stellar_wallet ? { publicKey: result.stellar_wallet } : {}),
+        ...(result.stellar_wallet_error ? { error: result.stellar_wallet_error } : {}),
+      },
+    });
+
+    return {
+      ok: true as const,
+      stellar_wallet: result.stellar_wallet,
+      stellar_wallet_status: result.stellar_wallet_status,
+      stellar_wallet_error: result.stellar_wallet_error,
+      stellar_network: result.stellar_network,
+      stellar_wallet_retry_count: result.stellar_wallet_retry_count,
+      stellar_wallet_last_retry_at: result.stellar_wallet_last_retry_at,
+    };
   }
 }

--- a/apps/api/src/users/wallet-reconciliation.service.spec.ts
+++ b/apps/api/src/users/wallet-reconciliation.service.spec.ts
@@ -1,0 +1,260 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  WALLET_RETRY_MAX_ATTEMPTS,
+  WalletReconciliationService,
+} from './wallet-reconciliation.service';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import { WalletService } from '../escrow/wallet.service';
+import { AuditService } from '../audit/audit.service';
+
+const FUNDED_PUBLIC_KEY = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+type Row = Record<string, unknown>;
+
+/**
+ * Cadena mínima estilo PostgREST: select/eq/lt/update/limit/single.
+ * Sin cliente real de Supabase ni credenciales.
+ */
+function createMemoryAdmin(initial: { profiles?: Row[]; parties?: Row[] }) {
+  const tables: Record<string, Row[]> = {
+    profiles: (initial.profiles ?? []).map((r) => ({ ...r })),
+    parties: (initial.parties ?? []).map((r) => ({ ...r })),
+  };
+
+  const from = jest.fn((table: string) => createQuery(table));
+
+  function createQuery(table: string) {
+    const filters: Array<(row: Row) => boolean> = [];
+    let mode: 'select' | 'update' = 'select';
+    let patch: Row = {};
+    let limitN: number | null = null;
+
+    const apply = () => {
+      let rows = (tables[table] ?? []).filter((r) => filters.every((f) => f(r)));
+      if (mode === 'update') {
+        const ids = new Set(rows.map((r) => r.id));
+        tables[table] = (tables[table] ?? []).map((r) =>
+          ids.has(r.id) ? { ...r, ...patch } : r,
+        );
+        rows = (tables[table] ?? []).filter((r) => ids.has(r.id));
+      }
+      if (limitN != null) rows = rows.slice(0, limitN);
+      return rows;
+    };
+
+    const result = (single: boolean, maybe = false) => {
+      const rows = apply();
+      if (single || maybe) {
+        const data = rows[0] ?? null;
+        return {
+          data,
+          error: single && !data ? { message: 'not found', code: 'PGRST116' } : null,
+        };
+      }
+      return { data: rows, error: null };
+    };
+
+    const q: Record<string, unknown> = {};
+    q.select = () => q;
+    q.update = (p: Row) => {
+      mode = 'update';
+      patch = p;
+      return q;
+    };
+    q.eq = (col: string, val: unknown) => {
+      filters.push((r) => r[col] === val);
+      return q;
+    };
+    q.neq = (col: string, val: unknown) => {
+      filters.push((r) => r[col] !== val);
+      return q;
+    };
+    q.lt = (col: string, val: unknown) => {
+      filters.push((r) => Number(r[col]) < Number(val));
+      return q;
+    };
+    q.lte = (col: string, val: unknown) => {
+      filters.push((r) => Number(r[col]) <= Number(val));
+      return q;
+    };
+    q.gt = (col: string, val: unknown) => {
+      filters.push((r) => String(r[col] ?? '') > String(val));
+      return q;
+    };
+    q.gte = (col: string, val: unknown) => {
+      filters.push((r) => String(r[col] ?? '') >= String(val));
+      return q;
+    };
+    q.is = (col: string, val: unknown) => {
+      filters.push((r) => (val === null ? r[col] == null : r[col] === val));
+      return q;
+    };
+    q.in = (col: string, vals: unknown[]) => {
+      filters.push((r) => vals.includes(r[col]));
+      return q;
+    };
+    q.or = () => q;
+    q.order = () => q;
+    q.limit = (n: number) => {
+      limitN = n;
+      return q;
+    };
+    q.single = () => Promise.resolve(result(true));
+    q.maybeSingle = () => Promise.resolve(result(true, true));
+    q.then = (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
+      Promise.resolve(result(false)).then(onFulfilled, onRejected);
+
+    return q;
+  }
+
+  return {
+    from,
+    tables,
+    expireBackoff(table: string) {
+      tables[table] = tables[table].map((r) => ({
+        ...r,
+        stellar_wallet_last_retry_at: '2020-01-01T00:00:00.000Z',
+      }));
+    },
+  };
+}
+
+function failedProfile(overrides: Row = {}): Row {
+  return {
+    id: 'profile-failed-1',
+    email: 'stuck@velar.cr',
+    stellar_wallet: null,
+    stellar_wallet_status: 'failed',
+    stellar_wallet_error: 'friendbot timeout',
+    stellar_wallet_retry_count: 0,
+    stellar_wallet_last_retry_at: null,
+    stellar_network: null,
+    ...overrides,
+  };
+}
+
+describe('WalletReconciliationService', () => {
+  let service: WalletReconciliationService;
+  let createWalletRecord: jest.Mock;
+  let audit: { emit: jest.Mock };
+  let memory: ReturnType<typeof createMemoryAdmin>;
+
+  async function compile(profiles: Row[], parties: Row[] = []) {
+    createWalletRecord = jest.fn();
+    audit = { emit: jest.fn().mockResolvedValue(undefined) };
+    memory = createMemoryAdmin({ profiles, parties });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WalletReconciliationService,
+        { provide: SupabaseService, useValue: { admin: { from: memory.from } } },
+        { provide: WalletService, useValue: { createWalletRecord } },
+        { provide: AuditService, useValue: audit },
+      ],
+    }).compile();
+
+    service = module.get(WalletReconciliationService);
+  }
+
+  describe('reconcileFailedWallets — failed → funded', () => {
+    it('persiste status funded cuando createWalletRecord (mock) financia la cuenta', async () => {
+      await compile([failedProfile()]);
+      createWalletRecord.mockResolvedValue({
+        publicKey: FUNDED_PUBLIC_KEY,
+        status: 'funded',
+        network: 'testnet',
+      });
+
+      await service.reconcileFailedWallets();
+
+      expect(createWalletRecord).toHaveBeenCalledTimes(1);
+      const updated = memory.tables.profiles[0];
+      expect(updated.stellar_wallet_status).toMatch(/^(funded|created)$/);
+      expect(updated.stellar_wallet).toBe(FUNDED_PUBLIC_KEY);
+    });
+  });
+
+  describe('retryProfile — failed → funded', () => {
+    it('actualiza el perfil a funded/created con la clave mockeada', async () => {
+      await compile([failedProfile()]);
+      createWalletRecord.mockResolvedValue({
+        publicKey: FUNDED_PUBLIC_KEY,
+        status: 'funded',
+        network: 'testnet',
+      });
+
+      await service.retryProfile('profile-failed-1');
+
+      expect(createWalletRecord).toHaveBeenCalled();
+      const updated = memory.tables.profiles[0];
+      expect(updated.stellar_wallet_status).toMatch(/^(funded|created)$/);
+      expect(updated.stellar_wallet).toBe(FUNDED_PUBLIC_KEY);
+    });
+  });
+
+  describe('reintentos acotados', () => {
+    it('no llama createWalletRecord si retry_count ya está en MAX', async () => {
+      const max = WALLET_RETRY_MAX_ATTEMPTS;
+      await compile([
+        failedProfile({
+          stellar_wallet_retry_count: max,
+          stellar_wallet_last_retry_at: '2020-01-01T00:00:00.000Z',
+        }),
+      ]);
+      createWalletRecord.mockResolvedValue({
+        publicKey: FUNDED_PUBLIC_KEY,
+        status: 'failed',
+        network: 'testnet',
+        error: 'still down',
+      });
+
+      await service.reconcileFailedWallets();
+
+      expect(createWalletRecord).not.toHaveBeenCalled();
+      expect(memory.tables.profiles[0].stellar_wallet_retry_count).toBe(max);
+    });
+
+    it('deja de reintentar al llegar a MAX aunque el mock falle siempre', async () => {
+      const max = WALLET_RETRY_MAX_ATTEMPTS;
+      await compile([failedProfile()]);
+      createWalletRecord.mockResolvedValue({
+        publicKey: FUNDED_PUBLIC_KEY,
+        status: 'failed',
+        network: 'testnet',
+        error: 'permanent',
+      });
+
+      for (let i = 0; i < max + 8; i++) {
+        memory.expireBackoff('profiles');
+        memory.expireBackoff('parties');
+        await service.reconcileFailedWallets();
+      }
+
+      expect(createWalletRecord.mock.calls.length).toBeLessThanOrEqual(max);
+      expect(createWalletRecord).toHaveBeenCalled();
+      expect(Number(memory.tables.profiles[0].stellar_wallet_retry_count)).toBeLessThanOrEqual(max);
+      expect(Number(memory.tables.profiles[0].stellar_wallet_retry_count)).toBe(max);
+    });
+  });
+
+  describe('backoff', () => {
+    it('omite filas con last_retry_at reciente', async () => {
+      await compile([
+        failedProfile({
+          stellar_wallet_retry_count: 1,
+          stellar_wallet_last_retry_at: new Date().toISOString(),
+        }),
+      ]);
+      createWalletRecord.mockResolvedValue({
+        publicKey: FUNDED_PUBLIC_KEY,
+        status: 'funded',
+        network: 'testnet',
+      });
+
+      await service.reconcileFailedWallets();
+
+      expect(createWalletRecord).not.toHaveBeenCalled();
+      expect(memory.tables.profiles[0].stellar_wallet_status).toBe('failed');
+    });
+  });
+});

--- a/apps/api/src/users/wallet-reconciliation.service.ts
+++ b/apps/api/src/users/wallet-reconciliation.service.ts
@@ -1,0 +1,412 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { AuditEventType } from '@velar/types';
+import { AuditService } from '../audit/audit.service';
+import { SupabaseService } from '../common/supabase/supabase.service';
+import {
+  CustodyWalletCreation,
+  WalletService,
+} from '../escrow/wallet.service';
+
+/** Hard stop: do not call Friendbot again for this row. */
+export const WALLET_RETRY_MAX_ATTEMPTS = 5;
+
+/** Cap Friendbot calls per serverless invocation (~60s). Shared across profiles + parties. */
+export const WALLET_RETRY_BATCH_SIZE = 10;
+
+/**
+ * Delay after N failures before the next attempt is eligible.
+ * Index 0 = wait after 1st failure, … index 4 = wait after 5th (unused once MAX is hit).
+ */
+export const WALLET_RETRY_BACKOFF_MS = [
+  60_000,
+  5 * 60_000,
+  15 * 60_000,
+  60 * 60_000,
+  6 * 60 * 60_000,
+] as const;
+
+const FETCH_WINDOW = 50;
+
+export type WalletReconcileSummary = {
+  profilesAttempted: number;
+  partiesAttempted: number;
+  succeeded: number;
+  failed: number;
+  skipped: number;
+};
+
+export type ProfileWalletRetryResult = {
+  id: string;
+  stellar_wallet: string | null;
+  stellar_wallet_status: string | null;
+  stellar_network: string | null;
+  stellar_created_at: string | null;
+  stellar_wallet_error: string | null;
+  stellar_wallet_retry_count: number;
+  stellar_wallet_last_retry_at: string | null;
+  previousStatus: string | null;
+  partyUpdated: boolean;
+  skipped?: 'not_failed' | 'max_attempts' | 'raced';
+};
+
+type FailedWalletRow = {
+  id: string;
+  stellar_wallet?: string | null;
+  stellar_wallet_status?: string | null;
+  stellar_wallet_error?: string | null;
+  stellar_wallet_retry_count?: number | null;
+  stellar_wallet_last_retry_at?: string | null;
+  stellar_network?: string | null;
+  stellar_created_at?: string | null;
+};
+
+type FailedProfileRow = FailedWalletRow & {
+  email?: string | null;
+  role?: string | null;
+  party_id?: string | null;
+};
+
+type FailedPartyRow = FailedWalletRow & {
+  code?: string | null;
+};
+
+const PROFILE_SELECT =
+  'id, email, role, party_id, stellar_wallet, stellar_wallet_status, stellar_network, stellar_created_at, stellar_wallet_error, stellar_wallet_retry_count, stellar_wallet_last_retry_at';
+const PARTY_SELECT =
+  'id, code, stellar_wallet, stellar_wallet_status, stellar_network, stellar_created_at, stellar_wallet_error, stellar_wallet_retry_count, stellar_wallet_last_retry_at';
+
+export function walletRetryBackoffElapsed(
+  lastRetryAt: string | null | undefined,
+  retryCount: number,
+  nowMs = Date.now(),
+): boolean {
+  if (!lastRetryAt) return true;
+  const idx = Math.min(Math.max(retryCount - 1, 0), WALLET_RETRY_BACKOFF_MS.length - 1);
+  const waitMs = WALLET_RETRY_BACKOFF_MS[idx];
+  return nowMs - Date.parse(lastRetryAt) >= waitMs;
+}
+
+function retryCountOf(row: FailedWalletRow): number {
+  return row.stellar_wallet_retry_count ?? 0;
+}
+
+function isSuccessStatus(status: CustodyWalletCreation['status']): boolean {
+  return status === 'created' || status === 'funded';
+}
+
+function toProfileResult(
+  row: FailedProfileRow,
+  partyUpdated: boolean,
+  skipped?: ProfileWalletRetryResult['skipped'],
+  previousStatus?: string | null,
+): ProfileWalletRetryResult {
+  return {
+    id: row.id,
+    stellar_wallet: row.stellar_wallet ?? null,
+    stellar_wallet_status: row.stellar_wallet_status ?? null,
+    stellar_network: row.stellar_network ?? null,
+    stellar_created_at: row.stellar_created_at ?? null,
+    stellar_wallet_error: row.stellar_wallet_error ?? null,
+    stellar_wallet_retry_count: retryCountOf(row),
+    stellar_wallet_last_retry_at: row.stellar_wallet_last_retry_at ?? null,
+    previousStatus: previousStatus ?? row.stellar_wallet_status ?? null,
+    partyUpdated,
+    ...(skipped ? { skipped } : {}),
+  };
+}
+
+@Injectable()
+export class WalletReconciliationService {
+  private readonly logger = new Logger(WalletReconciliationService.name);
+
+  constructor(
+    private readonly wallets: WalletService,
+    private readonly supabase: SupabaseService,
+    private readonly audit: AuditService,
+  ) {}
+
+  /**
+   * Batch job for failed custodial wallets (admin HTTP or future Vercel Cron).
+   * No @nestjs/schedule — that does not run on Vercel serverless.
+   */
+  async reconcileFailedWallets(): Promise<WalletReconcileSummary> {
+    const summary: WalletReconcileSummary = {
+      profilesAttempted: 0,
+      partiesAttempted: 0,
+      succeeded: 0,
+      failed: 0,
+      skipped: 0,
+    };
+
+    const profiles = await this.loadFailedProfiles();
+    const parties = await this.loadFailedParties();
+    const eligibleProfiles = profiles.filter((row) => this.isBatchEligible(row));
+    const eligibleParties = parties.filter((row) => this.isBatchEligible(row));
+    summary.skipped =
+      profiles.length - eligibleProfiles.length + (parties.length - eligibleParties.length);
+
+    let remaining = WALLET_RETRY_BATCH_SIZE;
+    const syncedPartyIds = new Set<string>();
+
+    for (const profile of eligibleProfiles) {
+      if (remaining <= 0) {
+        summary.skipped += 1;
+        continue;
+      }
+      remaining -= 1;
+      summary.profilesAttempted += 1;
+      const result = await this.attemptProfile(profile, {
+        bypassBackoff: false,
+        emitAudit: false,
+      });
+      if (result.skipped === 'raced' || result.skipped === 'not_failed' || result.skipped === 'max_attempts') {
+        summary.skipped += 1;
+        continue;
+      }
+      if (isSuccessStatus((result.stellar_wallet_status as CustodyWalletCreation['status']) ?? 'failed')) {
+        summary.succeeded += 1;
+      } else {
+        summary.failed += 1;
+      }
+      if (result.partyUpdated && profile.party_id) {
+        syncedPartyIds.add(profile.party_id);
+      }
+    }
+
+    for (const party of eligibleParties) {
+      if (syncedPartyIds.has(party.id)) {
+        summary.skipped += 1;
+        continue;
+      }
+      if (remaining <= 0) {
+        summary.skipped += 1;
+        continue;
+      }
+      remaining -= 1;
+      summary.partiesAttempted += 1;
+      const ok = await this.attemptParty(party);
+      if (ok === 'skipped') {
+        summary.skipped += 1;
+      } else if (ok === 'success') {
+        summary.succeeded += 1;
+      } else {
+        summary.failed += 1;
+      }
+    }
+
+    await this.audit.emit({
+      type: AuditEventType.WALLET_PROVISIONED,
+      payload: { source: 'wallet_reconciliation_batch', ...summary },
+    });
+    return summary;
+  }
+
+  /**
+   * Manual single-user retry (HTTP agent wires admin POST). Bypasses backoff
+   * so an admin can retry immediately; still refuses rows at MAX attempts.
+   */
+  async retryProfile(profileId: string, actorId?: string): Promise<ProfileWalletRetryResult> {
+    const profile = await this.loadProfileById(profileId);
+    if (!profile) throw new NotFoundException('Usuario no encontrado');
+
+    return this.attemptProfile(profile, { bypassBackoff: true, emitAudit: false, actorId });
+  }
+
+  private isBatchEligible(row: FailedWalletRow): boolean {
+    const count = retryCountOf(row);
+    if (count >= WALLET_RETRY_MAX_ATTEMPTS) return false;
+    return walletRetryBackoffElapsed(row.stellar_wallet_last_retry_at, count);
+  }
+
+  private async loadFailedProfiles(): Promise<FailedProfileRow[]> {
+    const { data, error } = await this.supabase.admin
+      .from('profiles')
+      .select(PROFILE_SELECT)
+      .eq('stellar_wallet_status', 'failed')
+      .lt('stellar_wallet_retry_count', WALLET_RETRY_MAX_ATTEMPTS)
+      .limit(FETCH_WINDOW);
+    if (error) {
+      this.logger.warn(`loadFailedProfiles: ${error.message}`);
+      return [];
+    }
+    return (data ?? []) as FailedProfileRow[];
+  }
+
+  private async loadFailedParties(): Promise<FailedPartyRow[]> {
+    const { data, error } = await this.supabase.admin
+      .from('parties')
+      .select(PARTY_SELECT)
+      .eq('stellar_wallet_status', 'failed')
+      .lt('stellar_wallet_retry_count', WALLET_RETRY_MAX_ATTEMPTS)
+      .limit(FETCH_WINDOW);
+    if (error) {
+      this.logger.warn(`loadFailedParties: ${error.message}`);
+      return [];
+    }
+    return (data ?? []) as FailedPartyRow[];
+  }
+
+  private async loadProfileById(id: string): Promise<FailedProfileRow | null> {
+    const { data, error } = await this.supabase.admin
+      .from('profiles')
+      .select(PROFILE_SELECT)
+      .eq('id', id)
+      .maybeSingle();
+    if (error) {
+      this.logger.warn(`loadProfileById: ${error.message}`);
+      return null;
+    }
+    return (data as FailedProfileRow | null) ?? null;
+  }
+
+  private async attemptProfile(
+    profile: FailedProfileRow,
+    opts: { bypassBackoff: boolean; emitAudit: boolean; actorId?: string },
+  ): Promise<ProfileWalletRetryResult> {
+    if (profile.stellar_wallet_status !== 'failed') {
+      return toProfileResult(profile, false, 'not_failed');
+    }
+    const count = retryCountOf(profile);
+    if (count >= WALLET_RETRY_MAX_ATTEMPTS) {
+      return toProfileResult(profile, false, 'max_attempts');
+    }
+    if (!opts.bypassBackoff && !walletRetryBackoffElapsed(profile.stellar_wallet_last_retry_at, count)) {
+      return toProfileResult(profile, false, 'not_failed');
+    }
+
+    const previousKey = profile.stellar_wallet ?? null;
+    const previousStatus = profile.stellar_wallet_status;
+    const label = profile.email ?? profile.id;
+    const wallet = await this.createWalletRecordSafely(label);
+    const persisted = await this.persistRetry('profiles', profile.id, count, wallet);
+    if (!persisted) {
+      const fresh = (await this.loadProfileById(profile.id)) ?? profile;
+      return toProfileResult(fresh, false, 'raced');
+    }
+
+    const partyUpdated = await this.syncPartyIfSameBrokenWallet(
+      profile.party_id,
+      previousKey,
+      wallet,
+      count,
+    );
+
+    const fresh = (await this.loadProfileById(profile.id)) ?? {
+      ...profile,
+      ...this.patchFromWallet(count, wallet),
+    };
+    if (opts.emitAudit) {
+      await this.audit.emit({
+        type: AuditEventType.WALLET_PROVISIONED,
+        actorId: opts.actorId,
+        payload: {
+          source: 'wallet_reconciliation',
+          targetUserId: profile.id,
+          previousStatus,
+          newStatus: wallet.status,
+          publicKey: wallet.publicKey || null,
+          error: wallet.error ?? null,
+          partyUpdated,
+        },
+      });
+    }
+    return toProfileResult(fresh, partyUpdated, undefined, previousStatus);
+  }
+
+  private async attemptParty(party: FailedPartyRow): Promise<'success' | 'failed' | 'skipped'> {
+    if (party.stellar_wallet_status !== 'failed') return 'skipped';
+    const count = retryCountOf(party);
+    if (count >= WALLET_RETRY_MAX_ATTEMPTS) return 'skipped';
+    if (!walletRetryBackoffElapsed(party.stellar_wallet_last_retry_at, count)) return 'skipped';
+
+    const wallet = await this.createWalletRecordSafely(`party:${party.code ?? party.id}`);
+    const persisted = await this.persistRetry('parties', party.id, count, wallet);
+    if (!persisted) return 'skipped';
+    return isSuccessStatus(wallet.status) ? 'success' : 'failed';
+  }
+
+  /**
+   * Always mint via createWalletRecord(label). That method uses Keypair.random(),
+   * so every retry provisions a **new** keypair (even when Friendbot fails and the
+   * secret is still persisted). We do not fund an existing public key here.
+   */
+  private async createWalletRecordSafely(label: string): Promise<CustodyWalletCreation> {
+    try {
+      return await this.wallets.createWalletRecord(label);
+    } catch (e) {
+      const error = (e as Error).message;
+      this.logger.warn(`createWalletRecord threw for ${label}: ${error}`);
+      return { publicKey: '', status: 'failed', network: 'testnet', error };
+    }
+  }
+
+  private patchFromWallet(
+    previousRetryCount: number,
+    wallet: CustodyWalletCreation,
+  ): Record<string, unknown> {
+    const now = new Date().toISOString();
+    const ok = isSuccessStatus(wallet.status);
+    const patch: Record<string, unknown> = {
+      stellar_wallet_status: wallet.status,
+      stellar_network: wallet.network,
+      stellar_wallet_error: ok ? null : (wallet.error ?? 'wallet retry failed'),
+      stellar_wallet_retry_count: ok ? 0 : previousRetryCount + 1,
+      stellar_wallet_last_retry_at: now,
+    };
+    if (wallet.publicKey) {
+      patch.stellar_wallet = wallet.publicKey;
+      patch.stellar_created_at = now;
+    }
+    return patch;
+  }
+
+  private async persistRetry(
+    table: 'profiles' | 'parties',
+    id: string,
+    previousRetryCount: number,
+    wallet: CustodyWalletCreation,
+  ): Promise<boolean> {
+    const patch = this.patchFromWallet(previousRetryCount, wallet);
+    const { data, error } = await this.supabase.admin
+      .from(table)
+      .update(patch)
+      .eq('id', id)
+      .eq('stellar_wallet_status', 'failed')
+      .select('id')
+      .maybeSingle();
+    if (error) {
+      this.logger.warn(`persistRetry ${table}/${id}: ${error.message}`);
+      return false;
+    }
+    return Boolean(data);
+  }
+
+  /**
+   * Emisor profiles often share the custodial key with `parties`. Copy the new
+   * record only when the party is clearly the same broken wallet — never clobber
+   * a funded/created party wallet or a different failed key.
+   */
+  private async syncPartyIfSameBrokenWallet(
+    partyId: string | null | undefined,
+    previousProfileKey: string | null,
+    wallet: CustodyWalletCreation,
+    previousRetryCount: number,
+  ): Promise<boolean> {
+    if (!partyId) return false;
+    const { data, error } = await this.supabase.admin
+      .from('parties')
+      .select(PARTY_SELECT)
+      .eq('id', partyId)
+      .maybeSingle();
+    if (error || !data) return false;
+    const party = data as FailedPartyRow;
+    if (!this.isSameBrokenPartyWallet(party, previousProfileKey)) return false;
+    return this.persistRetry('parties', party.id, previousRetryCount, wallet);
+  }
+
+  private isSameBrokenPartyWallet(party: FailedPartyRow, previousProfileKey: string | null): boolean {
+    if (party.stellar_wallet_status !== 'failed') return false;
+    if (!party.stellar_wallet) return true;
+    return Boolean(previousProfileKey) && party.stellar_wallet === previousProfileKey;
+  }
+}

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -55,8 +55,11 @@ Migración de notificaciones (`supabase/migrations/20260608000000_notifications.
 ```
 GET    /api/users/me
 PATCH  /api/users/me
-GET    /api/users                 (admin/tse)
+GET    /api/users                 (admin/tse; incluye stellar_wallet_status + stellar_wallet_error)
 PATCH  /api/users/:id/role        (admin)
+POST   /api/users/:id/wallet/retry (admin; ver §14)
+PATCH  /api/users/:id/deactivate   (admin; ver §12)
+PATCH  /api/users/:id/reactivate   (admin; ver §12)
 
 GET    /api/parties
 GET    /api/parties/:id
@@ -774,4 +777,61 @@ para simular Horizon/Soroban — no se necesita conexión real a testnet ni cred
 npm run build --workspace apps/api
 npm run lint --workspace apps/api
 npm run test --workspace apps/api -- health
+```
+
+---
+
+## 14. Reconciliación de wallets de custodia (`failed` → retry)
+
+`AuthService.register` y `UsersService.ensureProfileWallet` llaman a `WalletService.createWalletRecord()`. Friendbot (testnet) puede fallar; **el registro no se aborta**: se persiste `stellar_wallet_status = 'failed'` y el mensaje en `stellar_wallet_error`. Un perfil o partido en `failed` no puede recibir tokens de bono hasta que haya una cuenta funded.
+
+Esto **no** cambia el interior de Friendbot ni de `createWalletRecord()`. La capa de resiliencia es `WalletReconciliationService`: vuelve a llamar al mismo método.
+
+### Por qué quedan wallets `failed` (y por qué GET no las sana)
+
+- **Register:** si `createWalletRecord()` tira o devuelve `status: 'failed'`, el profile (y el party, si aplica) se guarda igual, con status/error. El alta de cuenta no depende de Friendbot.
+- **`ensureProfileWallet`:** corre solo desde `getProfile` cuando `stellar_wallet` está vacío. Si Friendbot falla, `createWalletRecord()` **igual persiste un keypair** y el profile queda con `stellar_wallet` seteado y status `failed`.
+- **`getProfile` no reintenta** si `stellar_wallet` ya tiene valor. Un failed con clave pública **nunca** se auto-repara en `GET /api/users/me`. La reconciliación tiene que filtrar por **status**, no por “falta de clave”.
+
+### Cómo selecciona el job
+
+Consulta `profiles` y `parties` con `stellar_wallet_status = 'failed'`, índices parciales en `20260829000000_custodial_wallet_retry.sql`.
+
+Además exige `stellar_wallet_retry_count < 5` y que el backoff sobre `stellar_wallet_last_retry_at` ya haya vencido (si nunca se reintentó, entra). El lote está acotado (~10 filas) para caber en una invocación serverless de 60s y no martillar Friendbot.
+
+### Reintentos acotados
+
+Columnas (profiles y parties): `stellar_wallet_retry_count` (default 0), `stellar_wallet_last_retry_at`, más las existentes `stellar_wallet_status` / `stellar_wallet_error`.
+
+| Resultado | Persistencia |
+|---|---|
+| Éxito (`created` / `funded`) | Actualiza clave, status, limpia `stellar_wallet_error`, resetea `retry_count`. |
+| Falla | Incrementa `retry_count`, escribe `stellar_wallet_error`, setea `last_retry_at`. |
+
+Tope **5** intentos. Backoff exponencial a partir de `last_retry_at` (p. ej. 1m, 5m, 15m, 1h, 6h). Al llegar al máximo, el job **omite** la fila.
+
+Cada reintento llama `createWalletRecord(label)` otra vez. Ese método hace `Keypair.random()`: **es un keypair nuevo**, no un “fund” de la clave failed. Queda aceptado en este epic; no se agregó un fund-existing-key.
+
+### Por qué no hay `@nestjs/schedule`
+
+La API corre en **Vercel serverless** (`vercel.api.json`, `api/index.ts`, `maxDuration` 60s). Un cron de `@nestjs/schedule` no corre entre invocaciones en frío: no está en el stack y **no** hay que agregarlo.
+
+El lote `WalletReconciliationService.reconcileFailedWallets()` no está en un cron Nest. Hoy se dispara el reintento **por usuario** con `POST /api/users/:id/wallet/retry` (admin). El método de lote queda listo para un Vercel Cron / HTTP futuro; no es un proceso Nest de larga duración.
+
+### `POST /api/users/:id/wallet/retry` (solo admin)
+
+Reintento **manual de un usuario**. Misma barra que `setRole` / `deactivate`: `actorRole !== 'admin'` → `ForbiddenException`. **TSE no reintenta.** No es self-retry; no toca `PATCH /api/users/me/wallet` (Freighter).
+
+Si la operación no tira, `AuditService.emit()` con tipo `wallet_retry_requested` (`AuditEventType`; valor en `audit_event_type` vía `20260829000001_wallet_retry_audit_event.sql`). `actorId` = admin. Payload típico: `targetUserId`, status previo/nuevo, `publicKey` / `error` si aplica.
+
+### Superficie en `GET /api/users`
+
+`listUsers` (admin/tse) ya hace `select('*, parties(*)')`. Con las columnas de wallet en el schema, el directorio **ya trae** `stellar_wallet_status`, `stellar_wallet_error`, `retry_count` y `last_retry_at` — no hace falta un endpoint extra de “salud de wallet”.
+
+### Comprobación local sin credenciales
+
+Specs con `WalletService.createWalletRecord` y `SupabaseService` mockeados (mismo patrón que `users-lifecycle.service.spec.ts`). **Sin** Friendbot real, testnet ni credenciales VELAR.
+
+```bash
+npm run test --workspace apps/api -- --testPathPatterns wallet-reconciliation
 ```

--- a/packages/types/src/audit.ts
+++ b/packages/types/src/audit.ts
@@ -41,6 +41,7 @@ export const AuditEventType = {
   AUTH_EMAIL_CHANGE_REQUESTED: 'auth_email_change_requested',
   AUTH_ACCOUNT_DEACTIVATED: 'auth_account_deactivated',
   AUTH_ACCOUNT_REACTIVATED: 'auth_account_reactivated',
+  WALLET_RETRY_REQUESTED: 'wallet_retry_requested',
 } as const;
 
 export type AuditEventType =

--- a/packages/types/src/contracts.ts
+++ b/packages/types/src/contracts.ts
@@ -54,6 +54,8 @@ import {
 import {
   profileRowSchema,
   recipientRowSchema,
+  retryWalletRequestSchema,
+  retryWalletResponseSchema,
   setRoleRequestSchema,
   updateProfileRequestSchema,
   updateWalletRequestSchema,
@@ -183,6 +185,7 @@ export const apiContracts = {
   'users.setRole': endpoint({ method: 'PATCH', path: '/users/:id/role', module: 'users', auth: true, body: setRoleRequestSchema, params: paramsIdSchema, query: noQuery, response: profileRowSchema }),
   'users.deactivate': endpoint({ method: 'PATCH', path: '/users/:id/deactivate', module: 'users', auth: true, body: noBody, params: paramsIdSchema, query: noQuery, response: accountStatusResponseSchema }),
   'users.reactivate': endpoint({ method: 'PATCH', path: '/users/:id/reactivate', module: 'users', auth: true, body: noBody, params: paramsIdSchema, query: noQuery, response: accountStatusResponseSchema }),
+  'users.retryWallet': endpoint({ method: 'POST', path: '/users/:id/wallet/retry', module: 'users', auth: true, body: retryWalletRequestSchema, params: paramsIdSchema, query: noQuery, response: retryWalletResponseSchema }),
 } as const;
 
 export type EndpointName = keyof typeof apiContracts;

--- a/packages/types/src/schemas/users.ts
+++ b/packages/types/src/schemas/users.ts
@@ -19,6 +19,12 @@ export const profileRowSchema = z.object({
   party_id: idSchema.nullable(),
   stellar_wallet: z.string().nullable(),
   stellar_public_key: z.string().nullable().optional(),
+  stellar_wallet_status: z.string().nullable().optional(),
+  stellar_wallet_error: z.string().nullable().optional(),
+  stellar_network: z.string().nullable().optional(),
+  stellar_created_at: z.string().nullable().optional(),
+  stellar_wallet_retry_count: z.number().int().nullable().optional(),
+  stellar_wallet_last_retry_at: z.string().nullable().optional(),
   country: z.string().min(2).max(2).optional(),
   created_at: requiredStringSchema,
   updated_at: requiredStringSchema,
@@ -33,4 +39,17 @@ export const recipientRowSchema = z.object({
 export const walletResponseSchema = z.object({
   ok: z.literal(true),
   stellar_public_key: z.string().regex(/^G[A-Z2-7]{55}$/),
+}).passthrough();
+
+/** POST /users/:id/wallet/retry — Express may send `{}`; do not use z.undefined(). */
+export const retryWalletRequestSchema = z.object({}).strict();
+
+export const retryWalletResponseSchema = z.object({
+  ok: z.literal(true),
+  stellar_wallet: z.string().nullable().optional(),
+  stellar_wallet_status: z.string().nullable().optional(),
+  stellar_wallet_error: z.string().nullable().optional(),
+  stellar_network: z.string().nullable().optional(),
+  stellar_wallet_retry_count: z.number().int().nullable().optional(),
+  stellar_wallet_last_retry_at: z.string().nullable().optional(),
 }).passthrough();

--- a/packages/types/types/audit.d.ts
+++ b/packages/types/types/audit.d.ts
@@ -39,6 +39,7 @@ export declare const AuditEventType: {
     readonly AUTH_EMAIL_CHANGE_REQUESTED: "auth_email_change_requested";
     readonly AUTH_ACCOUNT_DEACTIVATED: "auth_account_deactivated";
     readonly AUTH_ACCOUNT_REACTIVATED: "auth_account_reactivated";
+    readonly WALLET_RETRY_REQUESTED: "wallet_retry_requested";
 };
 export type AuditEventType = (typeof AuditEventType)[keyof typeof AuditEventType];
 export interface AuditEvent {

--- a/packages/types/types/audit.js
+++ b/packages/types/types/audit.js
@@ -44,4 +44,5 @@ exports.AuditEventType = {
     AUTH_EMAIL_CHANGE_REQUESTED: 'auth_email_change_requested',
     AUTH_ACCOUNT_DEACTIVATED: 'auth_account_deactivated',
     AUTH_ACCOUNT_REACTIVATED: 'auth_account_reactivated',
+    WALLET_RETRY_REQUESTED: 'wallet_retry_requested',
 };

--- a/packages/types/types/contracts.d.ts
+++ b/packages/types/types/contracts.d.ts
@@ -2089,6 +2089,12 @@ export declare const apiContracts: {
             party_id: z.ZodNullable<z.ZodString>;
             stellar_wallet: z.ZodNullable<z.ZodString>;
             stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_status: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_network: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_created_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_retry_count: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_wallet_last_retry_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             country: z.ZodOptional<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
@@ -2119,6 +2125,12 @@ export declare const apiContracts: {
             party_id: z.ZodNullable<z.ZodString>;
             stellar_wallet: z.ZodNullable<z.ZodString>;
             stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_status: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_network: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_created_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_retry_count: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_wallet_last_retry_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             country: z.ZodOptional<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
@@ -2162,6 +2174,12 @@ export declare const apiContracts: {
             party_id: z.ZodNullable<z.ZodString>;
             stellar_wallet: z.ZodNullable<z.ZodString>;
             stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_status: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_network: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_created_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_retry_count: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_wallet_last_retry_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             country: z.ZodOptional<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
@@ -2223,6 +2241,12 @@ export declare const apiContracts: {
             party_id: z.ZodNullable<z.ZodString>;
             stellar_wallet: z.ZodNullable<z.ZodString>;
             stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_status: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_network: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_created_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_retry_count: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_wallet_last_retry_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
             country: z.ZodOptional<z.ZodString>;
             created_at: z.ZodString;
             updated_at: z.ZodString;
@@ -2259,6 +2283,26 @@ export declare const apiContracts: {
             userId: z.ZodString;
             active: z.ZodBoolean;
         }, z.core.$strict>;
+    };
+    readonly 'users.retryWallet': {
+        method: HttpMethod;
+        path: string;
+        module: "auth" | "bonds" | "transfers" | "reports" | "escrow" | "notifications" | "users" | "contracts";
+        auth: boolean;
+        body: z.ZodObject<{}, z.core.$strict>;
+        params: z.ZodObject<{
+            id: z.ZodString;
+        }, z.core.$strip>;
+        query: z.ZodObject<{}, z.core.$strict>;
+        response: z.ZodObject<{
+            ok: z.ZodLiteral<true>;
+            stellar_wallet: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_status: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_network: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+            stellar_wallet_retry_count: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+            stellar_wallet_last_retry_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+        }, z.core.$loose>;
     };
 };
 export type EndpointName = keyof typeof apiContracts;

--- a/packages/types/types/contracts.js
+++ b/packages/types/types/contracts.js
@@ -92,6 +92,7 @@ exports.apiContracts = {
     'users.setRole': endpoint({ method: 'PATCH', path: '/users/:id/role', module: 'users', auth: true, body: users_1.setRoleRequestSchema, params: common_1.paramsIdSchema, query: noQuery, response: users_1.profileRowSchema }),
     'users.deactivate': endpoint({ method: 'PATCH', path: '/users/:id/deactivate', module: 'users', auth: true, body: noBody, params: common_1.paramsIdSchema, query: noQuery, response: auth_1.accountStatusResponseSchema }),
     'users.reactivate': endpoint({ method: 'PATCH', path: '/users/:id/reactivate', module: 'users', auth: true, body: noBody, params: common_1.paramsIdSchema, query: noQuery, response: auth_1.accountStatusResponseSchema }),
+    'users.retryWallet': endpoint({ method: 'POST', path: '/users/:id/wallet/retry', module: 'users', auth: true, body: users_1.retryWalletRequestSchema, params: common_1.paramsIdSchema, query: noQuery, response: users_1.retryWalletResponseSchema }),
 };
 function normalizedPath(value) {
     const path = value.split('?')[0].replace(/^https?:\/\/[^/]+/i, '').replace(/^\/api(?=\/|$)/, '');

--- a/packages/types/types/schemas/users.d.ts
+++ b/packages/types/types/schemas/users.d.ts
@@ -30,6 +30,12 @@ export declare const profileRowSchema: z.ZodObject<{
     party_id: z.ZodNullable<z.ZodString>;
     stellar_wallet: z.ZodNullable<z.ZodString>;
     stellar_public_key: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    stellar_wallet_status: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    stellar_wallet_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    stellar_network: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    stellar_created_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    stellar_wallet_retry_count: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+    stellar_wallet_last_retry_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
     country: z.ZodOptional<z.ZodString>;
     created_at: z.ZodString;
     updated_at: z.ZodString;
@@ -50,4 +56,15 @@ export declare const recipientRowSchema: z.ZodObject<{
 export declare const walletResponseSchema: z.ZodObject<{
     ok: z.ZodLiteral<true>;
     stellar_public_key: z.ZodString;
+}, z.core.$loose>;
+/** POST /users/:id/wallet/retry — Express may send `{}`; do not use z.undefined(). */
+export declare const retryWalletRequestSchema: z.ZodObject<{}, z.core.$strict>;
+export declare const retryWalletResponseSchema: z.ZodObject<{
+    ok: z.ZodLiteral<true>;
+    stellar_wallet: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    stellar_wallet_status: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    stellar_wallet_error: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    stellar_network: z.ZodOptional<z.ZodNullable<z.ZodString>>;
+    stellar_wallet_retry_count: z.ZodOptional<z.ZodNullable<z.ZodNumber>>;
+    stellar_wallet_last_retry_at: z.ZodOptional<z.ZodNullable<z.ZodString>>;
 }, z.core.$loose>;

--- a/packages/types/types/schemas/users.js
+++ b/packages/types/types/schemas/users.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.walletResponseSchema = exports.recipientRowSchema = exports.profileRowSchema = exports.setRoleRequestSchema = exports.updateWalletRequestSchema = exports.updateProfileRequestSchema = void 0;
+exports.retryWalletResponseSchema = exports.retryWalletRequestSchema = exports.walletResponseSchema = exports.recipientRowSchema = exports.profileRowSchema = exports.setRoleRequestSchema = exports.updateWalletRequestSchema = exports.updateProfileRequestSchema = void 0;
 const zod_1 = require("zod");
 const common_1 = require("./common");
 exports.updateProfileRequestSchema = zod_1.z.object({
@@ -18,6 +18,12 @@ exports.profileRowSchema = zod_1.z.object({
     party_id: common_1.idSchema.nullable(),
     stellar_wallet: zod_1.z.string().nullable(),
     stellar_public_key: zod_1.z.string().nullable().optional(),
+    stellar_wallet_status: zod_1.z.string().nullable().optional(),
+    stellar_wallet_error: zod_1.z.string().nullable().optional(),
+    stellar_network: zod_1.z.string().nullable().optional(),
+    stellar_created_at: zod_1.z.string().nullable().optional(),
+    stellar_wallet_retry_count: zod_1.z.number().int().nullable().optional(),
+    stellar_wallet_last_retry_at: zod_1.z.string().nullable().optional(),
     country: zod_1.z.string().min(2).max(2).optional(),
     created_at: common_1.requiredStringSchema,
     updated_at: common_1.requiredStringSchema,
@@ -31,4 +37,15 @@ exports.recipientRowSchema = zod_1.z.object({
 exports.walletResponseSchema = zod_1.z.object({
     ok: zod_1.z.literal(true),
     stellar_public_key: zod_1.z.string().regex(/^G[A-Z2-7]{55}$/),
+}).passthrough();
+/** POST /users/:id/wallet/retry — Express may send `{}`; do not use z.undefined(). */
+exports.retryWalletRequestSchema = zod_1.z.object({}).strict();
+exports.retryWalletResponseSchema = zod_1.z.object({
+    ok: zod_1.z.literal(true),
+    stellar_wallet: zod_1.z.string().nullable().optional(),
+    stellar_wallet_status: zod_1.z.string().nullable().optional(),
+    stellar_wallet_error: zod_1.z.string().nullable().optional(),
+    stellar_network: zod_1.z.string().nullable().optional(),
+    stellar_wallet_retry_count: zod_1.z.number().int().nullable().optional(),
+    stellar_wallet_last_retry_at: zod_1.z.string().nullable().optional(),
 }).passthrough();

--- a/supabase/migrations/20260829000000_custodial_wallet_retry.sql
+++ b/supabase/migrations/20260829000000_custodial_wallet_retry.sql
@@ -1,0 +1,20 @@
+-- Custodial wallet reconciliation: bounded retry metadata on profiles and parties.
+-- Adds stellar_wallet_retry_count and stellar_wallet_last_retry_at.
+-- Does not change existing stellar_wallet / status / error / network / created_at.
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS stellar_wallet_retry_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS stellar_wallet_last_retry_at timestamptz;
+
+ALTER TABLE parties
+  ADD COLUMN IF NOT EXISTS stellar_wallet_retry_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS stellar_wallet_last_retry_at timestamptz;
+
+-- Reconciliation jobs scan failed wallets ordered by last retry (backoff).
+CREATE INDEX IF NOT EXISTS idx_profiles_stellar_wallet_failed
+  ON profiles (stellar_wallet_last_retry_at, stellar_wallet_retry_count)
+  WHERE stellar_wallet_status = 'failed';
+
+CREATE INDEX IF NOT EXISTS idx_parties_stellar_wallet_failed
+  ON parties (stellar_wallet_last_retry_at, stellar_wallet_retry_count)
+  WHERE stellar_wallet_status = 'failed';

--- a/supabase/migrations/20260829000001_wallet_retry_audit_event.sql
+++ b/supabase/migrations/20260829000001_wallet_retry_audit_event.sql
@@ -1,0 +1,3 @@
+-- Audit event for admin/manual custodial wallet retry (ADD VALUE only; do not use in this transaction).
+
+ALTER TYPE audit_event_type ADD VALUE IF NOT EXISTS 'wallet_retry_requested';


### PR DESCRIPTION
Closes #81

## Summary
- Retry failed custodial Stellar wallets with bounded backoff (`retry_count` / `last_retry_at`) via `WalletReconciliationService`, wrapping existing `WalletService.createWalletRecord()` (no Friendbot/create-wallet internals changed).
- Admin-only `POST /api/users/:id/wallet/retry` (audited as `WALLET_RETRY_REQUESTED`); live HTTP is per-user. Batch `reconcileFailedWallets()` is ready for a future Vercel Cron, not a Nest scheduler today.
- `GET /users` surfaces `stellar_wallet_status`, `stellar_wallet_error`, and retry fields. Schema + `docs/BACKEND.md` §14 document the flow.

## Test plan
- [ ] Mocked reconcile: failed → funded
- [ ] Bounded retries / no infinite Friendbot
- [ ] POST /users/:id/wallet/retry forbidden for non-admin
- [ ] Audit event emitted
- [ ] GET /users shows stellar_wallet_status + stellar_wallet_error
- [ ] No real Stellar credentials required for CI

Local verification (after `npm install`): `npm run build`, `npm run lint`, and `npm run test` in `apps/api` — 55 suites / 505 tests passed; lint 0 errors.

## FWC26 campaign (human)
Contributor eligibility actions — do these yourself; they are not automated:
- [x] Follow Velar on X: https://x.com/VelarApp
- [x] Star the repository: https://github.com/Velar-Bonds/Velar
- [x] Follow the Velar-Bonds organization: https://github.com/Velar-Bonds


Made with [Cursor](https://cursor.com)